### PR TITLE
Fix heartbeat runtime propagation and notify fallback

### DIFF
--- a/lib/dispatch/index.notify-fallback.test.ts
+++ b/lib/dispatch/index.notify-fallback.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert";
+import { createTestHarness, type TestHarness } from "../testing/index.js";
+import { dispatchTask } from "./index.js";
+
+describe("dispatchTask notification fallback", () => {
+  let h: TestHarness;
+
+  afterEach(async () => {
+    if (h) await h.cleanup();
+  });
+
+  it("uses runCommand notification path when runtime is unavailable", async () => {
+    h = await createTestHarness();
+    h.provider.seedIssue({
+      iid: 19,
+      title: "Fallback notify",
+      labels: ["To Do"],
+    });
+
+    await dispatchTask({
+      workspaceDir: h.workspaceDir,
+      agentId: "test-agent",
+      project: h.project,
+      issueId: 19,
+      issueTitle: "Fallback notify",
+      issueDescription: "",
+      issueUrl: "https://github.com/rayjolt/devclaw/issues/19",
+      role: "developer",
+      level: "senior",
+      fromLabel: "To Do",
+      toLabel: "Doing",
+      provider: h.provider,
+      runCommand: h.runCommand,
+    });
+
+    const notifyCommands = h.commands.commands.filter(
+      (c) =>
+        c.argv[0] === "openclaw" &&
+        c.argv[1] === "message" &&
+        c.argv[2] === "send",
+    );
+
+    assert.ok(
+      notifyCommands.length >= 1,
+      "Expected openclaw message send fallback command",
+    );
+  });
+});

--- a/lib/dispatch/index.ts
+++ b/lib/dispatch/index.ts
@@ -17,14 +17,42 @@ import {
 import { resolveModel } from "../roles/index.js";
 import { notify, getNotificationConfig } from "./notify.js";
 import { loadConfig, type ResolvedRoleConfig } from "../config/index.js";
-import { ReviewPolicy, TestPolicy, resolveReviewRouting, resolveTestRouting, resolveNotifyChannel, isFeedbackState, hasReviewCheck, producesReviewableWork, hasTestPhase, detectOwner, getOwnerLabel, OWNER_LABEL_COLOR, getRoleLabelColor, STEP_ROUTING_COLOR } from "../workflow/index.js";
-import { fetchPrFeedback, fetchPrContext, type PrFeedback, type PrContext } from "./pr-context.js";
+import {
+  ReviewPolicy,
+  TestPolicy,
+  resolveReviewRouting,
+  resolveTestRouting,
+  resolveNotifyChannel,
+  isFeedbackState,
+  hasReviewCheck,
+  producesReviewableWork,
+  hasTestPhase,
+  detectOwner,
+  getOwnerLabel,
+  OWNER_LABEL_COLOR,
+  getRoleLabelColor,
+  STEP_ROUTING_COLOR,
+} from "../workflow/index.js";
+import {
+  fetchPrFeedback,
+  fetchPrContext,
+  type PrFeedback,
+  type PrContext,
+} from "./pr-context.js";
 import { formatAttachmentsForTask } from "./attachments.js";
 import { loadRoleInstructions } from "./bootstrap-hook.js";
 import { slotName } from "../names.js";
 
-import { buildTaskMessage, buildAnnouncement, formatSessionLabel } from "./message-builder.js";
-import { ensureSessionFireAndForget, sendToAgent, shouldClearSession } from "./session.js";
+import {
+  buildTaskMessage,
+  buildAnnouncement,
+  formatSessionLabel,
+} from "./message-builder.js";
+import {
+  ensureSessionFireAndForget,
+  sendToAgent,
+  shouldClearSession,
+} from "./session.js";
 import { acknowledgeComments, EYES_EMOJI } from "./acknowledge.js";
 
 export type DispatchOpts = {
@@ -84,9 +112,20 @@ export async function dispatchTask(
   opts: DispatchOpts,
 ): Promise<DispatchResult> {
   const {
-    workspaceDir, agentId, project, issueId, issueTitle,
-    issueDescription, issueUrl, role, level, fromLabel, toLabel,
-    provider, pluginConfig, runtime,
+    workspaceDir,
+    agentId,
+    project,
+    issueId,
+    issueTitle,
+    issueDescription,
+    issueUrl,
+    role,
+    level,
+    fromLabel,
+    toLabel,
+    provider,
+    pluginConfig,
+    runtime,
   } = opts;
 
   const slotIndex = opts.slotIndex ?? 0;
@@ -103,7 +142,15 @@ export async function dispatchTask(
 
   // Context budget check: clear session if over budget (unless same issue — feedback cycle)
   if (existingSessionKey && timeouts.sessionContextBudget < 1) {
-    const shouldClear = await shouldClearSession(existingSessionKey, slot.issueId, issueId, timeouts, workspaceDir, project.name, rc);
+    const shouldClear = await shouldClearSession(
+      existingSessionKey,
+      slot.issueId,
+      issueId,
+      timeouts,
+      workspaceDir,
+      project.name,
+      rc,
+    );
     if (shouldClear) {
       await updateSlot(workspaceDir, project.slug, role, level, slotIndex, {
         sessionKey: null,
@@ -122,7 +169,14 @@ export async function dispatchTask(
   if (existingSessionKey && existingSessionKey !== sessionKey) {
     // Delete the orphaned gateway session (fire-and-forget)
     rc(
-      ["openclaw", "gateway", "call", "sessions.delete", "--params", JSON.stringify({ key: existingSessionKey })],
+      [
+        "openclaw",
+        "gateway",
+        "call",
+        "sessions.delete",
+        "--params",
+        JSON.stringify({ key: existingSessionKey }),
+      ],
       { timeoutMs: 10_000 },
     ).catch(() => {});
     existingSessionKey = null;
@@ -136,26 +190,46 @@ export async function dispatchTask(
   // Fetch PR context based on workflow role semantics (no hardcoded role/label checks)
   const { workflow } = resolvedConfig;
   const prFeedback = isFeedbackState(workflow, fromLabel)
-    ? await fetchPrFeedback(provider, issueId) : undefined;
+    ? await fetchPrFeedback(provider, issueId)
+    : undefined;
   const prContext = hasReviewCheck(workflow, role)
-    ? await fetchPrContext(provider, issueId) : undefined;
+    ? await fetchPrContext(provider, issueId)
+    : undefined;
 
   // Fetch attachment context (best-effort — never blocks dispatch)
   let attachmentContext: string | undefined;
   try {
-    attachmentContext = await formatAttachmentsForTask(workspaceDir, project.slug, issueId) || undefined;
-  } catch { /* best-effort */ }
+    attachmentContext =
+      (await formatAttachmentsForTask(workspaceDir, project.slug, issueId)) ||
+      undefined;
+  } catch {
+    /* best-effort */
+  }
 
   const primaryChannelId = project.channels[0]?.channelId ?? project.slug;
   const taskMessage = buildTaskMessage({
-    projectName: project.name, channelId: primaryChannelId, role, issueId,
-    issueTitle, issueDescription, issueUrl,
-    repo: project.repo, baseBranch: project.baseBranch,
-    comments, resolvedRole, prContext, prFeedback, attachmentContext,
+    projectName: project.name,
+    channelId: primaryChannelId,
+    role,
+    issueId,
+    issueTitle,
+    issueDescription,
+    issueUrl,
+    repo: project.repo,
+    baseBranch: project.baseBranch,
+    comments,
+    resolvedRole,
+    prContext,
+    prFeedback,
+    attachmentContext,
   });
 
   // Load role-specific instructions to inject into the worker's system prompt
-  const roleInstructions = await loadRoleInstructions(workspaceDir, project.name, role);
+  const roleInstructions = await loadRoleInstructions(
+    workspaceDir,
+    project.name,
+    role,
+  );
 
   // ── Commitment point — transition label (issue leaves queue) ────────
   await provider.transitionLabel(issueId, fromLabel, toLabel);
@@ -163,7 +237,13 @@ export async function dispatchTask(
   // Mark issue + PR as managed and all consumed comments as seen (fire-and-forget)
   provider.reactToIssue(issueId, EYES_EMOJI).catch(() => {});
   provider.reactToPr(issueId, EYES_EMOJI).catch(() => {});
-  acknowledgeComments(provider, issueId, comments, prFeedback, workspaceDir).catch((err) => {
+  acknowledgeComments(
+    provider,
+    issueId,
+    comments,
+    prFeedback,
+    workspaceDir,
+  ).catch((err) => {
     auditLog(workspaceDir, "dispatch_warning", {
       step: "acknowledgeComments",
       issue: issueId,
@@ -186,10 +266,12 @@ export async function dispatchTask(
     // Step 1c: Apply review routing label when role produces reviewable work (best-effort)
     if (producesReviewableWork(workflow, role)) {
       const reviewLabel = resolveReviewRouting(
-        workflow.reviewPolicy ?? ReviewPolicy.HUMAN, level,
+        workflow.reviewPolicy ?? ReviewPolicy.HUMAN,
+        level,
       );
       const oldRouting = issue.labels.filter((l) => l.startsWith("review:"));
-      if (oldRouting.length > 0) await provider.removeLabels(issueId, oldRouting);
+      if (oldRouting.length > 0)
+        await provider.removeLabels(issueId, oldRouting);
       await provider.ensureLabel(reviewLabel, STEP_ROUTING_COLOR);
       await provider.addLabel(issueId, reviewLabel);
     }
@@ -197,10 +279,12 @@ export async function dispatchTask(
     // Step 1e: Apply test routing label when workflow has a test phase (best-effort)
     if (hasTestPhase(workflow)) {
       const testLabel = resolveTestRouting(
-        workflow.testPolicy ?? TestPolicy.SKIP, level,
+        workflow.testPolicy ?? TestPolicy.SKIP,
+        level,
       );
       const oldTestRouting = issue.labels.filter((l) => l.startsWith("test:"));
-      if (oldTestRouting.length > 0) await provider.removeLabels(issueId, oldTestRouting);
+      if (oldTestRouting.length > 0)
+        await provider.removeLabels(issueId, oldTestRouting);
       await provider.ensureLabel(testLabel, STEP_ROUTING_COLOR);
       await provider.addLabel(issueId, testLabel);
     }
@@ -218,7 +302,10 @@ export async function dispatchTask(
   // Step 2: Send notification early (before session dispatch which can timeout)
   // This ensures users see the notification even if gateway is slow
   const notifyConfig = getNotificationConfig(pluginConfig);
-  const notifyTarget = resolveNotifyChannel(issue?.labels ?? [], project.channels);
+  const notifyTarget = resolveNotifyChannel(
+    issue?.labels ?? [],
+    project.channels,
+  );
   notify(
     {
       type: "workerStart",
@@ -238,10 +325,13 @@ export async function dispatchTask(
       channel: notifyTarget?.channel ?? "telegram",
       runtime,
       accountId: notifyTarget?.accountId,
+      runCommand: rc,
     },
   ).catch((err) => {
     auditLog(workspaceDir, "dispatch_warning", {
-      step: "notify", issue: issueId, role,
+      step: "notify",
+      issue: issueId,
+      role,
       error: (err as Error).message ?? String(err),
     }).catch(() => {});
   });
@@ -249,12 +339,25 @@ export async function dispatchTask(
   // Step 3: Ensure session exists (fire-and-forget — don't wait for gateway)
   // Session key is deterministic, so we can proceed immediately
   const sessionLabel = formatSessionLabel(project.name, role, level, botName);
-  ensureSessionFireAndForget(sessionKey, model, workspaceDir, rc, timeouts.sessionPatchMs, sessionLabel);
+  ensureSessionFireAndForget(
+    sessionKey,
+    model,
+    workspaceDir,
+    rc,
+    timeouts.sessionPatchMs,
+    sessionLabel,
+  );
 
   // Step 4: Send task to agent (fire-and-forget)
   sendToAgent(sessionKey, taskMessage, {
-    agentId, projectName: project.name, issueId, role, level, slotIndex,
-    orchestratorSessionKey: opts.sessionKey, workspaceDir,
+    agentId,
+    projectName: project.name,
+    issueId,
+    role,
+    level,
+    slotIndex,
+    orchestratorSessionKey: opts.sessionKey,
+    workspaceDir,
     dispatchTimeoutMs: timeouts.dispatchMs,
     extraSystemPrompt: roleInstructions.trim() || undefined,
     model,
@@ -264,32 +367,66 @@ export async function dispatchTask(
   // Step 5: Update worker state
   try {
     await recordWorkerState(workspaceDir, project.slug, role, slotIndex, {
-      issueId, level, sessionKey, sessionAction, fromLabel, name: botName,
+      issueId,
+      level,
+      sessionKey,
+      sessionAction,
+      fromLabel,
+      name: botName,
     });
   } catch (err) {
     // Session is already dispatched — log warning but don't fail
     await auditLog(workspaceDir, "dispatch", {
-      project: project.name, issue: issueId, role,
+      project: project.name,
+      issue: issueId,
+      role,
       warning: "State update failed after successful dispatch",
-      error: (err as Error).message, sessionKey,
+      error: (err as Error).message,
+      sessionKey,
     });
   }
 
   // Step 6: Audit
   await auditDispatch(workspaceDir, {
-    project: project.name, issueId, issueTitle,
-    role, level, model, sessionAction, sessionKey,
-    fromLabel, toLabel,
+    project: project.name,
+    issueId,
+    issueTitle,
+    role,
+    level,
+    model,
+    sessionAction,
+    sessionKey,
+    fromLabel,
+    toLabel,
   });
 
-  const announcement = buildAnnouncement(level, role, sessionAction, issueId, issueTitle, issueUrl, resolvedRole, botName);
+  const announcement = buildAnnouncement(
+    level,
+    role,
+    sessionAction,
+    issueId,
+    issueTitle,
+    issueUrl,
+    resolvedRole,
+    botName,
+  );
 
   return { sessionAction, sessionKey, level, model, announcement };
 }
 
 async function recordWorkerState(
-  workspaceDir: string, slug: string, role: string, slotIndex: number,
-  opts: { issueId: number; level: string; sessionKey: string; sessionAction: "spawn" | "send"; fromLabel?: string; name?: string },
+  workspaceDir: string,
+  slug: string,
+  role: string,
+  slotIndex: number,
+  opts: {
+    issueId: number;
+    level: string;
+    sessionKey: string;
+    sessionAction: "spawn" | "send";
+    fromLabel?: string;
+    name?: string;
+  },
 ): Promise<void> {
   await activateWorker(workspaceDir, slug, role, {
     issueId: String(opts.issueId),
@@ -305,20 +442,32 @@ async function recordWorkerState(
 async function auditDispatch(
   workspaceDir: string,
   opts: {
-    project: string; issueId: number; issueTitle: string;
-    role: string; level: string; model: string; sessionAction: string;
-    sessionKey: string; fromLabel: string; toLabel: string;
+    project: string;
+    issueId: number;
+    issueTitle: string;
+    role: string;
+    level: string;
+    model: string;
+    sessionAction: string;
+    sessionKey: string;
+    fromLabel: string;
+    toLabel: string;
   },
 ): Promise<void> {
   await auditLog(workspaceDir, "dispatch", {
     project: opts.project,
-    issue: opts.issueId, issueTitle: opts.issueTitle,
-    role: opts.role, level: opts.level,
-    sessionAction: opts.sessionAction, sessionKey: opts.sessionKey,
+    issue: opts.issueId,
+    issueTitle: opts.issueTitle,
+    role: opts.role,
+    level: opts.level,
+    sessionAction: opts.sessionAction,
+    sessionKey: opts.sessionKey,
     labelTransition: `${opts.fromLabel} → ${opts.toLabel}`,
   });
   await auditLog(workspaceDir, "model_selection", {
-    issue: opts.issueId, role: opts.role, level: opts.level, model: opts.model,
+    issue: opts.issueId,
+    role: opts.role,
+    level: opts.level,
+    model: opts.model,
   });
 }
-

--- a/lib/services/heartbeat/tick-runner.dispatch.test.ts
+++ b/lib/services/heartbeat/tick-runner.dispatch.test.ts
@@ -1,0 +1,21 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+describe("heartbeat tick-runner dispatch wiring", () => {
+  it("forwards runtime to projectTick options", () => {
+    const filePath = path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "tick-runner.ts",
+    );
+    const src = fs.readFileSync(filePath, "utf-8");
+
+    assert.match(
+      src,
+      /projectTick\(\{[\s\S]*runtime,[\s\S]*runCommand,[\s\S]*\}\)/m,
+      "tick-runner should pass runtime into projectTick() dispatch path",
+    );
+  });
+});

--- a/lib/services/heartbeat/tick-runner.ts
+++ b/lib/services/heartbeat/tick-runner.ts
@@ -4,13 +4,15 @@
 import type { PluginRuntime } from "openclaw/plugin-sdk";
 import type { RunCommand } from "../../context.js";
 import path from "node:path";
-import { readProjects, getProject, type Project } from "../../projects/index.js";
+import {
+  readProjects,
+  getProject,
+  type Project,
+} from "../../projects/index.js";
 import { log as auditLog } from "../../audit.js";
 import { DATA_DIR } from "../../setup/migrate-layout.js";
 import { loadInstanceName } from "../../instance.js";
-import {
-  type SessionLookup,
-} from "./health.js";
+import { type SessionLookup } from "./health.js";
 import { projectTick } from "../tick.js";
 import { createProvider } from "../../providers/index.js";
 import { loadConfig } from "../../config/index.js";
@@ -50,11 +52,22 @@ export async function tick(opts: {
   runtime?: PluginRuntime;
   runCommand: RunCommand;
 }): Promise<TickResult> {
-  const { workspaceDir, agentId, config, pluginConfig, sessions, runtime, runCommand } = opts;
+  const {
+    workspaceDir,
+    agentId,
+    config,
+    pluginConfig,
+    sessions,
+    runtime,
+    runCommand,
+  } = opts;
 
   // Load instance name for ownership filtering and auto-claiming
   const resolvedWorkspaceConfig = await loadConfig(workspaceDir);
-  const instanceName = await loadInstanceName(workspaceDir, resolvedWorkspaceConfig.instanceName);
+  const instanceName = await loadInstanceName(
+    workspaceDir,
+    resolvedWorkspaceConfig.instanceName,
+  );
 
   const data = await readProjects(workspaceDir);
   const slugs = Object.keys(data.projects);
@@ -108,17 +121,34 @@ export async function tick(opts: {
 
       // Review pass: transition issues whose PR check condition is met
       result.totalReviewTransitions += await performReviewPass(
-        workspaceDir, slug, project, provider, resolvedConfig, pluginConfig, runtime, runCommand,
+        workspaceDir,
+        slug,
+        project,
+        provider,
+        resolvedConfig,
+        pluginConfig,
+        runtime,
+        runCommand,
       );
 
       // Review skip pass: auto-merge and transition review:skip issues through the review queue
       result.totalReviewSkipTransitions += await performReviewSkipPass(
-        workspaceDir, slug, project, provider, resolvedConfig, pluginConfig, runtime, runCommand,
+        workspaceDir,
+        slug,
+        project,
+        provider,
+        resolvedConfig,
+        pluginConfig,
+        runtime,
+        runCommand,
       );
 
       // Test skip pass: auto-transition test:skip issues through the test queue
       result.totalTestSkipTransitions += await performTestSkipPass(
-        workspaceDir, slug, provider, resolvedConfig,
+        workspaceDir,
+        slug,
+        provider,
+        resolvedConfig,
       );
 
       // Budget check: stop if we've hit the limit
@@ -143,6 +173,7 @@ export async function tick(opts: {
         agentId,
         pluginConfig,
         maxPickups: remaining,
+        runtime,
         instanceName,
         runCommand,
       });
@@ -185,6 +216,6 @@ export async function checkProjectActive(
   const project = getProject(data, slug);
   if (!project) return false;
   return Object.values(project.workers).some((w) =>
-    Object.values(w.levels).some(slots => slots.some(s => s.active)),
+    Object.values(w.levels).some((slots) => slots.some((s) => s.active)),
   );
 }


### PR DESCRIPTION
## Summary
- pass `runtime` from heartbeat tick-runner through to `projectTick`
- pass `runCommand` fallback into `notify()` from dispatch path
- add regression tests for missing-runtime notify fallback and heartbeat tick-runner dispatch wiring

## Testing
- npm run check
- npm run test:core

Closes #19
