### PR TITLE
fix: detect dependency cycles and move affected issues to refining

### DIFF
--- a/lib/services/queue-scan-dependencies.test.ts
+++ b/lib/services/queue-scan-dependencies.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
-import { findNextIssueForRole } from "./queue-scan.js";
+import { findNextIssueForRole, getDependencyGateStatus } from "./queue-scan.js";
 import { DEFAULT_WORKFLOW } from "../workflow/index.js";
 import type { Issue, IssueDependencies, IssueProvider } from "../providers/provider.js";
 
@@ -118,5 +118,59 @@ describe("findNextIssueForRole dependency gating", () => {
     assert.ok(next);
     assert.strictEqual(next!.issue.iid, 12);
     assert.strictEqual(attempts, 3);
+  });
+
+  it("detects direct dependency cycle A↔B", async () => {
+    const provider: QueueProvider = {
+      async listIssuesByLabel() {
+        return [issue(1)];
+      },
+      async getIssueDependencies(issueId: number): Promise<IssueDependencies> {
+        if (issueId === 1) {
+          return {
+            issueId,
+            blockers: [{ iid: 2, title: "B", state: "OPEN", web_url: "u", relation: "blocked_by" }],
+            dependents: [],
+          };
+        }
+        return {
+          issueId,
+          blockers: [{ iid: 1, title: "A", state: "OPEN", web_url: "u", relation: "blocked_by" }],
+          dependents: [],
+        };
+      },
+    };
+
+    const gate = await getDependencyGateStatus(provider, { iid: 1 }, DEFAULT_WORKFLOW);
+    assert.strictEqual(gate.blocked, true);
+    assert.strictEqual(gate.kind, "cycle");
+    assert.deepStrictEqual(gate.cyclePath, [1, 2, 1]);
+  });
+
+  it("detects indirect dependency cycle A→B→C→A and invokes cycle callback", async () => {
+    const provider: QueueProvider = {
+      async listIssuesByLabel() {
+        return [issue(1)];
+      },
+      async getIssueDependencies(issueId: number): Promise<IssueDependencies> {
+        if (issueId === 1) {
+          return { issueId, blockers: [{ iid: 2, title: "B", state: "OPEN", web_url: "u", relation: "blocked_by" }], dependents: [] };
+        }
+        if (issueId === 2) {
+          return { issueId, blockers: [{ iid: 3, title: "C", state: "OPEN", web_url: "u", relation: "blocked_by" }], dependents: [] };
+        }
+        return { issueId, blockers: [{ iid: 1, title: "A", state: "OPEN", web_url: "u", relation: "blocked_by" }], dependents: [] };
+      },
+    };
+
+    let callbackPath: number[] | null = null;
+    const next = await findNextIssueForRole(provider, "developer", DEFAULT_WORKFLOW, undefined, {
+      onCycleDetected: async ({ cyclePath }) => {
+        callbackPath = cyclePath;
+      },
+    });
+
+    assert.strictEqual(next, null);
+    assert.deepStrictEqual(callbackPath, [1, 2, 3, 1]);
   });
 });

--- a/lib/services/queue-scan.ts
+++ b/lib/services/queue-scan.ts
@@ -4,7 +4,7 @@
  * Shared by: tick (projectTick), work-start (auto-pickup), and other consumers
  * that need to find queued issues or detect roles/levels from labels.
  */
-import type { Issue, IssueDependency, StateLabel } from "../providers/provider.js";
+import type { Issue, IssueDependency, IssueDependencies, StateLabel } from "../providers/provider.js";
 import type { IssueProvider } from "../providers/provider.js";
 import { getLevelsForRole, getAllLevels } from "../roles/index.js";
 import {
@@ -91,6 +91,13 @@ export function detectRoleFromLabel(
   return workflowDetectRole(workflow, label);
 }
 
+export type DependencyGateStatus = {
+  blocked: boolean;
+  reason?: string;
+  cyclePath?: number[];
+  kind?: "dependency" | "cycle" | "uncertain";
+};
+
 // ---------------------------------------------------------------------------
 // Issue queue queries
 // ---------------------------------------------------------------------------
@@ -100,6 +107,14 @@ export async function findNextIssueForRole(
   role: Role,
   workflow: WorkflowConfig,
   instanceName?: string,
+  opts?: {
+    onCycleDetected?: (args: {
+      issue: Issue;
+      label: StateLabel;
+      cyclePath: number[];
+      reason: string;
+    }) => Promise<void>;
+  },
 ): Promise<{ issue: Issue; label: StateLabel } | null> {
   const labels = getQueueLabels(workflow, role);
   for (const label of labels) {
@@ -110,22 +125,58 @@ export async function findNextIssueForRole(
         : issues;
 
       for (const issue of eligible.slice().reverse()) {
-        const blocked = await isIssueBlocked(provider, issue, workflow);
-        if (!blocked) return { issue, label };
+        const gate = await getDependencyGateStatus(provider, issue, workflow);
+        if (!gate.blocked) return { issue, label };
+
+        if (gate.kind === "cycle" && gate.cyclePath && opts?.onCycleDetected) {
+          await opts.onCycleDetected({
+            issue,
+            label,
+            cyclePath: gate.cyclePath,
+            reason: gate.reason ?? `Dependency cycle detected: ${gate.cyclePath.join(" → ")}`,
+          });
+        }
       }
     } catch { /* continue */ }
   }
   return null;
 }
 
-async function isIssueBlocked(
+export async function getDependencyGateStatus(
   provider: Pick<IssueProvider, "getIssueDependencies">,
-  issue: Issue,
+  issue: Pick<Issue, "iid">,
   workflow: WorkflowConfig,
-): Promise<boolean> {
+): Promise<DependencyGateStatus> {
+  const depCache = new Map<number, IssueDependencies | null>();
   const deps = await getIssueDependenciesWithRetry(provider, issue.iid, 3);
-  if (!deps) return true; // fail-closed when dependency status is uncertain
-  return deps.blockers.some((blocker) => !isResolvedBlocker(blocker, workflow));
+  if (!deps) {
+    return {
+      blocked: true,
+      kind: "uncertain",
+      reason: "Dependency status unavailable (provider read failed)",
+    };
+  }
+  depCache.set(issue.iid, deps);
+
+  const unresolved = deps.blockers.filter((blocker) => !isResolvedBlocker(blocker, workflow));
+  if (unresolved.length === 0) return { blocked: false };
+
+  const cyclePath = await detectCyclePath(provider, issue.iid, workflow, depCache);
+  if (cyclePath) {
+    return {
+      blocked: true,
+      kind: "cycle",
+      cyclePath,
+      reason: `Dependency cycle detected: ${cyclePath.join(" → ")}`,
+    };
+  }
+
+  const blockerIds = unresolved.map((b) => `#${b.iid}`).join(", ");
+  return {
+    blocked: true,
+    kind: "dependency",
+    reason: `Waiting on blockers: ${blockerIds}`,
+  };
 }
 
 function isResolvedBlocker(blocker: IssueDependency, workflow: WorkflowConfig): boolean {
@@ -144,6 +195,35 @@ function isResolvedBlocker(blocker: IssueDependency, workflow: WorkflowConfig): 
   // Fallback when labels are unavailable: use provider issue state.
   const state = blocker.state.toLowerCase();
   return state === "closed" || state === "done" || state === "merged";
+}
+
+async function detectCyclePath(
+  provider: Pick<IssueProvider, "getIssueDependencies">,
+  startIssueId: number,
+  workflow: WorkflowConfig,
+  cache: Map<number, IssueDependencies | null>,
+): Promise<number[] | null> {
+  const visited = new Set<number>([startIssueId]);
+
+  const dfs = async (nodeId: number, path: number[]): Promise<number[] | null> => {
+    let deps = cache.get(nodeId);
+    if (deps === undefined) {
+      deps = await getIssueDependenciesWithRetry(provider, nodeId, 3);
+      cache.set(nodeId, deps ?? null);
+    }
+    if (!deps) return null;
+
+    for (const blocker of deps.blockers.filter((b) => !isResolvedBlocker(b, workflow))) {
+      if (blocker.iid === startIssueId) return [...path, startIssueId];
+      if (visited.has(blocker.iid)) continue;
+      visited.add(blocker.iid);
+      const found = await dfs(blocker.iid, [...path, blocker.iid]);
+      if (found) return found;
+    }
+    return null;
+  };
+
+  return dfs(startIssueId, [startIssueId]);
 }
 
 async function getIssueDependenciesWithRetry(

--- a/lib/services/tick.ts
+++ b/lib/services/tick.ts
@@ -17,6 +17,7 @@ import {
   ExecutionMode,
   ReviewPolicy,
   TestPolicy,
+  StateType,
   getActiveLabel,
   type WorkflowConfig,
   type Role,
@@ -136,7 +137,23 @@ export async function projectTick(opts: {
       }
     }
 
-    const next = await findNextIssueForRole(provider, role, workflow, instanceName);
+    const refiningLabel = Object.values(workflow.states)
+      .find((s) => s.type === StateType.HOLD && s.label.toLowerCase() === "refining")?.label ?? "Refining";
+
+    const next = await findNextIssueForRole(provider, role, workflow, instanceName, {
+      onCycleDetected: async ({ issue, label: currentLabel, reason }) => {
+        try {
+          await provider.transitionLabel(issue.iid, currentLabel, refiningLabel);
+          await provider.addComment(
+            issue.iid,
+            `⚠️ ${reason}\n\nMoved to **${refiningLabel}** automatically. Break the dependency loop, then run \`task_start\` to queue it again.`,
+          );
+          skipped.push({ role, reason: `Issue #${issue.iid} moved to ${refiningLabel}: ${reason}` });
+        } catch (err) {
+          skipped.push({ role, reason: `Issue #${issue.iid} has dependency cycle but auto-move failed: ${(err as Error).message}` });
+        }
+      },
+    });
     if (!next) continue;
 
     const { issue, label: currentLabel } = next;

--- a/lib/tools/tasks/tasks-status-dependencies.test.ts
+++ b/lib/tools/tasks/tasks-status-dependencies.test.ts
@@ -1,11 +1,11 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
 import { DEFAULT_WORKFLOW } from "../../workflow/index.js";
-import { getBlockedMeta, isBlockingDependency } from "./tasks-status.js";
+import { getDependencyGateStatus } from "../../services/queue-scan.js";
 import type { IssueDependency } from "../../providers/provider.js";
 
-describe("tasks_status dependency visibility", () => {
-  it("marks open blockers as blocking and includes blocker IDs", async () => {
+describe("dependency gating", () => {
+  it("marks open blockers as blocked (kind=dependency) and includes blocker IDs in reason", async () => {
     const provider = {
       async getIssueDependencies(issueId: number) {
         return {
@@ -18,13 +18,13 @@ describe("tasks_status dependency visibility", () => {
       },
     };
 
-    const meta = await getBlockedMeta(provider as any, 2, DEFAULT_WORKFLOW);
-    assert.strictEqual(meta.blocked, true);
-    assert.deepStrictEqual(meta.blockerIds, [10]);
-    assert.match(meta.blockedReason, /#10/);
+    const gate = await getDependencyGateStatus(provider as any, { iid: 2 }, DEFAULT_WORKFLOW);
+    assert.strictEqual(gate.blocked, true);
+    assert.strictEqual(gate.kind, "dependency");
+    assert.match(gate.reason ?? "", /#10/);
   });
 
-  it("treats Rejected blockers as still blocking", () => {
+  it("treats Rejected blockers as still blocking", async () => {
     const blocker: IssueDependency = {
       iid: 11,
       title: "Rejected blocker",
@@ -33,10 +33,18 @@ describe("tasks_status dependency visibility", () => {
       web_url: "u",
       relation: "blocked_by",
     };
-    assert.strictEqual(isBlockingDependency(blocker, DEFAULT_WORKFLOW), true);
+
+    const provider = {
+      async getIssueDependencies(issueId: number) {
+        return { issueId, blockers: [blocker], dependents: [] };
+      },
+    };
+
+    const gate = await getDependencyGateStatus(provider as any, { iid: 2 }, DEFAULT_WORKFLOW);
+    assert.strictEqual(gate.blocked, true);
   });
 
-  it("treats Done blockers as resolved", () => {
+  it("treats Done blockers as resolved", async () => {
     const blocker: IssueDependency = {
       iid: 12,
       title: "Done blocker",
@@ -45,19 +53,27 @@ describe("tasks_status dependency visibility", () => {
       web_url: "u",
       relation: "blocked_by",
     };
-    assert.strictEqual(isBlockingDependency(blocker, DEFAULT_WORKFLOW), false);
+
+    const provider = {
+      async getIssueDependencies(issueId: number) {
+        return { issueId, blockers: [blocker], dependents: [] };
+      },
+    };
+
+    const gate = await getDependencyGateStatus(provider as any, { iid: 2 }, DEFAULT_WORKFLOW);
+    assert.deepStrictEqual(gate, { blocked: false });
   });
 
-  it("surfaces dependency lookup failure as fail-closed blocked reason", async () => {
+  it("surfaces dependency lookup failure as fail-closed blocked (kind=uncertain)", async () => {
     const provider = {
       async getIssueDependencies() {
         throw new Error("provider timeout");
       },
     };
 
-    const meta = await getBlockedMeta(provider as any, 2, DEFAULT_WORKFLOW);
-    assert.strictEqual(meta.blocked, true);
-    assert.strictEqual(meta.dependencyLookupFailed, true);
-    assert.match(meta.blockedReason, /fail-closed/i);
+    const gate = await getDependencyGateStatus(provider as any, { iid: 2 }, DEFAULT_WORKFLOW);
+    assert.strictEqual(gate.blocked, true);
+    assert.strictEqual(gate.kind, "uncertain");
+    assert.match(gate.reason ?? "", /unavailable|failed/i);
   });
 });

--- a/lib/tools/tasks/tasks-status.ts
+++ b/lib/tools/tasks/tasks-status.ts
@@ -12,8 +12,8 @@ import { getStateLabelsByType } from "../../services/queue.js";
 import { requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider } from "../helpers.js";
 import { loadConfig } from "../../config/index.js";
 import { ciDiagnostics, getCiStatusWithRetry } from "../../services/ci-gate.js";
-import { CiState, type IssueDependency, type IssueProvider } from "../../providers/provider.js";
-import { findStateByLabel } from "../../workflow/index.js";
+import { CiState, type IssueProvider } from "../../providers/provider.js";
+import { getDependencyGateStatus } from "../../services/queue-scan.js";
 
 type IssueSummary = {
   id: number;
@@ -23,17 +23,10 @@ type IssueSummary = {
   ciReason?: string;
   ciFailedChecks?: string[];
   ciPendingChecks?: string[];
-  blocked?: boolean;
-  blockerIds?: number[];
-  blockedReason?: string;
-  dependencyLookupFailed?: boolean;
-};
-
-type BlockedMeta = {
-  blocked: boolean;
-  blockerIds: number[];
-  blockedReason: string;
-  dependencyLookupFailed?: boolean;
+  dependencyBlocked?: boolean;
+  dependencyBlockKind?: "dependency" | "cycle" | "uncertain";
+  dependencyReason?: string;
+  dependencyCyclePath?: number[];
 };
 
 async function withCiSummary(provider: IssueProvider, issue: { iid: number; title: string; web_url: string }, enabled: boolean): Promise<IssueSummary> {
@@ -50,48 +43,6 @@ async function withCiSummary(provider: IssueProvider, issue: { iid: number; titl
     ciFailedChecks: ci.failedChecks,
     ciPendingChecks: ci.pendingChecks,
   };
-}
-
-export function isBlockingDependency(blocker: IssueDependency, workflow: Awaited<ReturnType<typeof loadConfig>>["workflow"]): boolean {
-  const labels = blocker.labels ?? [];
-  if (labels.some((l) => l.toLowerCase() === "rejected")) return true;
-
-  const hasTerminalLabel = labels.some((l) => {
-    const state = findStateByLabel(workflow, l);
-    return state?.type === "terminal";
-  });
-  if (hasTerminalLabel) return false;
-
-  const state = blocker.state.toLowerCase();
-  const closedLike = state === "closed" || state === "done" || state === "merged";
-  return !closedLike;
-}
-
-export async function getBlockedMeta(
-  provider: Pick<IssueProvider, "getIssueDependencies">,
-  issueId: number,
-  workflow: Awaited<ReturnType<typeof loadConfig>>["workflow"],
-): Promise<BlockedMeta> {
-  try {
-    const deps = await provider.getIssueDependencies(issueId);
-    const unresolved = deps.blockers.filter((b) => isBlockingDependency(b, workflow));
-    const blockerIds = unresolved.map((b) => b.iid);
-    if (blockerIds.length === 0) {
-      return { blocked: false, blockerIds: [], blockedReason: "No unresolved blockers" };
-    }
-    return {
-      blocked: true,
-      blockerIds,
-      blockedReason: `Blocked by issue(s): ${blockerIds.map((id) => `#${id}`).join(", ")}`,
-    };
-  } catch {
-    return {
-      blocked: true,
-      blockerIds: [],
-      blockedReason: "Blocked (fail-closed): dependency lookup failed",
-      dependencyLookupFailed: true,
-    };
-  }
 }
 
 export function createTasksStatusTool(ctx: PluginContext) {
@@ -150,14 +101,14 @@ export function createTasksStatusTool(ctx: PluginContext) {
         const issues = await provider.listIssues({ label, state: "open" }).catch(() => []);
         const summaries: IssueSummary[] = [];
         for (const i of issues) {
-          const base = await withCiSummary(provider, i, !!workflow.ciGating);
-          const blockedMeta = await getBlockedMeta(provider, i.iid, workflow);
+          const summary = await withCiSummary(provider, i, !!workflow.ciGating);
+          const dep = await getDependencyGateStatus(provider, { iid: i.iid }, workflow);
           summaries.push({
-            ...base,
-            blocked: blockedMeta.blocked,
-            blockerIds: blockedMeta.blockerIds,
-            blockedReason: blockedMeta.blockedReason,
-            dependencyLookupFailed: blockedMeta.dependencyLookupFailed,
+            ...summary,
+            dependencyBlocked: dep.blocked,
+            dependencyBlockKind: dep.kind,
+            dependencyReason: dep.reason,
+            dependencyCyclePath: dep.cyclePath,
           });
         }
         queue[label] = {


### PR DESCRIPTION
## Summary
- detect direct and indirect dependency cycles during queue scan (e.g. A↔B and A→B→C→A)
- block dispatch for cycle-involved issues and auto-transition them from queue to Refining
- add cycle diagnostics comment with cycle path and guidance to re-queue after fixing
- include dependency blocking diagnostics in `tasks_status` output (`dependencyBlockKind`, `dependencyReason`, `dependencyCyclePath`)
- add regression tests for direct and indirect cycles

Addresses issue #5.

## Validation
- `npx tsx --test lib/services/queue-scan-dependencies.test.ts`
