### PR TITLE
Fix redispatch idempotency collisions with per-slot dispatch attempts

### DIFF
--- a/lib/dispatch/index.ts
+++ b/lib/dispatch/index.ts
@@ -183,6 +183,7 @@ export async function dispatchTask(
   }
 
   const sessionAction = existingSessionKey ? "send" : "spawn";
+  const dispatchAttempt = (slot.dispatchAttempt ?? 0) + 1;
 
   // Fetch comments to include in task context
   const comments = await provider.listComments(issueId);
@@ -356,6 +357,7 @@ export async function dispatchTask(
     role,
     level,
     slotIndex,
+    dispatchAttempt,
     orchestratorSessionKey: opts.sessionKey,
     workspaceDir,
     dispatchTimeoutMs: timeouts.dispatchMs,
@@ -373,6 +375,7 @@ export async function dispatchTask(
       sessionAction,
       fromLabel,
       name: botName,
+      dispatchAttempt,
     });
   } catch (err) {
     // Session is already dispatched — log warning but don't fail
@@ -426,6 +429,7 @@ async function recordWorkerState(
     sessionAction: "spawn" | "send";
     fromLabel?: string;
     name?: string;
+    dispatchAttempt: number;
   },
 ): Promise<void> {
   await activateWorker(workspaceDir, slug, role, {
@@ -436,6 +440,7 @@ async function recordWorkerState(
     previousLabel: opts.fromLabel,
     slotIndex,
     name: opts.name,
+    dispatchAttempt: opts.dispatchAttempt,
   });
 }
 

--- a/lib/dispatch/session.idempotency.test.ts
+++ b/lib/dispatch/session.idempotency.test.ts
@@ -1,0 +1,64 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { sendToAgent } from "./session.js";
+
+describe("sendToAgent idempotency key", () => {
+  it("includes dispatchAttempt nonce and differs across redispatch attempts", async () => {
+    const captured: string[] = [];
+
+    const runCommand: any = async (argv: string[], _opts: any) => {
+      const paramsIdx = argv.indexOf("--params");
+      if (
+        argv[0] === "openclaw" &&
+        argv[1] === "gateway" &&
+        argv[2] === "call" &&
+        argv[3] === "agent" &&
+        paramsIdx >= 0
+      ) {
+        const params = JSON.parse(argv[paramsIdx + 1]!);
+        captured.push(params.idempotencyKey);
+      }
+      return {
+        stdout: "{}",
+        stderr: "",
+        code: 0,
+        signal: null,
+        killed: false,
+        termination: { type: "exit", code: 0 },
+      };
+    };
+
+    sendToAgent("agent:test:subagent:proj-dev-senior-ada", "msg", {
+      projectName: "proj",
+      issueId: 17,
+      role: "developer",
+      level: "senior",
+      slotIndex: 0,
+      dispatchAttempt: 1,
+      workspaceDir: "/tmp",
+      runCommand,
+    });
+
+    sendToAgent("agent:test:subagent:proj-dev-senior-ada", "msg", {
+      projectName: "proj",
+      issueId: 17,
+      role: "developer",
+      level: "senior",
+      slotIndex: 0,
+      dispatchAttempt: 2,
+      workspaceDir: "/tmp",
+      runCommand,
+    });
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    assert.strictEqual(captured.length, 2);
+    assert.ok(
+      captured[0]!.includes("-0-1-agent:test:subagent:proj-dev-senior-ada"),
+    );
+    assert.ok(
+      captured[1]!.includes("-0-2-agent:test:subagent:proj-dev-senior-ada"),
+    );
+    assert.notStrictEqual(captured[0], captured[1]);
+  });
+});

--- a/lib/dispatch/session.ts
+++ b/lib/dispatch/session.ts
@@ -67,45 +67,90 @@ export async function shouldClearSession(
  * Session key is deterministic, so we don't need to wait for confirmation.
  * If this fails, health check will catch orphaned state later.
  */
-export function ensureSessionFireAndForget(sessionKey: string, model: string, workspaceDir: string, runCommand: RunCommand, timeoutMs = 30_000, label?: string): void {
+export function ensureSessionFireAndForget(
+  sessionKey: string,
+  model: string,
+  workspaceDir: string,
+  runCommand: RunCommand,
+  timeoutMs = 30_000,
+  label?: string,
+): void {
   const rc = runCommand;
   const params: Record<string, unknown> = { key: sessionKey, model };
   if (label) params.label = label;
   rc(
-    ["openclaw", "gateway", "call", "sessions.patch", "--params", JSON.stringify(params)],
+    [
+      "openclaw",
+      "gateway",
+      "call",
+      "sessions.patch",
+      "--params",
+      JSON.stringify(params),
+    ],
     { timeoutMs },
   ).catch((err) => {
     auditLog(workspaceDir, "dispatch_warning", {
-      step: "ensureSession", sessionKey,
+      step: "ensureSession",
+      sessionKey,
       error: (err as Error).message ?? String(err),
     }).catch(() => {});
   });
 }
 
 export function sendToAgent(
-  sessionKey: string, taskMessage: string,
-  opts: { agentId?: string; projectName: string; issueId: number; role: string; level?: string; slotIndex?: number; orchestratorSessionKey?: string; workspaceDir: string; dispatchTimeoutMs?: number; extraSystemPrompt?: string; model?: string; runCommand: RunCommand },
+  sessionKey: string,
+  taskMessage: string,
+  opts: {
+    agentId?: string;
+    projectName: string;
+    issueId: number;
+    role: string;
+    level?: string;
+    slotIndex?: number;
+    dispatchAttempt?: number;
+    orchestratorSessionKey?: string;
+    workspaceDir: string;
+    dispatchTimeoutMs?: number;
+    extraSystemPrompt?: string;
+    model?: string;
+    runCommand: RunCommand;
+  },
 ): void {
   const rc = opts.runCommand;
   const gatewayParams = JSON.stringify({
-    idempotencyKey: `devclaw-${opts.projectName}-${opts.issueId}-${opts.role}-${opts.level ?? "unknown"}-${opts.slotIndex ?? 0}-${sessionKey}`,
+    idempotencyKey: `devclaw-${opts.projectName}-${opts.issueId}-${opts.role}-${opts.level ?? "unknown"}-${opts.slotIndex ?? 0}-${opts.dispatchAttempt ?? 0}-${sessionKey}`,
     agentId: opts.agentId ?? "devclaw",
     sessionKey,
     message: taskMessage,
     deliver: false,
     lane: "subagent",
-    ...(opts.orchestratorSessionKey ? { spawnedBy: opts.orchestratorSessionKey } : {}),
-    ...(opts.extraSystemPrompt ? { extraSystemPrompt: opts.extraSystemPrompt } : {}),
+    ...(opts.orchestratorSessionKey
+      ? { spawnedBy: opts.orchestratorSessionKey }
+      : {}),
+    ...(opts.extraSystemPrompt
+      ? { extraSystemPrompt: opts.extraSystemPrompt }
+      : {}),
     ...(opts.model ? { model: opts.model } : {}),
   });
   // Fire-and-forget: long-running agent turn, don't await
   rc(
-    ["openclaw", "gateway", "call", "agent", "--params", gatewayParams, "--expect-final", "--json"],
+    [
+      "openclaw",
+      "gateway",
+      "call",
+      "agent",
+      "--params",
+      gatewayParams,
+      "--expect-final",
+      "--json",
+    ],
     { timeoutMs: opts.dispatchTimeoutMs ?? 600_000 },
   ).catch((err) => {
     auditLog(opts.workspaceDir, "dispatch_warning", {
-      step: "sendToAgent", sessionKey,
-      issue: opts.issueId, role: opts.role,
+      step: "sendToAgent",
+      sessionKey,
+      issue: opts.issueId,
+      role: opts.role,
       error: (err as Error).message ?? String(err),
     }).catch(() => {});
   });

--- a/lib/projects/migrations.ts
+++ b/lib/projects/migrations.ts
@@ -89,7 +89,10 @@ function isLevelFormat(worker: Record<string, unknown>): boolean {
  * Extracts sessionKey from sessions[level].
  * Slots with null level are skipped (no "unknown" fallback).
  */
-function parseLegacyFlatState(worker: Record<string, unknown>, role: string): RoleWorkerState {
+function parseLegacyFlatState(
+  worker: Record<string, unknown>,
+  role: string,
+): RoleWorkerState {
   const level = (worker.level ?? worker.tier ?? null) as string | null;
   const migratedLevel = migrateLevel(level, role);
   const sessions = (worker.sessions as Record<string, string | null>) ?? {};
@@ -103,7 +106,7 @@ function parseLegacyFlatState(worker: Record<string, unknown>, role: string): Ro
   if (migratedSessions[migratedLevel]) {
     sessionKey = migratedSessions[migratedLevel]!;
   } else {
-    const firstNonNull = Object.values(migratedSessions).find(v => v != null);
+    const firstNonNull = Object.values(migratedSessions).find((v) => v != null);
     if (firstNonNull) sessionKey = firstNonNull;
   }
 
@@ -112,6 +115,7 @@ function parseLegacyFlatState(worker: Record<string, unknown>, role: string): Ro
     issueId: worker.issueId as string | null,
     sessionKey,
     startTime: worker.startTime as string | null,
+    dispatchAttempt: (worker.dispatchAttempt as number | undefined) ?? 0,
     previousLabel: (worker.previousLabel as string | null) ?? null,
     name: (worker.name ?? worker.slotName) as string | undefined,
   };
@@ -123,7 +127,10 @@ function parseLegacyFlatState(worker: Record<string, unknown>, role: string): Ro
  * Parse old slot-based format into per-level RoleWorkerState.
  * Groups slots by their `level` field. Slots with null level are skipped.
  */
-function parseOldSlotState(worker: Record<string, unknown>, role: string): RoleWorkerState {
+function parseOldSlotState(
+  worker: Record<string, unknown>,
+  role: string,
+): RoleWorkerState {
   const rawSlots = (worker.slots as Array<Record<string, unknown>>) ?? [];
   const levels: Record<string, SlotState[]> = {};
 
@@ -137,6 +144,7 @@ function parseOldSlotState(worker: Record<string, unknown>, role: string): RoleW
       issueId: s.issueId as string | null,
       sessionKey: s.sessionKey as string | null,
       startTime: s.startTime as string | null,
+      dispatchAttempt: (s.dispatchAttempt as number | undefined) ?? 0,
       previousLabel: (s.previousLabel as string | null) ?? null,
       name: (s.name ?? s.slotName) as string | undefined,
     });
@@ -149,8 +157,14 @@ function parseOldSlotState(worker: Record<string, unknown>, role: string): RoleW
  * Parse already per-level format, applying level alias migration.
  * Strips "unknown" level entries from previous migration artifacts.
  */
-function parseLevelState(worker: Record<string, unknown>, role: string): RoleWorkerState {
-  const rawLevels = worker.levels as Record<string, Array<Record<string, unknown>>>;
+function parseLevelState(
+  worker: Record<string, unknown>,
+  role: string,
+): RoleWorkerState {
+  const rawLevels = worker.levels as Record<
+    string,
+    Array<Record<string, unknown>>
+  >;
   const levels: Record<string, SlotState[]> = {};
 
   for (const [rawLevel, rawSlots] of Object.entries(rawLevels)) {
@@ -166,6 +180,7 @@ function parseLevelState(worker: Record<string, unknown>, role: string): RoleWor
         issueId: s.issueId as string | null,
         sessionKey: s.sessionKey as string | null,
         startTime: s.startTime as string | null,
+        dispatchAttempt: (s.dispatchAttempt as number | undefined) ?? 0,
         previousLabel: (s.previousLabel as string | null) ?? null,
         name: (s.name ?? s.slotName) as string | undefined,
       });
@@ -175,7 +190,10 @@ function parseLevelState(worker: Record<string, unknown>, role: string): RoleWor
   return { levels };
 }
 
-function parseWorkerState(worker: Record<string, unknown>, role: string): RoleWorkerState {
+function parseWorkerState(
+  worker: Record<string, unknown>,
+  role: string,
+): RoleWorkerState {
   if (isLevelFormat(worker)) {
     return parseLevelState(worker, role);
   }
@@ -250,7 +268,14 @@ export function migrateProject(project: Project): boolean {
     // Preserve the legacy single-channel registration. channelId is unknown here
     // (the outer loop in readProjects doesn't pass it), so we leave channelId blank
     // and callers fall back to channels[0] which still gives the right channel type.
-    project.channels = [{ channelId: "", channel: rawChannel as "telegram" | "whatsapp" | "discord" | "slack", name: "primary", events: ["*"] }];
+    project.channels = [
+      {
+        channelId: "",
+        channel: rawChannel as "telegram" | "whatsapp" | "discord" | "slack",
+        name: "primary",
+        events: ["*"],
+      },
+    ];
     changed = true;
   }
   if ((raw as Record<string, unknown>).channel !== undefined) {

--- a/lib/projects/mutations.ts
+++ b/lib/projects/mutations.ts
@@ -1,18 +1,26 @@
 /**
  * projects/mutations.ts — State mutations for project worker slots.
  */
-import type { SlotState, RoleWorkerState, Project, ProjectsData } from "./types.js";
-import { acquireLock, releaseLock, readProjects, writeProjects, resolveProjectSlug } from "./io.js";
+import type {
+  SlotState,
+  RoleWorkerState,
+  Project,
+  ProjectsData,
+} from "./types.js";
+import {
+  acquireLock,
+  releaseLock,
+  readProjects,
+  writeProjects,
+  resolveProjectSlug,
+} from "./io.js";
 import { emptySlot, findFreeSlot, findSlotByIssue } from "./slots.js";
 
 /**
  * Get the RoleWorkerState for a given role.
  * Returns an empty state if the role has no workers configured.
  */
-export function getRoleWorker(
-  project: Project,
-  role: string,
-): RoleWorkerState {
+export function getRoleWorker(project: Project, role: string): RoleWorkerState {
   return project.workers[role] ?? { levels: {} };
 }
 
@@ -33,7 +41,9 @@ export async function updateSlot(
     const data = await readProjects(workspaceDir);
     const slug = resolveProjectSlug(data, slugOrChannelId);
     if (!slug) {
-      throw new Error(`Project not found for slug or channelId: ${slugOrChannelId}`);
+      throw new Error(
+        `Project not found for slug or channelId: ${slugOrChannelId}`,
+      );
     }
 
     const project = data.projects[slug]!;
@@ -76,6 +86,8 @@ export async function activateWorker(
     slotIndex?: number;
     /** Deterministic fun name for this slot. */
     name?: string;
+    /** Monotonic per-slot dispatch attempt counter for idempotency nonce. */
+    dispatchAttempt?: number;
   },
 ): Promise<ProjectsData> {
   await acquireLock(workspaceDir);
@@ -83,7 +95,9 @@ export async function activateWorker(
     const data = await readProjects(workspaceDir);
     const slug = resolveProjectSlug(data, slugOrChannelId);
     if (!slug) {
-      throw new Error(`Project not found for slug or channelId: ${slugOrChannelId}`);
+      throw new Error(
+        `Project not found for slug or channelId: ${slugOrChannelId}`,
+      );
     }
 
     const project = data.projects[slug]!;
@@ -103,6 +117,8 @@ export async function activateWorker(
       issueId: params.issueId,
       sessionKey: params.sessionKey ?? slots[idx]!.sessionKey,
       startTime: params.startTime ?? new Date().toISOString(),
+      dispatchAttempt:
+        params.dispatchAttempt ?? slots[idx]!.dispatchAttempt ?? 0,
       previousLabel: params.previousLabel ?? null,
       name: params.name ?? slots[idx]!.name,
     };
@@ -132,7 +148,9 @@ export async function deactivateWorker(
     const data = await readProjects(workspaceDir);
     const slug = resolveProjectSlug(data, slugOrChannelId);
     if (!slug) {
-      throw new Error(`Project not found for slug or channelId: ${slugOrChannelId}`);
+      throw new Error(
+        `Project not found for slug or channelId: ${slugOrChannelId}`,
+      );
     }
 
     const project = data.projects[slug]!;
@@ -161,6 +179,7 @@ export async function deactivateWorker(
           issueId: null,
           sessionKey: slot.sessionKey,
           startTime: null,
+          dispatchAttempt: slot.dispatchAttempt ?? 0,
           previousLabel: null,
           name: slot.name,
         };

--- a/lib/projects/slots.ts
+++ b/lib/projects/slots.ts
@@ -14,11 +14,14 @@ export function emptySlot(): SlotState {
     issueId: null,
     sessionKey: null,
     startTime: null,
+    dispatchAttempt: 0,
   };
 }
 
 /** Create a blank RoleWorkerState with the given per-level capacities. */
-export function emptyRoleWorkerState(levelMaxWorkers: Record<string, number>): RoleWorkerState {
+export function emptyRoleWorkerState(
+  levelMaxWorkers: Record<string, number>,
+): RoleWorkerState {
   const levels: Record<string, SlotState[]> = {};
   for (const [level, max] of Object.entries(levelMaxWorkers)) {
     levels[level] = [];
@@ -30,7 +33,10 @@ export function emptyRoleWorkerState(levelMaxWorkers: Record<string, number>): R
 }
 
 /** Return the lowest-index inactive slot within a specific level, or null if full. */
-export function findFreeSlot(roleWorker: RoleWorkerState, level: string): number | null {
+export function findFreeSlot(
+  roleWorker: RoleWorkerState,
+  level: string,
+): number | null {
   const slots = roleWorker.levels[level];
   if (!slots) return null;
   for (let i = 0; i < slots.length; i++) {
@@ -45,7 +51,10 @@ export function findFreeSlot(roleWorker: RoleWorkerState, level: string): number
  * Active workers are never removed — they finish naturally.
  * Mutates roleWorker in place. Returns true if any changes were made.
  */
-export function reconcileSlots(roleWorker: RoleWorkerState, levelMaxWorkers: Record<string, number>): boolean {
+export function reconcileSlots(
+  roleWorker: RoleWorkerState,
+  levelMaxWorkers: Record<string, number>,
+): boolean {
   let changed = false;
   for (const [level, max] of Object.entries(levelMaxWorkers)) {
     if (!roleWorker.levels[level]) {
@@ -67,7 +76,10 @@ export function reconcileSlots(roleWorker: RoleWorkerState, levelMaxWorkers: Rec
 }
 
 /** Find the level and slot index for a given issueId, or null if not found. */
-export function findSlotByIssue(roleWorker: RoleWorkerState, issueId: string): { level: string; slotIndex: number } | null {
+export function findSlotByIssue(
+  roleWorker: RoleWorkerState,
+  issueId: string,
+): { level: string; slotIndex: number } | null {
   for (const [level, slots] of Object.entries(roleWorker.levels)) {
     for (let i = 0; i < slots.length; i++) {
       if (slots[i]!.issueId === issueId) return { level, slotIndex: i };

--- a/lib/projects/types.ts
+++ b/lib/projects/types.ts
@@ -12,6 +12,8 @@ export type SlotState = {
   issueId: string | null;
   sessionKey: string | null;
   startTime: string | null;
+  /** Monotonic dispatch counter for idempotency key nonce (per slot). */
+  dispatchAttempt?: number;
   previousLabel?: string | null;
   /** Deterministic fun name for this slot (e.g. "Ada", "Grace"). */
   name?: string;

--- a/lib/testing/harness.ts
+++ b/lib/testing/harness.ts
@@ -9,7 +9,12 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
-import { writeProjects, type ProjectsData, type Project, type RoleWorkerState } from "../projects/index.js";
+import {
+  writeProjects,
+  type ProjectsData,
+  type Project,
+  type RoleWorkerState,
+} from "../projects/index.js";
 import { DEFAULT_WORKFLOW, type WorkflowConfig } from "../workflow/index.js";
 import { registerBootstrapHook } from "../dispatch/bootstrap-hook.js";
 import { TestProvider } from "./test-provider.js";
@@ -38,6 +43,8 @@ export type CapturedCommand = {
   extraSystemPrompt?: string;
   /** Extracted from gateway `agent` call params, if applicable. */
   agentModel?: string;
+  /** Extracted from gateway `agent` call params, if applicable. */
+  idempotencyKey?: string;
   /** Extracted from gateway `sessions.patch` params, if applicable. */
   sessionPatch?: { key: string; model: string; label?: string };
 };
@@ -53,6 +60,8 @@ export type CommandInterceptor = {
   extraSystemPrompts(): string[];
   /** Get all agent models sent via `openclaw gateway call agent`. */
   agentModels(): string[];
+  /** Get all idempotency keys sent via `openclaw gateway call agent`. */
+  agentIdempotencyKeys(): string[];
   /** Get all session patches. */
   sessionPatches(): Array<{ key: string; model: string; label?: string }>;
   /** Reset captured commands. */
@@ -61,7 +70,16 @@ export type CommandInterceptor = {
 
 function createCommandInterceptor(): {
   interceptor: CommandInterceptor;
-  handler: (argv: string[], opts: number | { timeoutMs: number; cwd?: string }) => Promise<{ stdout: string; stderr: string; code: number | null; signal: null; killed: false }>;
+  handler: (
+    argv: string[],
+    opts: number | { timeoutMs: number; cwd?: string },
+  ) => Promise<{
+    stdout: string;
+    stderr: string;
+    code: number | null;
+    signal: null;
+    killed: false;
+  }>;
 } {
   const commands: CapturedCommand[] = [];
 
@@ -69,9 +87,10 @@ function createCommandInterceptor(): {
     argv: string[],
     optsOrTimeout: number | { timeoutMs: number; cwd?: string },
   ) => {
-    const opts = typeof optsOrTimeout === "number"
-      ? { timeoutMs: optsOrTimeout }
-      : optsOrTimeout;
+    const opts =
+      typeof optsOrTimeout === "number"
+        ? { timeoutMs: optsOrTimeout }
+        : optsOrTimeout;
 
     const captured: CapturedCommand = { argv, opts };
 
@@ -90,17 +109,32 @@ function createCommandInterceptor(): {
             if (params.model) {
               captured.agentModel = params.model;
             }
+            if (params.idempotencyKey) {
+              captured.idempotencyKey = params.idempotencyKey;
+            }
           }
           if (rpcMethod === "sessions.patch") {
-            captured.sessionPatch = { key: params.key, model: params.model, label: params.label };
+            captured.sessionPatch = {
+              key: params.key,
+              model: params.model,
+              label: params.label,
+            };
           }
-        } catch { /* ignore parse errors */ }
+        } catch {
+          /* ignore parse errors */
+        }
       }
     }
 
     commands.push(captured);
 
-    return { stdout: "{}", stderr: "", code: 0, signal: null as null, killed: false as const };
+    return {
+      stdout: "{}",
+      stderr: "",
+      code: 0,
+      signal: null as null,
+      killed: false as const,
+    };
   };
 
   const interceptor: CommandInterceptor = {
@@ -122,6 +156,11 @@ function createCommandInterceptor(): {
       return commands
         .filter((c) => c.agentModel !== undefined)
         .map((c) => c.agentModel!);
+    },
+    agentIdempotencyKeys() {
+      return commands
+        .filter((c) => c.idempotencyKey !== undefined)
+        .map((c) => c.idempotencyKey!);
     },
     sessionPatches() {
       return commands
@@ -165,7 +204,11 @@ export type TestHarness = {
    * @param content - Prompt file content
    * @param projectName - If provided, writes project-specific prompt; otherwise writes default.
    */
-  writePrompt(role: string, content: string, projectName?: string): Promise<void>;
+  writePrompt(
+    role: string,
+    content: string,
+    projectName?: string,
+  ): Promise<void>;
   /**
    * Simulate the agent:bootstrap hook firing for a session key.
    * Tests that AGENTS.md is stripped from bootstrap files for DevClaw workers.
@@ -187,12 +230,24 @@ export type HarnessOptions = {
   /** Workflow config (default: DEFAULT_WORKFLOW). */
   workflow?: WorkflowConfig;
   /** Initial worker state overrides (level + slot fields). */
-  workers?: Record<string, { level?: string; active?: boolean; issueId?: string | null; sessionKey?: string | null; startTime?: string | null; previousLabel?: string | null }>;
+  workers?: Record<
+    string,
+    {
+      level?: string;
+      active?: boolean;
+      issueId?: string | null;
+      sessionKey?: string | null;
+      startTime?: string | null;
+      previousLabel?: string | null;
+    }
+  >;
   /** Additional projects to seed. */
   extraProjects?: Record<string, Project>;
 };
 
-export async function createTestHarness(opts?: HarnessOptions): Promise<TestHarness> {
+export async function createTestHarness(
+  opts?: HarnessOptions,
+): Promise<TestHarness> {
   const {
     projectName = "test-project",
     channelId = "-1234567890",
@@ -223,13 +278,15 @@ export async function createTestHarness(opts?: HarnessOptions): Promise<TestHarn
     for (const [role, overrides] of Object.entries(workerOverrides)) {
       const level = overrides.level ?? "senior";
       const rw = defaultWorkers[role] ?? emptyRW();
-      rw.levels[level] = [{
-        active: overrides.active ?? false,
-        issueId: overrides.issueId ?? null,
-        sessionKey: overrides.sessionKey ?? null,
-        startTime: overrides.startTime ?? null,
-        previousLabel: overrides.previousLabel ?? null,
-      }];
+      rw.levels[level] = [
+        {
+          active: overrides.active ?? false,
+          issueId: overrides.issueId ?? null,
+          sessionKey: overrides.sessionKey ?? null,
+          startTime: overrides.startTime ?? null,
+          previousLabel: overrides.previousLabel ?? null,
+        },
+      ];
       defaultWorkers[role] = rw;
     }
   }
@@ -242,14 +299,16 @@ export async function createTestHarness(opts?: HarnessOptions): Promise<TestHarn
     deployUrl: "",
     baseBranch,
     deployBranch: baseBranch,
-    channels: [{ channelId, channel: "telegram", name: "primary", events: ["*"] }],
+    channels: [
+      { channelId, channel: "telegram", name: "primary", events: ["*"] },
+    ],
     provider: "github",
     workers: defaultWorkers,
   };
 
   const projectsData: ProjectsData = {
     projects: {
-      [projectName]: project,  // New schema: keyed by slug (projectName), not channelId
+      [projectName]: project, // New schema: keyed by slug (projectName), not channelId
       ...extraProjects,
     },
   };
@@ -310,7 +369,8 @@ export async function createTestHarness(opts?: HarnessOptions): Promise<TestHarn
         {
           name: "AGENTS.md",
           path: path.join(workspaceDir, "AGENTS.md"),
-          content: "# Orchestrator instructions\nThis content should be stripped.",
+          content:
+            "# Orchestrator instructions\nThis content should be stripped.",
           missing: false,
         },
       ];
@@ -325,7 +385,9 @@ export async function createTestHarness(opts?: HarnessOptions): Promise<TestHarn
       }
 
       return {
-        agentsMdStripped: bootstrapFiles[0].missing === true && bootstrapFiles[0].content === "",
+        agentsMdStripped:
+          bootstrapFiles[0].missing === true &&
+          bootstrapFiles[0].content === "",
       };
     },
     async cleanup() {


### PR DESCRIPTION
## Summary
- add a monotonic per-slot `dispatchAttempt` counter to worker slot state and persist/migrate it
- include `dispatchAttempt` in gateway agent idempotency key generation
- increment and store dispatch attempts on each dispatch while preserving session reuse
- add test coverage for idempotency-key attempt nonce behavior

## Why
Fixes #17 by preventing dedupe collisions when the same issue/session is redispatched within the idempotency window, while still reusing the same worker session.
