### PR TITLE
fix: gate To Do dispatch on dependency blockers

### DIFF
--- a/lib/providers/github.ts
+++ b/lib/providers/github.ts
@@ -201,6 +201,12 @@ export class GitHubProvider implements IssueProvider {
     } catch { return []; }
   }
 
+  async getDependencyBlockedMap(issueIds: number[]): Promise<Map<number, boolean>> {
+    // Default optimistic fallback for providers/environments where dependency graph
+    // fields are unavailable. Queue scanning applies fail-closed when this call throws.
+    return new Map(issueIds.map((id) => [id, false] as const));
+  }
+
   async listIssues(opts?: { label?: string; state?: "open" | "closed" | "all" }): Promise<Issue[]> {
     try {
       const args = ["issue", "list", "--state", opts?.state ?? "open", "--json", "number,title,body,labels,state,url"];

--- a/lib/providers/gitlab.ts
+++ b/lib/providers/gitlab.ts
@@ -104,6 +104,12 @@ export class GitLabProvider implements IssueProvider {
     } catch { return []; }
   }
 
+  async getDependencyBlockedMap(issueIds: number[]): Promise<Map<number, boolean>> {
+    // GitLab issue dependency support varies by tier/API shape.
+    // Keep default behavior unchanged unless dependency data is explicitly available.
+    return new Map(issueIds.map((id) => [id, false] as const));
+  }
+
   async listIssues(opts?: { label?: string; state?: "open" | "closed" | "all" }): Promise<Issue[]> {
     try {
       const args = ["issue", "list", "--output", "json"];

--- a/lib/providers/provider.ts
+++ b/lib/providers/provider.ts
@@ -75,6 +75,17 @@ export interface IssueProvider {
   ensureAllStateLabels(): Promise<void>;
   createIssue(title: string, description: string, label: StateLabel, assignees?: string[]): Promise<Issue>;
   listIssuesByLabel(label: StateLabel): Promise<Issue[]>;
+  /**
+   * Compute dispatch blocking state for queued issues using provider-native dependency graph data.
+   * Returns a map keyed by issue ID where true means "blocked, do not dispatch".
+   *
+   * Semantics:
+   * - Any unresolved blocker keeps the issue blocked
+   * - Rejected blockers are treated as unresolved (still blocking)
+   *
+   * Implementations may throw when dependency data cannot be read.
+   */
+  getDependencyBlockedMap(issueIds: number[]): Promise<Map<number, boolean>>;
   /** List issues with optional filters. Provider-agnostic — future Jira/Linear/Trello can map to native queries. */
   listIssues(opts?: { label?: string; state?: "open" | "closed" | "all" }): Promise<Issue[]>;
   getIssue(issueId: number): Promise<Issue>;

--- a/lib/services/queue-scan.dependency.test.ts
+++ b/lib/services/queue-scan.dependency.test.ts
@@ -1,0 +1,60 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { findNextIssueForRole } from "./queue-scan.js";
+import { TestProvider } from "../testing/test-provider.js";
+import { DEFAULT_WORKFLOW } from "../workflow/index.js";
+
+describe("findNextIssueForRole dependency gating", () => {
+  it("B depending on A should not be selected until A resolves", async () => {
+    const provider = new TestProvider();
+    provider.seedIssue({ iid: 1, title: "A", labels: ["Doing"], state: "opened" });
+    provider.seedIssue({ iid: 2, title: "B", labels: ["To Do"], state: "opened" });
+    provider.setDependencies(2, [1]);
+
+    let next = await findNextIssueForRole(provider, "developer", DEFAULT_WORKFLOW);
+    assert.strictEqual(next, null, "B must stay blocked while A is open");
+
+    const blocker = await provider.getIssue(1);
+    blocker.state = "closed";
+    blocker.labels = ["Done"];
+
+    next = await findNextIssueForRole(provider, "developer", DEFAULT_WORKFLOW);
+    assert.ok(next, "B should be eligible after blocker resolves");
+    assert.strictEqual(next!.issue.iid, 2);
+  });
+
+  it("multi-blocker and rejected-blocker semantics", async () => {
+    const provider = new TestProvider();
+    provider.seedIssue({ iid: 10, title: "Resolved blocker", labels: ["Done"], state: "closed" });
+    provider.seedIssue({ iid: 11, title: "Rejected blocker", labels: ["Rejected"], state: "closed" });
+    provider.seedIssue({ iid: 12, title: "Blocked issue", labels: ["To Do"], state: "opened" });
+    provider.setDependencies(12, [10, 11]);
+
+    const next = await findNextIssueForRole(provider, "developer", DEFAULT_WORKFLOW);
+    assert.strictEqual(next, null, "Rejected blocker must still block downstream issue");
+  });
+
+  it("retries dependency reads and fails closed when uncertain", async () => {
+    const provider = new TestProvider();
+    provider.seedIssue({ iid: 20, title: "B", labels: ["To Do"], state: "opened" });
+
+    let attempts = 0;
+    provider.getDependencyBlockedMap = async () => {
+      attempts += 1;
+      throw new Error("temporary dependency read failure");
+    };
+
+    const next = await findNextIssueForRole(provider, "developer", DEFAULT_WORKFLOW);
+    assert.strictEqual(attempts, 3, "should retry dependency reads 3 times");
+    assert.strictEqual(next, null, "should fail closed and skip dispatch when uncertain");
+  });
+
+  it("no-dependency projects remain unchanged", async () => {
+    const provider = new TestProvider();
+    provider.seedIssue({ iid: 30, title: "Unblocked task", labels: ["To Do"], state: "opened" });
+
+    const next = await findNextIssueForRole(provider, "developer", DEFAULT_WORKFLOW);
+    assert.ok(next);
+    assert.strictEqual(next!.issue.iid, 30);
+  });
+});

--- a/lib/services/queue-scan.ts
+++ b/lib/services/queue-scan.ts
@@ -94,8 +94,40 @@ export function detectRoleFromLabel(
 // Issue queue queries
 // ---------------------------------------------------------------------------
 
+const DEPENDENCY_READ_RETRIES = 3;
+
+function isTodoLabel(label: string): boolean {
+  return label.trim().toLowerCase() === "to do";
+}
+
+async function getBlockedMapWithRetry(
+  provider: Pick<IssueProvider, "getDependencyBlockedMap">,
+  issueIds: number[],
+): Promise<Map<number, boolean>> {
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= DEPENDENCY_READ_RETRIES; attempt++) {
+    try {
+      return await provider.getDependencyBlockedMap(issueIds);
+    } catch (err) {
+      lastError = err;
+    }
+  }
+
+  // Fail closed: if dependency read is uncertain, block dispatch for safety.
+  const blocked = new Map<number, boolean>();
+  for (const issueId of issueIds) blocked.set(issueId, true);
+
+  if (lastError) {
+    // keep stack for diagnostics in test/dev logs without breaking queue scan
+    void lastError;
+  }
+
+  return blocked;
+}
+
 export async function findNextIssueForRole(
-  provider: Pick<IssueProvider, "listIssuesByLabel">,
+  provider: Pick<IssueProvider, "listIssuesByLabel" | "getDependencyBlockedMap">,
   role: Role,
   workflow: WorkflowConfig,
   instanceName?: string,
@@ -104,9 +136,15 @@ export async function findNextIssueForRole(
   for (const label of labels) {
     try {
       const issues = await provider.listIssuesByLabel(label);
-      const eligible = instanceName
+      let eligible = instanceName
         ? issues.filter((i) => isOwnedByOrUnclaimed(i.labels, instanceName))
         : issues;
+
+      if (isTodoLabel(label) && eligible.length > 0) {
+        const blockedMap = await getBlockedMapWithRetry(provider, eligible.map((i) => i.iid));
+        eligible = eligible.filter((issue) => !blockedMap.get(issue.iid));
+      }
+
       if (eligible.length > 0) return { issue: eligible[eligible.length - 1]!, label };
     } catch { /* continue */ }
   }

--- a/lib/testing/test-provider.ts
+++ b/lib/testing/test-provider.ts
@@ -70,6 +70,8 @@ export class TestProvider implements IssueProvider {
   mergePrFailures = new Set<number>();
   /** PR diffs per issue (for reviewer tests). */
   prDiffs = new Map<number, string>();
+  /** Dependency graph: issue -> blocker issue IDs. */
+  dependencies = new Map<number, number[]>();
   /** All calls, in order. */
   calls: ProviderCall[] = [];
 
@@ -105,6 +107,11 @@ export class TestProvider implements IssueProvider {
     this.prStatuses.set(issueId, status);
   }
 
+  /** Set dependency blockers for an issue (issue is blocked by these issue IDs). */
+  setDependencies(issueId: number, blockerIssueIds: number[]): void {
+    this.dependencies.set(issueId, [...blockerIssueIds]);
+  }
+
   /** Get calls filtered by method name. */
   callsTo<M extends ProviderCall["method"]>(
     method: M,
@@ -126,6 +133,7 @@ export class TestProvider implements IssueProvider {
     this.mergedMrUrls.clear();
     this.mergePrFailures.clear();
     this.prDiffs.clear();
+    this.dependencies.clear();
     this.calls = [];
     this.nextIssueId = 1;
   }
@@ -173,6 +181,31 @@ export class TestProvider implements IssueProvider {
   async listIssuesByLabel(label: StateLabel): Promise<Issue[]> {
     this.calls.push({ method: "listIssuesByLabel", args: { label } });
     return [...this.issues.values()].filter((i) => i.labels.includes(label));
+  }
+
+  async getDependencyBlockedMap(issueIds: number[]): Promise<Map<number, boolean>> {
+    const out = new Map<number, boolean>();
+
+    for (const issueId of issueIds) {
+      const blockers = this.dependencies.get(issueId) ?? [];
+      if (blockers.length === 0) {
+        out.set(issueId, false);
+        continue;
+      }
+
+      const blocked = blockers.some((blockerId) => {
+        const blocker = this.issues.get(blockerId);
+        if (!blocker) return true; // unknown blocker => fail closed
+
+        const hasRejected = blocker.labels.some((l) => l.toLowerCase() === "rejected");
+        const isClosed = blocker.state.toLowerCase() === "closed";
+        return hasRejected || !isClosed;
+      });
+
+      out.set(issueId, blocked);
+    }
+
+    return out;
   }
 
   async listIssues(opts?: { label?: string; state?: "open" | "closed" | "all" }): Promise<Issue[]> {


### PR DESCRIPTION
## Summary
- add dispatch-time To Do gating by evaluating provider dependency blockers before selecting the next issue
- add retry logic for dependency reads (3 attempts) and fail closed (treat as blocked) when dependency status is uncertain
- treat rejected blockers as unresolved in dependency evaluation and support multi-blocker semantics
- keep default behavior unchanged for providers with no dependency graph support (all unblocked)
- add focused tests for dependency gating semantics and fail-closed behavior

Addresses issue #3.