### PR TITLE
feat: add provider-level issue dependency retrieval

### DIFF
--- a/lib/providers/github.ts
+++ b/lib/providers/github.ts
@@ -6,6 +6,7 @@ import {
   type Issue,
   type StateLabel,
   type IssueComment,
+  type IssueDependencies,
   type PrStatus,
   type PrReviewComment,
   PrState,
@@ -213,6 +214,47 @@ export class GitHubProvider implements IssueProvider {
   async getIssue(issueId: number): Promise<Issue> {
     const raw = await this.gh(["issue", "view", String(issueId), "--json", "number,title,body,labels,state,url"]);
     return toIssue(JSON.parse(raw) as GhIssue);
+  }
+
+  async getIssueDependencies(issueId: number): Promise<IssueDependencies> {
+    const repo = await this.getRepoInfo();
+    if (!repo) throw new Error("Unable to resolve repository owner/name for dependency query");
+
+    const query = `{
+      repository(owner: "${repo.owner}", name: "${repo.name}") {
+        issue(number: ${issueId}) {
+          trackedInIssues(first: 100) {
+            nodes { number title state url }
+          }
+          trackedIssues(first: 100) {
+            nodes { number title state url }
+          }
+        }
+      }
+    }`;
+
+    const raw = await this.gh(["api", "graphql", "-f", `query=${query}`]);
+    const data = JSON.parse(raw);
+    const issue = data?.data?.repository?.issue;
+    if (!issue) throw new Error(`Issue #${issueId} not found in repository ${repo.owner}/${repo.name}`);
+
+    const blockers = (issue.trackedInIssues?.nodes ?? []).map((dep: any) => ({
+      iid: dep.number,
+      title: dep.title ?? "",
+      state: dep.state ?? "",
+      web_url: dep.url ?? "",
+      relation: "blocked_by" as const,
+    }));
+
+    const dependents = (issue.trackedIssues?.nodes ?? []).map((dep: any) => ({
+      iid: dep.number,
+      title: dep.title ?? "",
+      state: dep.state ?? "",
+      web_url: dep.url ?? "",
+      relation: "blocks" as const,
+    }));
+
+    return { issueId, blockers, dependents };
   }
 
   async listComments(issueId: number): Promise<IssueComment[]> {

--- a/lib/providers/gitlab.ts
+++ b/lib/providers/gitlab.ts
@@ -6,6 +6,7 @@ import {
   type Issue,
   type StateLabel,
   type IssueComment,
+  type IssueDependencies,
   type PrStatus,
   type PrReviewComment,
   PrState,
@@ -119,6 +120,12 @@ export class GitLabProvider implements IssueProvider {
   async getIssue(issueId: number): Promise<Issue> {
     const raw = await this.glab(["issue", "view", String(issueId), "--output", "json"]);
     return JSON.parse(raw) as Issue;
+  }
+
+  async getIssueDependencies(issueId: number): Promise<IssueDependencies> {
+    // GitLab adapter support will be added when we wire native issue-link/dependency relations.
+    // Return a normalized empty graph to preserve backward compatibility.
+    return { issueId, blockers: [], dependents: [] };
   }
 
   async listComments(issueId: number): Promise<IssueComment[]> {

--- a/lib/providers/provider-issue-dependencies.test.ts
+++ b/lib/providers/provider-issue-dependencies.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for provider dependency retrieval normalization.
+ *
+ * Run with: npx tsx --test lib/providers/provider-issue-dependencies.test.ts
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import type { RunCommand } from "../context.js";
+import { GitHubProvider } from "./github.js";
+import { GitLabProvider } from "./gitlab.js";
+
+function createGitHubRunCommand(opts: {
+  trackedInIssues?: Array<{ number: number; title: string; state: string; url: string }>;
+  trackedIssues?: Array<{ number: number; title: string; state: string; url: string }>;
+  failGraphql?: boolean;
+}): RunCommand {
+  const trackedInIssues = opts.trackedInIssues ?? [];
+  const trackedIssues = opts.trackedIssues ?? [];
+
+  return (async (command: string[]) => {
+    const rendered = command.join(" ");
+
+    if (rendered.includes("gh repo view --json owner,name")) {
+      return {
+        stdout: JSON.stringify({ owner: { login: "rayjolt" }, name: "devclaw" }),
+        stderr: "",
+        exitCode: 0,
+        code: 0,
+        signal: null,
+        killed: false,
+        termination: "exit",
+      } as any;
+    }
+
+    if (rendered.includes("gh api graphql")) {
+      if (opts.failGraphql) throw new Error("GraphQL is down");
+      return {
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              issue: {
+                trackedInIssues: { nodes: trackedInIssues },
+                trackedIssues: { nodes: trackedIssues },
+              },
+            },
+          },
+        }),
+        stderr: "",
+        exitCode: 0,
+        code: 0,
+        signal: null,
+        killed: false,
+        termination: "exit",
+      } as any;
+    }
+
+    throw new Error(`Unexpected command: ${rendered}`);
+  }) as RunCommand;
+}
+
+describe("GitHubProvider.getIssueDependencies", () => {
+  it("returns empty blockers/dependents when no dependencies exist", async () => {
+    const provider = new GitHubProvider({
+      repoPath: "/fake",
+      runCommand: createGitHubRunCommand({}),
+    });
+
+    const deps = await provider.getIssueDependencies(42);
+
+    assert.strictEqual(deps.issueId, 42);
+    assert.deepStrictEqual(deps.blockers, []);
+    assert.deepStrictEqual(deps.dependents, []);
+  });
+
+  it("normalizes a single blocker relation", async () => {
+    const provider = new GitHubProvider({
+      repoPath: "/fake",
+      runCommand: createGitHubRunCommand({
+        trackedInIssues: [
+          { number: 1, title: "Parent", state: "OPEN", url: "https://github.com/o/r/issues/1" },
+        ],
+      }),
+    });
+
+    const deps = await provider.getIssueDependencies(2);
+
+    assert.strictEqual(deps.blockers.length, 1);
+    assert.strictEqual(deps.blockers[0].iid, 1);
+    assert.strictEqual(deps.blockers[0].relation, "blocked_by");
+    assert.deepStrictEqual(deps.dependents, []);
+  });
+
+  it("normalizes multiple blockers and dependents", async () => {
+    const provider = new GitHubProvider({
+      repoPath: "/fake",
+      runCommand: createGitHubRunCommand({
+        trackedInIssues: [
+          { number: 1, title: "Blocker A", state: "OPEN", url: "https://github.com/o/r/issues/1" },
+          { number: 3, title: "Blocker B", state: "OPEN", url: "https://github.com/o/r/issues/3" },
+        ],
+        trackedIssues: [
+          { number: 7, title: "Dependent", state: "OPEN", url: "https://github.com/o/r/issues/7" },
+        ],
+      }),
+    });
+
+    const deps = await provider.getIssueDependencies(2);
+
+    assert.strictEqual(deps.blockers.length, 2);
+    assert.strictEqual(deps.blockers[1].iid, 3);
+    assert.strictEqual(deps.dependents.length, 1);
+    assert.strictEqual(deps.dependents[0].iid, 7);
+    assert.strictEqual(deps.dependents[0].relation, "blocks");
+  });
+
+  it("surfaces provider errors for upstream retry/fail-closed behavior", async () => {
+    const provider = new GitHubProvider({
+      repoPath: "/fake",
+      runCommand: createGitHubRunCommand({ failGraphql: true }),
+    });
+
+    await assert.rejects(() => provider.getIssueDependencies(2), /GraphQL is down/);
+  });
+});
+
+describe("GitLabProvider.getIssueDependencies", () => {
+  it("preserves backward compatibility with normalized empty graph", async () => {
+    const runCommand: RunCommand = (async () => {
+      throw new Error("should not be called");
+    }) as RunCommand;
+
+    const provider = new GitLabProvider({ repoPath: "/fake", runCommand });
+    const deps = await provider.getIssueDependencies(123);
+
+    assert.deepStrictEqual(deps, { issueId: 123, blockers: [], dependents: [] });
+  });
+});

--- a/lib/providers/provider.ts
+++ b/lib/providers/provider.ts
@@ -29,6 +29,30 @@ export type IssueComment = {
   created_at: string;
 };
 
+/**
+ * Provider-agnostic dependency edge for a single related issue.
+ *
+ * `relation` is from the perspective of the queried issue:
+ * - "blocks": this issue blocks the related issue (related is dependent)
+ * - "blocked_by": this issue is blocked by the related issue (related is blocker)
+ */
+export type IssueDependency = {
+  iid: number;
+  title: string;
+  state: string;
+  web_url: string;
+  relation: "blocks" | "blocked_by";
+};
+
+/**
+ * Normalized dependency graph slice for one issue.
+ */
+export type IssueDependencies = {
+  issueId: number;
+  blockers: IssueDependency[];
+  dependents: IssueDependency[];
+};
+
 /** Built-in PR states. */
 export const PrState = {
   OPEN: "open",
@@ -78,6 +102,11 @@ export interface IssueProvider {
   /** List issues with optional filters. Provider-agnostic — future Jira/Linear/Trello can map to native queries. */
   listIssues(opts?: { label?: string; state?: "open" | "closed" | "all" }): Promise<Issue[]>;
   getIssue(issueId: number): Promise<Issue>;
+  /**
+   * Get normalized dependency graph relations for an issue.
+   * Implementations should throw on provider/API failures so callers can retry/fail-closed.
+   */
+  getIssueDependencies(issueId: number): Promise<IssueDependencies>;
   listComments(issueId: number): Promise<IssueComment[]>;
   transitionLabel(issueId: number, from: StateLabel, to: StateLabel): Promise<void>;
   addLabel(issueId: number, label: string): Promise<void>;

--- a/lib/testing/test-provider.ts
+++ b/lib/testing/test-provider.ts
@@ -9,6 +9,7 @@ import type {
   Issue,
   StateLabel,
   IssueComment,
+  IssueDependencies,
   PrStatus,
 } from "../providers/provider.js";
 import { getStateLabels } from "../workflow/index.js";
@@ -33,6 +34,7 @@ export type ProviderCall =
   | { method: "listIssuesByLabel"; args: { label: StateLabel } }
   | { method: "listIssues"; args: { label?: string; state?: string } }
   | { method: "getIssue"; args: { issueId: number } }
+  | { method: "getIssueDependencies"; args: { issueId: number } }
   | { method: "listComments"; args: { issueId: number } }
   | {
       method: "transitionLabel";
@@ -189,6 +191,11 @@ export class TestProvider implements IssueProvider {
     const issue = this.issues.get(issueId);
     if (!issue) throw new Error(`Issue #${issueId} not found in TestProvider`);
     return issue;
+  }
+
+  async getIssueDependencies(issueId: number): Promise<IssueDependencies> {
+    this.calls.push({ method: "getIssueDependencies", args: { issueId } });
+    return { issueId, blockers: [], dependents: [] };
   }
 
   async listComments(issueId: number): Promise<IssueComment[]> {


### PR DESCRIPTION
Addresses issue #2.

## What changed
- Extended `IssueProvider` with normalized dependency types and `getIssueDependencies(issueId)`.
- Implemented GitHub dependency retrieval via GraphQL issue relations (`trackedInIssues` / `trackedIssues`) and normalized blocker/dependent edges.
- Added GitLab fallback implementation returning normalized empty dependency graphs for backward compatibility.
- Updated `TestProvider` to implement the new interface method.
- Added provider tests for no-dependency, single-blocker, multi-blocker, error propagation, and backward compatibility.

## Validation
- `npx tsx --test lib/providers/provider-issue-dependencies.test.ts lib/providers/provider-pr-status.test.ts`
