### PR TITLE
Fix #18: robust completion transition verification + retries

### DIFF
--- a/lib/services/pipeline-completion-robustness.test.ts
+++ b/lib/services/pipeline-completion-robustness.test.ts
@@ -137,6 +137,54 @@ describe("executeCompletion transition robustness", () => {
     );
   });
 
+  it("retries cleanup when retry starts with both old and new state labels", async () => {
+    const h = await createTestHarness({
+      workers: {
+        developer: { active: true, issueId: "22", level: "senior" },
+      },
+    });
+
+    h.provider.seedIssue({
+      iid: 22,
+      title: "Retry stale-label cleanup",
+      labels: ["Doing", "To Review"],
+    });
+
+    let attempts = 0;
+    const original = h.provider.transitionLabel.bind(h.provider);
+    h.provider.transitionLabel = async (...args) => {
+      attempts += 1;
+      if (attempts === 1)
+        throw new Error("provider temporarily unavailable during cleanup");
+      return original(...args);
+    };
+
+    const out = await executeCompletion({
+      workspaceDir: h.workspaceDir,
+      projectSlug: h.project.slug,
+      channels: h.project.channels,
+      role: "developer",
+      result: "done",
+      issueId: 22,
+      summary: "retry",
+      provider: h.provider,
+      repoPath: "/tmp/test-repo",
+      projectName: "test-project",
+      runCommand: h.runCommand,
+    });
+
+    assert.strictEqual(out.labelTransition, "Doing → To Review");
+    assert.strictEqual(out.transitionAttempts, 2);
+    assert.strictEqual(attempts, 2);
+
+    const issue = await h.provider.getIssue(22);
+    assert.ok(issue.labels.includes("To Review"));
+    assert.ok(
+      !issue.labels.includes("Doing"),
+      `labels=${issue.labels.join(",")}`,
+    );
+  });
+
   it("fails fast on stale/mismatched state precondition", async () => {
     const h = await createTestHarness({
       workers: {

--- a/lib/services/pipeline.ts
+++ b/lib/services/pipeline.ts
@@ -26,6 +26,7 @@ import {
   DEFAULT_WORKFLOW,
   getCompletionEmoji,
   getCompletionRule,
+  getStateLabels,
   getNextStateDescription,
   resolveNotifyChannel,
   type CompletionRule,
@@ -247,6 +248,7 @@ export async function executeCompletion(opts: {
       issueId,
       from: rule.from as StateLabel,
       to: effectiveTo as StateLabel,
+      workflow,
       correlationId,
       workspaceDir,
       role,
@@ -413,6 +415,7 @@ async function transitionLabelWithVerification(opts: {
   issueId: number;
   from: StateLabel;
   to: StateLabel;
+  workflow: WorkflowConfig;
   correlationId: string;
   workspaceDir: string;
   role: string;
@@ -422,9 +425,15 @@ async function transitionLabelWithVerification(opts: {
 }> {
   const maxAttempts = 3;
   let lastError: unknown = null;
+  const stateLabels = getStateLabels(opts.workflow);
+  const staleStateLabels = (labels: string[]) =>
+    labels.filter(
+      (label) => stateLabels.includes(label as StateLabel) && label !== opts.to,
+    );
 
   const before = await opts.provider.getIssue(opts.issueId);
-  if (before.labels.includes(opts.to)) {
+  const staleBefore = staleStateLabels(before.labels);
+  if (before.labels.includes(opts.to) && staleBefore.length === 0) {
     await auditLog(opts.workspaceDir, "pipeline_transition_already_applied", {
       issue: opts.issueId,
       role: opts.role,
@@ -434,7 +443,7 @@ async function transitionLabelWithVerification(opts: {
     }).catch(() => {});
     return { attempts: 0, issue: before };
   }
-  if (!before.labels.includes(opts.from)) {
+  if (!before.labels.includes(opts.from) && !before.labels.includes(opts.to)) {
     throw new Error(
       `Completion transition precondition failed for issue #${opts.issueId}: expected current label "${opts.from}" or already-transitioned "${opts.to}", got [${before.labels.join(", ")}] [correlationId=${opts.correlationId}]`,
     );
@@ -447,6 +456,12 @@ async function transitionLabelWithVerification(opts: {
       if (!issue.labels.includes(opts.to)) {
         throw new Error(
           `Transition verification failed: issue #${opts.issueId} missing target label "${opts.to}" after transition`,
+        );
+      }
+      const staleAfter = staleStateLabels(issue.labels);
+      if (staleAfter.length > 0) {
+        throw new Error(
+          `Transition verification failed: issue #${opts.issueId} still has stale state labels [${staleAfter.join(", ")}] after transition`,
         );
       }
 


### PR DESCRIPTION
## Summary
Fixes lost/phantom completion cases where `work_finish` could appear successful without a confirmed provider state transition.

### What changed
- Added completion correlation IDs (`correlationId`) and transition attempt count in completion output.
- Added explicit precondition check before transition: issue must currently contain expected `from` label.
- Added bounded retry + backoff for provider transition calls (3 attempts).
- Added post-transition verification (`getIssue`) to confirm target label is actually present before treating completion as success.
- Transition failure now throws explicit error with correlation ID and does **not** emit success-style completion notification.
- Moved worker completion notification to occur only after successful/verified transition + state updates.
- Added audit trail entries for failed transition attempts and verified success with correlation IDs.

### Tests
- New regression test file: `lib/services/pipeline-completion-robustness.test.ts`
  - retries transient transition failure and succeeds
  - fails when provider call returns but target label is missing (phantom completion)
  - fails fast on stale/mismatched precondition state

Closes #18
