### PR TITLE
Fix #21: require dispatch acceptance before Doing transition

### DIFF
--- a/lib/dispatch/index.acceptance-gating.test.ts
+++ b/lib/dispatch/index.acceptance-gating.test.ts
@@ -1,0 +1,264 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { dispatchTask } from "./index.js";
+import { createTestHarness } from "../testing/index.js";
+
+function withAgentStatus(
+  base: any,
+  status: "accepted" | "deduped" | "rejected" | "unavailable" | "timeout",
+) {
+  return (async (argv: string[], opts: any) => {
+    if (
+      argv[0] === "openclaw" &&
+      argv[1] === "gateway" &&
+      argv[2] === "call" &&
+      argv[3] === "agent"
+    ) {
+      if (status === "timeout")
+        throw new Error("gateway timeout while waiting for final event");
+      return {
+        stdout: JSON.stringify({ status, runId: `run-${status}` }),
+        stderr: "",
+        code: 0,
+        signal: null,
+        killed: false,
+      };
+    }
+    return base(argv, opts);
+  }) as any;
+}
+
+describe("dispatchTask acceptance gating", () => {
+  it("keeps issue in To Do and slot inactive when dispatch is deduped", async () => {
+    const h = await createTestHarness();
+    try {
+      h.provider.seedIssue({
+        iid: 21,
+        title: "Gate dispatch",
+        labels: ["To Do"],
+      });
+
+      await assert.rejects(
+        () =>
+          dispatchTask({
+            workspaceDir: h.workspaceDir,
+            project: h.project,
+            issueId: 21,
+            issueTitle: "Gate dispatch",
+            issueDescription: "",
+            issueUrl: "https://example.com/issues/21",
+            role: "developer",
+            level: "medior",
+            fromLabel: "To Do",
+            toLabel: "Doing",
+            provider: h.provider,
+            runCommand: withAgentStatus(h.runCommand, "deduped"),
+          }),
+        /dispatch deduped/i,
+      );
+
+      const issue = await h.provider.getIssue(21);
+      assert.ok(issue.labels.includes("To Do"));
+      assert.ok(!issue.labels.includes("Doing"));
+    } finally {
+      await h.cleanup();
+    }
+  });
+
+  it("increments idempotency nonce across failed attempts", async () => {
+    const h = await createTestHarness();
+    const seenKeys: string[] = [];
+    const rc = (async (argv: string[], opts: any) => {
+      if (
+        argv[0] === "openclaw" &&
+        argv[1] === "gateway" &&
+        argv[2] === "call" &&
+        argv[3] === "agent"
+      ) {
+        const params = JSON.parse(argv[argv.indexOf("--params") + 1]!);
+        seenKeys.push(params.idempotencyKey);
+        return {
+          stdout: JSON.stringify({ status: "deduped" }),
+          stderr: "",
+          code: 0,
+          signal: null,
+          killed: false,
+        };
+      }
+      return h.runCommand(argv, opts);
+    }) as any;
+
+    try {
+      h.provider.seedIssue({
+        iid: 24,
+        title: "nonce retry",
+        labels: ["To Do"],
+      });
+      await assert.rejects(() =>
+        dispatchTask({
+          workspaceDir: h.workspaceDir,
+          project: h.project,
+          issueId: 24,
+          issueTitle: "nonce retry",
+          issueDescription: "",
+          issueUrl: "https://example.com/issues/24",
+          role: "developer",
+          level: "medior",
+          fromLabel: "To Do",
+          toLabel: "Doing",
+          provider: h.provider,
+          runCommand: rc,
+        }),
+      );
+      await assert.rejects(() =>
+        dispatchTask({
+          workspaceDir: h.workspaceDir,
+          project: h.project,
+          issueId: 24,
+          issueTitle: "nonce retry",
+          issueDescription: "",
+          issueUrl: "https://example.com/issues/24",
+          role: "developer",
+          level: "medior",
+          fromLabel: "To Do",
+          toLabel: "Doing",
+          provider: h.provider,
+          runCommand: rc,
+        }),
+      );
+
+      assert.strictEqual(seenKeys.length, 2);
+      assert.notStrictEqual(seenKeys[0], seenKeys[1]);
+    } finally {
+      await h.cleanup();
+    }
+  });
+
+  it("marks slot active when label transition fails after acceptance", async () => {
+    const h = await createTestHarness();
+    try {
+      h.provider.seedIssue({
+        iid: 25,
+        title: "transition fail",
+        labels: ["To Do"],
+      });
+      const originalTransition = h.provider.transitionLabel.bind(h.provider);
+      h.provider.transitionLabel = async (
+        issueId: number,
+        from: any,
+        to: any,
+      ) => {
+        if (issueId === 25 && from === "To Do" && to === "Doing") {
+          throw new Error("provider outage");
+        }
+        return originalTransition(issueId, from, to);
+      };
+
+      await assert.rejects(
+        () =>
+          dispatchTask({
+            workspaceDir: h.workspaceDir,
+            project: h.project,
+            issueId: 25,
+            issueTitle: "transition fail",
+            issueDescription: "",
+            issueUrl: "https://example.com/issues/25",
+            role: "developer",
+            level: "medior",
+            fromLabel: "To Do",
+            toLabel: "Doing",
+            provider: h.provider,
+            runCommand: withAgentStatus(h.runCommand, "accepted"),
+          }),
+        /dispatch accepted but failed to transition/i,
+      );
+
+      const slot = h.project.workers.developer?.levels.medior?.[0];
+      assert.ok(
+        slot?.active,
+        "slot should be marked active after accepted dispatch",
+      );
+      assert.strictEqual(slot?.issueId, "25");
+
+      const issue = await h.provider.getIssue(25);
+      assert.ok(issue.labels.includes("To Do"));
+      assert.ok(!issue.labels.includes("Doing"));
+    } finally {
+      await h.cleanup();
+    }
+  });
+
+  for (const status of ["rejected", "unavailable", "timeout"] as const) {
+    it(`keeps issue in To Do when dispatch is ${status}`, async () => {
+      const h = await createTestHarness();
+      try {
+        h.provider.seedIssue({
+          iid: 22,
+          title: `Status ${status}`,
+          labels: ["To Do"],
+        });
+
+        await assert.rejects(
+          () =>
+            dispatchTask({
+              workspaceDir: h.workspaceDir,
+              project: h.project,
+              issueId: 22,
+              issueTitle: `Status ${status}`,
+              issueDescription: "",
+              issueUrl: "https://example.com/issues/22",
+              role: "developer",
+              level: "medior",
+              fromLabel: "To Do",
+              toLabel: "Doing",
+              provider: h.provider,
+              runCommand: withAgentStatus(h.runCommand, status),
+            }),
+          new RegExp(`dispatch ${status}`, "i"),
+        );
+
+        const issue = await h.provider.getIssue(22);
+        assert.ok(
+          issue.labels.includes("To Do"),
+          `labels: ${issue.labels.join(",")}`,
+        );
+        assert.ok(!issue.labels.includes("Doing"));
+      } finally {
+        await h.cleanup();
+      }
+    });
+  }
+
+  it("transitions to Doing only after accepted response", async () => {
+    const h = await createTestHarness();
+    try {
+      h.provider.seedIssue({
+        iid: 23,
+        title: "Accepted path",
+        labels: ["To Do"],
+      });
+
+      const out = await dispatchTask({
+        workspaceDir: h.workspaceDir,
+        project: h.project,
+        issueId: 23,
+        issueTitle: "Accepted path",
+        issueDescription: "",
+        issueUrl: "https://example.com/issues/23",
+        role: "developer",
+        level: "medior",
+        fromLabel: "To Do",
+        toLabel: "Doing",
+        provider: h.provider,
+        runCommand: withAgentStatus(h.runCommand, "accepted"),
+      });
+
+      assert.ok(out.sessionKey);
+      const issue = await h.provider.getIssue(23);
+      assert.ok(issue.labels.includes("Doing"));
+      assert.ok(!issue.labels.includes("To Do"));
+    } finally {
+      await h.cleanup();
+    }
+  });
+});

--- a/lib/dispatch/index.ts
+++ b/lib/dispatch/index.ts
@@ -52,6 +52,7 @@ import {
   ensureSessionFireAndForget,
   sendToAgent,
   shouldClearSession,
+  type DispatchAcceptance,
 } from "./session.js";
 import { acknowledgeComments, EYES_EMOJI } from "./acknowledge.js";
 
@@ -232,8 +233,117 @@ export async function dispatchTask(
     role,
   );
 
-  // ── Commitment point — transition label (issue leaves queue) ────────
-  await provider.transitionLabel(issueId, fromLabel, toLabel);
+  await auditLog(workspaceDir, "dispatch_attempt", {
+    project: project.name,
+    issue: issueId,
+    issueTitle,
+    role,
+    level,
+    sessionAction,
+    sessionKey,
+    fromLabel,
+    toLabel,
+    dispatchAttempt,
+  });
+
+  // Step 1: Ensure session exists (fire-and-forget)
+  const sessionLabel = formatSessionLabel(project.name, role, level, botName);
+  ensureSessionFireAndForget(
+    sessionKey,
+    model,
+    workspaceDir,
+    rc,
+    timeouts.sessionPatchMs,
+    sessionLabel,
+  );
+
+  // Step 2 (phase A): Attempt dispatch and require explicit acceptance
+  const acceptance = await sendToAgent(sessionKey, taskMessage, {
+    agentId,
+    projectName: project.name,
+    issueId,
+    role,
+    level,
+    slotIndex,
+    dispatchAttempt,
+    orchestratorSessionKey: opts.sessionKey,
+    workspaceDir,
+    dispatchTimeoutMs: timeouts.dispatchMs,
+    extraSystemPrompt: roleInstructions.trim() || undefined,
+    model,
+    runCommand: rc,
+  });
+
+  if (!acceptance.accepted) {
+    // Persist nonce progression so retries use a fresh idempotency key.
+    setInMemoryDispatchAttempt(
+      project,
+      role,
+      level,
+      slotIndex,
+      dispatchAttempt,
+    );
+    await updateSlot(workspaceDir, project.slug, role, level, slotIndex, {
+      dispatchAttempt,
+    }).catch(() => {});
+    await auditDispatchFailure(workspaceDir, {
+      project: project.name,
+      issueId,
+      role,
+      level,
+      fromLabel,
+      toLabel,
+      sessionKey,
+      dispatchAttempt,
+      acceptance,
+    });
+    throw new Error(
+      `dispatch ${acceptance.status}: ${acceptance.reason || "worker did not accept task"}`,
+    );
+  }
+
+  // Step 3 (phase B): transition label now that acceptance is confirmed
+  try {
+    await provider.transitionLabel(issueId, fromLabel, toLabel);
+  } catch (err) {
+    // Worker already accepted task. Mark slot active anyway to prevent duplicate pickups.
+    setInMemoryActiveState(project, role, level, slotIndex, {
+      issueId,
+      sessionKey,
+      previousLabel: fromLabel,
+      name: botName,
+      dispatchAttempt,
+    });
+    try {
+      await recordWorkerState(workspaceDir, project.slug, role, slotIndex, {
+        issueId,
+        level,
+        sessionKey,
+        sessionAction,
+        fromLabel,
+        name: botName,
+        dispatchAttempt,
+      });
+    } catch (stateErr) {
+      await auditLog(workspaceDir, "dispatch_warning", {
+        step: "recordWorkerState_after_transition_failure",
+        issue: issueId,
+        role,
+        sessionKey,
+        error: (stateErr as Error).message ?? String(stateErr),
+      });
+    }
+    await auditLog(workspaceDir, "dispatch_warning", {
+      step: "transitionLabel_after_accept",
+      issue: issueId,
+      role,
+      sessionKey,
+      error: (err as Error).message ?? String(err),
+    });
+    throw new Error(
+      `dispatch accepted but failed to transition ${fromLabel} → ${toLabel}: ${(err as Error).message ?? String(err)}`,
+    );
+  }
 
   // Mark issue + PR as managed and all consumed comments as seen (fire-and-forget)
   provider.reactToIssue(issueId, EYES_EMOJI).catch(() => {});
@@ -264,7 +374,6 @@ export async function dispatchTask(
     await provider.ensureLabel(roleLabel, getRoleLabelColor(role));
     await provider.addLabel(issueId, roleLabel);
 
-    // Step 1c: Apply review routing label when role produces reviewable work (best-effort)
     if (producesReviewableWork(workflow, role)) {
       const reviewLabel = resolveReviewRouting(
         workflow.reviewPolicy ?? ReviewPolicy.HUMAN,
@@ -277,7 +386,6 @@ export async function dispatchTask(
       await provider.addLabel(issueId, reviewLabel);
     }
 
-    // Step 1e: Apply test routing label when workflow has a test phase (best-effort)
     if (hasTestPhase(workflow)) {
       const testLabel = resolveTestRouting(
         workflow.testPolicy ?? TestPolicy.SKIP,
@@ -290,7 +398,6 @@ export async function dispatchTask(
       await provider.addLabel(issueId, testLabel);
     }
 
-    // Step 1d: Apply owner label if issue is unclaimed (auto-claim on pickup)
     if (opts.instanceName && !detectOwner(issue.labels)) {
       const ownerLabel = getOwnerLabel(opts.instanceName);
       await provider.ensureLabel(ownerLabel, OWNER_LABEL_COLOR);
@@ -300,8 +407,7 @@ export async function dispatchTask(
     // Best-effort — label failure must not abort dispatch
   }
 
-  // Step 2: Send notification early (before session dispatch which can timeout)
-  // This ensures users see the notification even if gateway is slow
+  // Step 4: Worker-start notification only after acceptance+transition
   const notifyConfig = getNotificationConfig(pluginConfig);
   const notifyTarget = resolveNotifyChannel(
     issue?.labels ?? [],
@@ -335,35 +441,6 @@ export async function dispatchTask(
       role,
       error: (err as Error).message ?? String(err),
     }).catch(() => {});
-  });
-
-  // Step 3: Ensure session exists (fire-and-forget — don't wait for gateway)
-  // Session key is deterministic, so we can proceed immediately
-  const sessionLabel = formatSessionLabel(project.name, role, level, botName);
-  ensureSessionFireAndForget(
-    sessionKey,
-    model,
-    workspaceDir,
-    rc,
-    timeouts.sessionPatchMs,
-    sessionLabel,
-  );
-
-  // Step 4: Send task to agent (fire-and-forget)
-  sendToAgent(sessionKey, taskMessage, {
-    agentId,
-    projectName: project.name,
-    issueId,
-    role,
-    level,
-    slotIndex,
-    dispatchAttempt,
-    orchestratorSessionKey: opts.sessionKey,
-    workspaceDir,
-    dispatchTimeoutMs: timeouts.dispatchMs,
-    extraSystemPrompt: roleInstructions.trim() || undefined,
-    model,
-    runCommand: rc,
   });
 
   // Step 5: Update worker state
@@ -417,6 +494,68 @@ export async function dispatchTask(
   return { sessionAction, sessionKey, level, model, announcement };
 }
 
+function ensureInMemorySlot(
+  project: Project,
+  role: string,
+  level: string,
+  slotIndex: number,
+): {
+  active: boolean;
+  issueId: string | null;
+  sessionKey: string | null;
+  startTime: string | null;
+  previousLabel?: string | null;
+  name?: string;
+  dispatchAttempt?: number;
+} {
+  if (!project.workers[role]) project.workers[role] = { levels: {} };
+  if (!project.workers[role]!.levels[level])
+    project.workers[role]!.levels[level] = [];
+  const slots = project.workers[role]!.levels[level]!;
+  while (slots.length <= slotIndex)
+    slots.push({
+      active: false,
+      issueId: null,
+      sessionKey: null,
+      startTime: null,
+    });
+  return slots[slotIndex]!;
+}
+
+function setInMemoryDispatchAttempt(
+  project: Project,
+  role: string,
+  level: string,
+  slotIndex: number,
+  dispatchAttempt: number,
+): void {
+  const slot = ensureInMemorySlot(project, role, level, slotIndex);
+  slot.dispatchAttempt = dispatchAttempt;
+}
+
+function setInMemoryActiveState(
+  project: Project,
+  role: string,
+  level: string,
+  slotIndex: number,
+  opts: {
+    issueId: number;
+    sessionKey: string;
+    previousLabel?: string;
+    name?: string;
+    dispatchAttempt: number;
+  },
+): void {
+  const slot = ensureInMemorySlot(project, role, level, slotIndex);
+  slot.active = true;
+  slot.issueId = String(opts.issueId);
+  slot.sessionKey = opts.sessionKey;
+  slot.startTime = new Date().toISOString();
+  slot.previousLabel = opts.previousLabel;
+  slot.name = opts.name;
+  slot.dispatchAttempt = opts.dispatchAttempt;
+}
+
 async function recordWorkerState(
   workspaceDir: string,
   slug: string,
@@ -459,6 +598,16 @@ async function auditDispatch(
     toLabel: string;
   },
 ): Promise<void> {
+  await auditLog(workspaceDir, "dispatch_accepted", {
+    project: opts.project,
+    issue: opts.issueId,
+    issueTitle: opts.issueTitle,
+    role: opts.role,
+    level: opts.level,
+    sessionAction: opts.sessionAction,
+    sessionKey: opts.sessionKey,
+    labelTransition: `${opts.fromLabel} → ${opts.toLabel}`,
+  });
   await auditLog(workspaceDir, "dispatch", {
     project: opts.project,
     issue: opts.issueId,
@@ -474,5 +623,39 @@ async function auditDispatch(
     role: opts.role,
     level: opts.level,
     model: opts.model,
+  });
+}
+
+async function auditDispatchFailure(
+  workspaceDir: string,
+  opts: {
+    project: string;
+    issueId: number;
+    role: string;
+    level: string;
+    fromLabel: string;
+    toLabel: string;
+    sessionKey: string;
+    dispatchAttempt: number;
+    acceptance: DispatchAcceptance;
+  },
+): Promise<void> {
+  const event =
+    opts.acceptance.status === "rejected" ||
+    opts.acceptance.status === "deduped"
+      ? "dispatch_rejected"
+      : "dispatch_failed";
+  await auditLog(workspaceDir, event, {
+    project: opts.project,
+    issue: opts.issueId,
+    role: opts.role,
+    level: opts.level,
+    sessionKey: opts.sessionKey,
+    dispatchAttempt: opts.dispatchAttempt,
+    fromLabel: opts.fromLabel,
+    toLabel: opts.toLabel,
+    status: opts.acceptance.status,
+    runId: opts.acceptance.runId,
+    reason: opts.acceptance.reason,
   });
 }

--- a/lib/dispatch/session.idempotency.test.ts
+++ b/lib/dispatch/session.idempotency.test.ts
@@ -19,7 +19,7 @@ describe("sendToAgent idempotency key", () => {
         captured.push(params.idempotencyKey);
       }
       return {
-        stdout: "{}",
+        stdout: '{"status":"accepted","runId":"run-test"}',
         stderr: "",
         code: 0,
         signal: null,
@@ -28,7 +28,7 @@ describe("sendToAgent idempotency key", () => {
       };
     };
 
-    sendToAgent("agent:test:subagent:proj-dev-senior-ada", "msg", {
+    await sendToAgent("agent:test:subagent:proj-dev-senior-ada", "msg", {
       projectName: "proj",
       issueId: 17,
       role: "developer",
@@ -39,7 +39,7 @@ describe("sendToAgent idempotency key", () => {
       runCommand,
     });
 
-    sendToAgent("agent:test:subagent:proj-dev-senior-ada", "msg", {
+    await sendToAgent("agent:test:subagent:proj-dev-senior-ada", "msg", {
       projectName: "proj",
       issueId: 17,
       role: "developer",

--- a/lib/dispatch/session.ts
+++ b/lib/dispatch/session.ts
@@ -97,7 +97,22 @@ export function ensureSessionFireAndForget(
   });
 }
 
-export function sendToAgent(
+export type DispatchAcceptance = {
+  accepted: boolean;
+  status:
+    | "accepted"
+    | "started"
+    | "deduped"
+    | "rejected"
+    | "unavailable"
+    | "timeout"
+    | "failed";
+  runId?: string;
+  reason?: string;
+  raw?: unknown;
+};
+
+export async function sendToAgent(
   sessionKey: string,
   taskMessage: string,
   opts: {
@@ -115,7 +130,7 @@ export function sendToAgent(
     model?: string;
     runCommand: RunCommand;
   },
-): void {
+): Promise<DispatchAcceptance> {
   const rc = opts.runCommand;
   const gatewayParams = JSON.stringify({
     idempotencyKey: `devclaw-${opts.projectName}-${opts.issueId}-${opts.role}-${opts.level ?? "unknown"}-${opts.slotIndex ?? 0}-${opts.dispatchAttempt ?? 0}-${sessionKey}`,
@@ -132,26 +147,132 @@ export function sendToAgent(
       : {}),
     ...(opts.model ? { model: opts.model } : {}),
   });
-  // Fire-and-forget: long-running agent turn, don't await
-  rc(
-    [
-      "openclaw",
-      "gateway",
-      "call",
-      "agent",
-      "--params",
-      gatewayParams,
-      "--expect-final",
-      "--json",
-    ],
-    { timeoutMs: opts.dispatchTimeoutMs ?? 600_000 },
-  ).catch((err) => {
-    auditLog(opts.workspaceDir, "dispatch_warning", {
+
+  try {
+    const result = await rc(
+      [
+        "openclaw",
+        "gateway",
+        "call",
+        "agent",
+        "--params",
+        gatewayParams,
+        "--expect-final",
+        "--json",
+      ],
+      { timeoutMs: opts.dispatchTimeoutMs ?? 600_000 },
+    );
+    return parseDispatchAcceptance(result.stdout);
+  } catch (err) {
+    const msg = (err as Error).message ?? String(err);
+    const timeout = /timeout|timed out/i.test(msg);
+    const status: DispatchAcceptance["status"] = timeout ? "timeout" : "failed";
+    await auditLog(opts.workspaceDir, "dispatch_warning", {
       step: "sendToAgent",
       sessionKey,
       issue: opts.issueId,
       role: opts.role,
-      error: (err as Error).message ?? String(err),
-    }).catch(() => {});
-  });
+      error: msg,
+      status,
+    });
+    return { accepted: false, status, reason: msg };
+  }
+}
+
+function parseDispatchAcceptance(stdout: string): DispatchAcceptance {
+  let parsed: unknown;
+  try {
+    parsed = stdout ? JSON.parse(stdout) : undefined;
+  } catch {
+    return {
+      accepted: false,
+      status: "failed",
+      reason: "agent RPC returned invalid JSON",
+      raw: stdout,
+    };
+  }
+
+  const o = (parsed ?? {}) as Record<string, unknown>;
+  const status = normalizeStatus(
+    o.status ??
+      (o.result as Record<string, unknown> | undefined)?.status ??
+      (o.final as Record<string, unknown> | undefined)?.status,
+  );
+  const runId =
+    String(
+      o.runId ??
+        (o.result as Record<string, unknown> | undefined)?.runId ??
+        (o.final as Record<string, unknown> | undefined)?.runId ??
+        "",
+    ) || undefined;
+
+  if (status === "accepted" || status === "started") {
+    return { accepted: true, status, runId, raw: parsed };
+  }
+
+  if (
+    status === "deduped" ||
+    status === "rejected" ||
+    status === "unavailable" ||
+    status === "timeout"
+  ) {
+    return {
+      accepted: false,
+      status,
+      runId,
+      reason: String(
+        o.reason ??
+          (o.result as Record<string, unknown> | undefined)?.reason ??
+          "",
+      ),
+      raw: parsed,
+    };
+  }
+
+  const acceptedFlag =
+    o.accepted ?? (o.result as Record<string, unknown> | undefined)?.accepted;
+  if (
+    acceptedFlag === true ||
+    (runId &&
+      (o.ok === true ||
+        (o.result as Record<string, unknown> | undefined)?.ok === true))
+  ) {
+    return { accepted: true, status: "accepted", runId, raw: parsed };
+  }
+
+  if (acceptedFlag === false) {
+    return {
+      accepted: false,
+      status: "rejected",
+      runId,
+      reason: String(
+        o.reason ??
+          (o.result as Record<string, unknown> | undefined)?.reason ??
+          "",
+      ),
+      raw: parsed,
+    };
+  }
+
+  return {
+    accepted: false,
+    status: "failed",
+    runId,
+    reason: "agent RPC did not include acceptance status",
+    raw: parsed,
+  };
+}
+
+function normalizeStatus(
+  value: unknown,
+): DispatchAcceptance["status"] | undefined {
+  const s = String(value ?? "").toLowerCase();
+  if (!s) return undefined;
+  if (s === "accepted" || s === "started") return s;
+  if (s === "deduped" || s === "duplicate" || s === "idempotent_replay")
+    return "deduped";
+  if (s === "rejected" || s === "denied") return "rejected";
+  if (s === "unavailable" || s === "offline") return "unavailable";
+  if (s === "timeout" || s === "timed_out") return "timeout";
+  return "failed";
 }

--- a/lib/testing/harness.ts
+++ b/lib/testing/harness.ts
@@ -93,6 +93,7 @@ function createCommandInterceptor(): {
         : optsOrTimeout;
 
     const captured: CapturedCommand = { argv, opts };
+    let mockStdout = "{}";
 
     // Parse gateway agent calls to extract task message
     if (argv[0] === "openclaw" && argv[1] === "gateway" && argv[2] === "call") {
@@ -112,6 +113,10 @@ function createCommandInterceptor(): {
             if (params.idempotencyKey) {
               captured.idempotencyKey = params.idempotencyKey;
             }
+            mockStdout = JSON.stringify({
+              status: "accepted",
+              runId: `run-${Date.now()}`,
+            });
           }
           if (rpcMethod === "sessions.patch") {
             captured.sessionPatch = {
@@ -129,7 +134,7 @@ function createCommandInterceptor(): {
     commands.push(captured);
 
     return {
-      stdout: "{}",
+      stdout: mockStdout,
       stderr: "",
       code: 0,
       signal: null as null,


### PR DESCRIPTION
## Summary
- implement two-phase dispatch semantics: attempt/accept first, then transition issue to active state
- require explicit worker acceptance from gateway agent expect-final response before moving To Do -> Doing
- keep queue state unchanged on dedupe/rejected/unavailable/timeout and emit structured diagnostics
- move worker-start notification to post-acceptance path to avoid false-active starts
- add regression tests for acceptance gating and false-active prevention scenarios

## Details
- sendToAgent now returns a parsed DispatchAcceptance result instead of fire-and-forget
- dispatchTask now:
  1. records dispatch_attempt
  2. dispatch-attempts worker and awaits acceptance
  3. only on acceptance transitions label and activates worker state
  4. audits accepted/rejected/failed outcomes (dispatch_accepted, dispatch_rejected, dispatch_failed)
- test harness agent RPC mock now returns accepted status by default

## Testing
- npm run validate

Closes #21
