### PR TITLE
Block Done/close when PR is conflicting or unmerged

### DIFF
--- a/lib/services/heartbeat/review-skip.ts
+++ b/lib/services/heartbeat/review-skip.ts
@@ -21,6 +21,7 @@ import { detectStepRouting } from "../queue-scan.js";
 import type { RunCommand } from "../../context.js";
 import { log as auditLog } from "../../audit.js";
 import { ciDiagnostics, getCiStatusWithRetry } from "../ci-gate.js";
+import { guardTerminalCompletion } from "../terminal-guard.js";
 
 /**
  * Scan review queue states and auto-merge + transition issues with review:skip.
@@ -62,6 +63,47 @@ export async function reviewSkipPass(opts: {
       // Only process issues managed by DevClaw (marked with 👀 on issue body).
       const isManaged = await provider.issueHasReaction(issue.iid, "eyes");
       if (!isManaged) continue;
+
+      // Pre-terminal guard (covers edge-case workflows where review:skip could lead to Done/closeIssue).
+      const guard = await guardTerminalCompletion({
+        workflow,
+        provider,
+        issueId: issue.iid,
+        fromLabel: state.label,
+        toState: targetState,
+        actions,
+      });
+
+      if (!guard.allow) {
+        const pr = guard.prStatus;
+        const prUrl = pr?.url ?? null;
+        try {
+          await provider.addComment(issue.iid, `⚠️ DevClaw blocked terminal completion: ${guard.reason} (${prUrl ?? "no PR url"}).`);
+        } catch { /* best-effort */ }
+        await auditLog(workspaceDir, "terminal_completion_blocked", {
+          project: projectName,
+          issueId: issue.iid,
+          from: state.label,
+          intendedTo: targetState.label,
+          reason: guard.reason,
+          prUrl,
+          prState: pr?.state,
+          mergeable: pr?.mergeable,
+        });
+        if (guard.toLabel) {
+          await provider.transitionLabel(issue.iid, state.label, guard.toLabel);
+          await auditLog(workspaceDir, "terminal_guard_transition", {
+            project: projectName,
+            issueId: issue.iid,
+            from: state.label,
+            to: guard.toLabel,
+            reason: guard.reason,
+            prUrl,
+          });
+          transitions++;
+        }
+        continue;
+      }
 
       // Execute SKIP transition actions
       let aborted = false;

--- a/lib/services/heartbeat/review.guard.test.ts
+++ b/lib/services/heartbeat/review.guard.test.ts
@@ -13,6 +13,7 @@ describe("heartbeat/review — terminal completion guard (human review path)", (
     // Custom workflow: approval would normally close immediately (terminal path), and we intentionally
     // omit the explicit MERGE_CONFLICT transition to ensure the shared terminal guard is doing the work.
     const workflow = structuredClone(DEFAULT_WORKFLOW);
+    workflow.states.toReview.on ??= {};
     workflow.states.toReview.on[WorkflowEvent.APPROVED] = { target: "done", actions: [Action.CLOSE_ISSUE] };
     delete (workflow.states.toReview.on as any)[WorkflowEvent.MERGE_CONFLICT];
 
@@ -45,6 +46,7 @@ describe("heartbeat/review — terminal completion guard (human review path)", (
 
     // Custom workflow: approval would close immediately, but it has no mergePr action.
     const workflow = structuredClone(DEFAULT_WORKFLOW);
+    workflow.states.toReview.on ??= {};
     workflow.states.toReview.on[WorkflowEvent.APPROVED] = { target: "done", actions: [Action.CLOSE_ISSUE] };
 
     provider.seedIssue({ iid: 21, title: "Approved but not merged", labels: ["To Review", "review:human"] });

--- a/lib/services/heartbeat/review.guard.test.ts
+++ b/lib/services/heartbeat/review.guard.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { reviewPass } from "./review.js";
+import { TestProvider } from "../../testing/test-provider.js";
+import { DEFAULT_WORKFLOW, Action, WorkflowEvent } from "../../workflow/index.js";
+import { PrState } from "../../providers/provider.js";
+
+describe("heartbeat/review — terminal completion guard (human review path)", () => {
+  it("blocks terminal completion and routes to To Improve when PR is conflicting (mergeable=false)", async () => {
+    const provider = new TestProvider();
+
+    // Custom workflow: approval would normally close immediately (terminal path), and we intentionally
+    // omit the explicit MERGE_CONFLICT transition to ensure the shared terminal guard is doing the work.
+    const workflow = structuredClone(DEFAULT_WORKFLOW);
+    workflow.states.toReview.on[WorkflowEvent.APPROVED] = { target: "done", actions: [Action.CLOSE_ISSUE] };
+    delete (workflow.states.toReview.on as any)[WorkflowEvent.MERGE_CONFLICT];
+
+    provider.seedIssue({ iid: 20, title: "Conflicting PR", labels: ["To Review", "review:human"] });
+    provider.setPrStatus(20, {
+      state: PrState.APPROVED,
+      url: "https://example/pr/20",
+      mergeable: false,
+    });
+
+    const n = await reviewPass({
+      workspaceDir: "/tmp",
+      projectName: "devclaw",
+      workflow,
+      provider,
+      repoPath: "/tmp/repo",
+      runCommand: (async () => ({ stdout: "", stderr: "", exitCode: 0, code: 0, signal: null, killed: false, termination: "exit" })) as any,
+    });
+
+    assert.equal(n, 1, "should transition away from terminal completion");
+
+    const issue = await provider.getIssue(20);
+    assert.ok(issue.labels.includes("To Improve"), `labels=${issue.labels.join(",")}`);
+    assert.equal(issue.state, "opened");
+    assert.equal(provider.callsTo("closeIssue").length, 0);
+  });
+
+  it("blocks terminal completion when auto-merge is off and PR is not merged yet (mergeable unknown)", async () => {
+    const provider = new TestProvider();
+
+    // Custom workflow: approval would close immediately, but it has no mergePr action.
+    const workflow = structuredClone(DEFAULT_WORKFLOW);
+    workflow.states.toReview.on[WorkflowEvent.APPROVED] = { target: "done", actions: [Action.CLOSE_ISSUE] };
+
+    provider.seedIssue({ iid: 21, title: "Approved but not merged", labels: ["To Review", "review:human"] });
+    provider.setPrStatus(21, {
+      state: PrState.APPROVED,
+      url: "https://example/pr/21",
+      // mergeable omitted/unknown — should not be treated as conflict, but auto-merge-off + unmerged must still block.
+    });
+
+    const n = await reviewPass({
+      workspaceDir: "/tmp",
+      projectName: "devclaw",
+      workflow,
+      provider,
+      repoPath: "/tmp/repo",
+      runCommand: (async () => ({ stdout: "", stderr: "", exitCode: 0, code: 0, signal: null, killed: false, termination: "exit" })) as any,
+    });
+
+    assert.equal(n, 0, "should not transition");
+
+    const issue = await provider.getIssue(21);
+    assert.ok(issue.labels.includes("To Review"), `labels=${issue.labels.join(",")}`);
+    assert.ok(!issue.labels.includes("Done"));
+    assert.equal(issue.state, "opened");
+
+    assert.equal(provider.callsTo("closeIssue").length, 0);
+    assert.equal(provider.callsTo("transitionLabel").length, 0);
+  });
+});

--- a/lib/services/heartbeat/review.ts
+++ b/lib/services/heartbeat/review.ts
@@ -18,6 +18,7 @@ import { detectStepRouting } from "../queue-scan.js";
 import type { RunCommand } from "../../context.js";
 import { log as auditLog } from "../../audit.js";
 import { ciDiagnostics, getCiStatusWithRetry } from "../ci-gate.js";
+import { guardTerminalCompletion } from "../terminal-guard.js";
 
 /**
  * Scan review-type states and transition issues whose PR check condition is met.
@@ -228,6 +229,59 @@ export async function reviewPass(opts: {
       const actions = typeof transition === "object" ? transition.actions : undefined;
       const targetState = workflow.states[targetKey];
       if (!targetState) continue;
+
+      // Pre-terminal guard: do not allow Done/closeIssue when PR is conflicting,
+      // or when auto-merge is off and PR is not actually merged yet.
+      const guard = await guardTerminalCompletion({
+        workflow,
+        provider,
+        issueId: issue.iid,
+        fromLabel: state.label,
+        toState: targetState,
+        actions,
+      });
+
+      if (!guard.allow) {
+        const pr = guard.prStatus;
+        const prUrl = pr?.url ?? status.url ?? null;
+        try {
+          if (guard.reason === "merge_conflict") {
+            await provider.addComment(issue.iid, `⚠️ DevClaw blocked terminal completion: PR has merge conflicts (${prUrl ?? "no PR url"}).`);
+          } else if (guard.reason === "pr_not_merged_auto_merge_off") {
+            await provider.addComment(issue.iid, `⏸️ DevClaw blocked terminal completion: auto-merge is off and PR is not merged yet (${prUrl ?? "no PR url"}). Merge the PR, then the heartbeat will close this issue.`);
+          } else if (guard.reason === "pr_closed_unmerged") {
+            await provider.addComment(issue.iid, `⚠️ DevClaw blocked terminal completion: PR was closed without merging (${prUrl ?? "no PR url"}).`);
+          } else {
+            await provider.addComment(issue.iid, "⚠️ DevClaw blocked terminal completion: unable to verify PR mergeability/merge state.");
+          }
+        } catch { /* best-effort */ }
+
+        await auditLog(workspaceDir, "terminal_completion_blocked", {
+          project: projectName,
+          issueId: issue.iid,
+          from: state.label,
+          intendedTo: targetState.label,
+          reason: guard.reason,
+          prUrl,
+          prState: pr?.state ?? status.state,
+          mergeable: pr?.mergeable ?? status.mergeable,
+        });
+
+        if (guard.toLabel) {
+          await provider.transitionLabel(issue.iid, state.label, guard.toLabel);
+          await auditLog(workspaceDir, "terminal_guard_transition", {
+            project: projectName,
+            issueId: issue.iid,
+            from: state.label,
+            to: guard.toLabel,
+            reason: guard.reason,
+            prUrl,
+          });
+          transitions++;
+        }
+
+        continue;
+      }
 
       // Execute transition actions — mergePr is critical (aborts on failure)
       let aborted = false;

--- a/lib/services/heartbeat/test-skip.guard.test.ts
+++ b/lib/services/heartbeat/test-skip.guard.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { createTestHarness } from "../../testing/harness.js";
+import { testSkipPass } from "./test-skip.js";
+
+describe("heartbeat/test-skip — terminal completion guard", () => {
+  it("routes to To Improve and does not close when PR is conflicting (mergeable=false)", async () => {
+    const h = await createTestHarness();
+    try {
+      h.provider.seedIssue({ iid: 1, title: "Conflict", labels: ["To Test", "test:skip"] });
+      h.provider.setPrStatus(1, { state: "open", url: "https://example.com/pr/1", mergeable: false });
+
+      const n = await testSkipPass({
+        workspaceDir: h.workspaceDir,
+        projectName: h.project.name,
+        workflow: h.workflow,
+        provider: h.provider,
+      });
+
+      assert.equal(n, 1, "should transition once (to feedback state)");
+
+      const issue = await h.provider.getIssue(1);
+      assert.ok(issue.labels.includes("To Improve"), `labels=${issue.labels.join(",")}`);
+      assert.equal(issue.state, "opened", "should not close issue on conflict");
+
+      assert.equal(h.provider.callsTo("closeIssue").length, 0);
+    } finally {
+      await h.cleanup();
+    }
+  });
+
+  it("does not transition to Done (and does not close) when auto-merge is off and PR is not merged", async () => {
+    const h = await createTestHarness();
+    try {
+      h.provider.seedIssue({ iid: 2, title: "Unmerged", labels: ["To Test", "test:skip"] });
+      h.provider.setPrStatus(2, { state: "approved", url: "https://example.com/pr/2", mergeable: true });
+
+      const n = await testSkipPass({
+        workspaceDir: h.workspaceDir,
+        projectName: h.project.name,
+        workflow: h.workflow,
+        provider: h.provider,
+      });
+
+      assert.equal(n, 0, "should not transition");
+
+      const issue = await h.provider.getIssue(2);
+      assert.ok(issue.labels.includes("To Test"), `labels=${issue.labels.join(",")}`);
+      assert.ok(!issue.labels.includes("Done"));
+      assert.equal(issue.state, "opened");
+
+      assert.equal(h.provider.callsTo("closeIssue").length, 0);
+      assert.equal(h.provider.callsTo("transitionLabel").length, 0);
+    } finally {
+      await h.cleanup();
+    }
+  });
+
+  it("allows transition to Done + close after PR is merged", async () => {
+    const h = await createTestHarness();
+    try {
+      h.provider.seedIssue({ iid: 3, title: "Merged", labels: ["To Test", "test:skip"] });
+      h.provider.setPrStatus(3, { state: "merged", url: "https://example.com/pr/3", mergeable: true });
+
+      const n = await testSkipPass({
+        workspaceDir: h.workspaceDir,
+        projectName: h.project.name,
+        workflow: h.workflow,
+        provider: h.provider,
+      });
+
+      assert.equal(n, 1);
+
+      const issue = await h.provider.getIssue(3);
+      assert.ok(issue.labels.includes("Done"), `labels=${issue.labels.join(",")}`);
+      assert.equal(issue.state, "closed", "should close issue when completing");
+
+      assert.equal(h.provider.callsTo("closeIssue").length, 1);
+    } finally {
+      await h.cleanup();
+    }
+  });
+});

--- a/lib/services/heartbeat/test-skip.guard.test.ts
+++ b/lib/services/heartbeat/test-skip.guard.test.ts
@@ -81,4 +81,30 @@ describe("heartbeat/test-skip — terminal completion guard", () => {
       await h.cleanup();
     }
   });
+
+  it("treats mergeable=unknown as non-conflicting (still allows close when PR is merged)", async () => {
+    const h = await createTestHarness();
+    try {
+      h.provider.seedIssue({ iid: 4, title: "Merged (unknown mergeable)", labels: ["To Test", "test:skip"] });
+      // mergeable omitted/unknown — should not be treated as conflicting.
+      h.provider.setPrStatus(4, { state: "merged", url: "https://example.com/pr/4" });
+
+      const n = await testSkipPass({
+        workspaceDir: h.workspaceDir,
+        projectName: h.project.name,
+        workflow: h.workflow,
+        provider: h.provider,
+      });
+
+      assert.equal(n, 1);
+
+      const issue = await h.provider.getIssue(4);
+      assert.ok(issue.labels.includes("Done"), `labels=${issue.labels.join(",")}`);
+      assert.equal(issue.state, "closed");
+
+      assert.equal(h.provider.callsTo("closeIssue").length, 1);
+    } finally {
+      await h.cleanup();
+    }
+  });
 });

--- a/lib/services/heartbeat/test-skip.ts
+++ b/lib/services/heartbeat/test-skip.ts
@@ -17,6 +17,7 @@ import {
 } from "../../workflow/index.js";
 import { detectStepRouting } from "../queue-scan.js";
 import { log as auditLog } from "../../audit.js";
+import { guardTerminalCompletion } from "../terminal-guard.js";
 
 /**
  * Scan test queue states and auto-transition issues with test:skip.
@@ -48,6 +49,60 @@ export async function testSkipPass(opts: {
     for (const issue of issues) {
       const routing = detectStepRouting(issue.labels, "test");
       if (routing !== "skip") continue;
+
+      // Pre-terminal guard: never allow Done/closeIssue if PR is conflicting or not merged (auto-merge off).
+      const guard = await guardTerminalCompletion({
+        workflow,
+        provider,
+        issueId: issue.iid,
+        fromLabel: state.label,
+        toState: targetState,
+        actions,
+      });
+
+      if (!guard.allow) {
+        const pr = guard.prStatus;
+        const prUrl = pr?.url ?? null;
+
+        // Best-effort: leave a clear breadcrumb.
+        try {
+          if (guard.reason === "merge_conflict") {
+            await provider.addComment(issue.iid, `⚠️ DevClaw blocked terminal completion: PR has merge conflicts (${prUrl ?? "no PR url"}).`);
+          } else if (guard.reason === "pr_not_merged_auto_merge_off") {
+            await provider.addComment(issue.iid, `⏸️ DevClaw blocked terminal completion: auto-merge is off and PR is not merged yet (${prUrl ?? "no PR url"}). Merge the PR, then the heartbeat will close this issue.`);
+          } else if (guard.reason === "pr_closed_unmerged") {
+            await provider.addComment(issue.iid, `⚠️ DevClaw blocked terminal completion: PR was closed without merging (${prUrl ?? "no PR url"}).`);
+          } else {
+            await provider.addComment(issue.iid, "⚠️ DevClaw blocked terminal completion: unable to verify PR mergeability/merge state.");
+          }
+        } catch { /* best-effort */ }
+
+        await auditLog(workspaceDir, "terminal_completion_blocked", {
+          project: projectName,
+          issueId: issue.iid,
+          from: state.label,
+          intendedTo: targetState.label,
+          reason: guard.reason,
+          prUrl,
+          prState: pr?.state,
+          mergeable: pr?.mergeable,
+        });
+
+        if (guard.toLabel) {
+          await provider.transitionLabel(issue.iid, state.label, guard.toLabel);
+          await auditLog(workspaceDir, "terminal_guard_transition", {
+            project: projectName,
+            issueId: issue.iid,
+            from: state.label,
+            to: guard.toLabel,
+            reason: guard.reason,
+            prUrl,
+          });
+          transitions++;
+        }
+
+        continue;
+      }
 
       // Execute SKIP transition actions
       if (actions) {

--- a/lib/services/pipeline-terminal-guard.test.ts
+++ b/lib/services/pipeline-terminal-guard.test.ts
@@ -1,0 +1,94 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { executeCompletion } from "./pipeline.js";
+import { createTestHarness } from "../testing/index.js";
+
+// Regression: pipeline completion must never execute terminal side effects
+// (especially closeIssue) when the shared terminal guard blocks.
+
+describe("executeCompletion terminal guard (pipeline)", () => {
+  it("does not close issue when PR is conflicting (mergeable=false)", async () => {
+    const h = await createTestHarness({
+      workers: {
+        tester: { active: true, issueId: "34", level: "senior" },
+      },
+    });
+
+    h.provider.seedIssue({
+      iid: 34,
+      title: "Conflicting PR should block terminal completion",
+      labels: ["Testing"],
+    });
+
+    h.provider.setPrStatus(34, {
+      state: "open",
+      url: "https://example.com/pr/34",
+      mergeable: false,
+    });
+
+    const out = await executeCompletion({
+      workspaceDir: h.workspaceDir,
+      projectSlug: h.project.slug,
+      channels: h.project.channels,
+      role: "tester",
+      result: "pass",
+      issueId: 34,
+      summary: "pass",
+      provider: h.provider,
+      repoPath: "/tmp/test-repo",
+      projectName: "test-project",
+      runCommand: h.runCommand,
+    });
+
+    assert.strictEqual(out.labelTransition, "Testing → To Improve");
+    assert.strictEqual(h.provider.callsTo("closeIssue").length, 0);
+
+    const issue = await h.provider.getIssue(34);
+    assert.strictEqual(issue.state, "opened");
+    assert.ok(issue.labels.includes("To Improve"), `labels=${issue.labels.join(",")}`);
+  });
+
+  it("does not close issue when auto-merge is off and PR is not merged", async () => {
+    const h = await createTestHarness({
+      workers: {
+        tester: { active: true, issueId: "35", level: "senior" },
+      },
+    });
+
+    h.provider.seedIssue({
+      iid: 35,
+      title: "Unmerged PR should block terminal completion when auto-merge is off",
+      labels: ["Testing"],
+    });
+
+    // mergeable unknown/true should not matter; without mergePr in the action list,
+    // terminal completion must wait for provider to report PR merged.
+    h.provider.setPrStatus(35, {
+      state: "open",
+      url: "https://example.com/pr/35",
+      mergeable: true,
+    });
+
+    const out = await executeCompletion({
+      workspaceDir: h.workspaceDir,
+      projectSlug: h.project.slug,
+      channels: h.project.channels,
+      role: "tester",
+      result: "pass",
+      issueId: 35,
+      summary: "pass",
+      provider: h.provider,
+      repoPath: "/tmp/test-repo",
+      projectName: "test-project",
+      runCommand: h.runCommand,
+    });
+
+    // Guard blocks without suggesting a state change; pipeline stays put.
+    assert.strictEqual(out.labelTransition, "Testing → Testing");
+    assert.strictEqual(h.provider.callsTo("closeIssue").length, 0);
+
+    const issue = await h.provider.getIssue(35);
+    assert.strictEqual(issue.state, "opened");
+    assert.ok(issue.labels.includes("Testing"), `labels=${issue.labels.join(",")}`);
+  });
+});

--- a/lib/services/pipeline.ts
+++ b/lib/services/pipeline.ts
@@ -110,6 +110,69 @@ export async function executeCompletion(opts: {
   let terminalGuardOverrideToLabel: string | null = null;
   let terminalGuardReason: string | null = null;
 
+  // IMPORTANT: pre-terminal guard must run before any terminal side effects.
+  // Pipeline actions can include side effects (merge, close) — so we compute the
+  // guard upfront and then skip any terminal actions if the guard blocks.
+  const intendedTargetState = findStateByLabel(workflow, rule.to);
+  const terminalGuard = intendedTargetState
+    ? await guardTerminalCompletion({
+        workflow,
+        provider,
+        issueId,
+        fromLabel: rule.from,
+        toState: intendedTargetState,
+        actions: rule.actions,
+      })
+    : null;
+
+  const terminalBlocked = terminalGuard?.allow === false;
+  if (terminalGuard && terminalGuard.allow === false) {
+    const pr = terminalGuard.prStatus;
+    const guardPrUrl = pr?.url ?? null;
+    terminalGuardReason = terminalGuard.reason;
+    terminalGuardOverrideToLabel = terminalGuard.toLabel ?? rule.from;
+
+    // Best-effort: leave breadcrumbs for humans.
+    try {
+      if (terminalGuard.reason === "merge_conflict") {
+        await provider.addComment(
+          issueId,
+          `⚠️ DevClaw blocked terminal completion: PR has merge conflicts (${guardPrUrl ?? "no PR url"}).`,
+        );
+      } else if (terminalGuard.reason === "pr_not_merged_auto_merge_off") {
+        await provider.addComment(
+          issueId,
+          `⏸️ DevClaw blocked terminal completion: auto-merge is off and PR is not merged yet (${guardPrUrl ?? "no PR url"}). Merge the PR, then DevClaw will close this issue.`,
+        );
+      } else if (terminalGuard.reason === "pr_closed_unmerged") {
+        await provider.addComment(
+          issueId,
+          `⚠️ DevClaw blocked terminal completion: PR was closed without merging (${guardPrUrl ?? "no PR url"}).`,
+        );
+      } else {
+        await provider.addComment(
+          issueId,
+          "⚠️ DevClaw blocked terminal completion: unable to verify PR mergeability/merge state.",
+        );
+      }
+    } catch {
+      /* best-effort */
+    }
+
+    await auditLog(workspaceDir, "terminal_completion_blocked", {
+      project: projectName,
+      issueId,
+      from: rule.from,
+      intendedTo: rule.to,
+      reason: terminalGuard.reason,
+      prUrl: guardPrUrl,
+      prState: pr?.state,
+      mergeable: pr?.mergeable,
+      correlationId,
+      path: "pipeline",
+    }).catch(() => {});
+  }
+
   for (const action of rule.actions) {
     switch (action) {
       case Action.GIT_PULL:
@@ -150,6 +213,8 @@ export async function executeCompletion(opts: {
         }
         break;
       case Action.MERGE_PR:
+        // If the pre-terminal guard blocks, do not attempt terminal side effects.
+        if (terminalBlocked) break;
         try {
           if (!prTitle) {
             try {
@@ -229,55 +294,9 @@ export async function executeCompletion(opts: {
   let nextState = getNextStateDescription(workflow, role, result);
   const notifyConfig = getNotificationConfig(pluginConfig);
 
-  // Pre-terminal guard (covers pipeline-driven transitions too, not only heartbeat):
-  // never allow terminal completion if PR is conflicting, and when auto-merge is off
-  // do not close until provider reports PR merged.
-  const intendedTargetState = findStateByLabel(workflow, rule.to);
-  if (intendedTargetState) {
-    const guard = await guardTerminalCompletion({
-      workflow,
-      provider,
-      issueId,
-      fromLabel: rule.from,
-      toState: intendedTargetState,
-      actions: rule.actions,
-    });
 
-    if (!guard.allow) {
-      const pr = guard.prStatus;
-      const prUrl = pr?.url ?? null;
-      terminalGuardReason = guard.reason;
-      terminalGuardOverrideToLabel = guard.toLabel ?? rule.from;
-
-      try {
-        if (guard.reason === "merge_conflict") {
-          await provider.addComment(issueId, `⚠️ DevClaw blocked terminal completion: PR has merge conflicts (${prUrl ?? "no PR url"}).`);
-        } else if (guard.reason === "pr_not_merged_auto_merge_off") {
-          await provider.addComment(issueId, `⏸️ DevClaw blocked terminal completion: auto-merge is off and PR is not merged yet (${prUrl ?? "no PR url"}). Merge the PR, then DevClaw will close this issue.`);
-        } else if (guard.reason === "pr_closed_unmerged") {
-          await provider.addComment(issueId, `⚠️ DevClaw blocked terminal completion: PR was closed without merging (${prUrl ?? "no PR url"}).`);
-        } else {
-          await provider.addComment(issueId, "⚠️ DevClaw blocked terminal completion: unable to verify PR mergeability/merge state.");
-        }
-      } catch {
-        /* best-effort */
-      }
-
-      await auditLog(workspaceDir, "terminal_completion_blocked", {
-        project: projectName,
-        issueId,
-        from: rule.from,
-        intendedTo: rule.to,
-        reason: guard.reason,
-        prUrl,
-        prState: pr?.state,
-        mergeable: pr?.mergeable,
-        correlationId,
-        path: "pipeline",
-      }).catch(() => {});
-
-      nextState = `blocked: ${guard.reason}`;
-    }
+  if (terminalBlocked && terminalGuardReason) {
+    nextState = `blocked: ${terminalGuardReason}`;
   }
 
   let workerName: string | undefined;

--- a/lib/services/pipeline.ts
+++ b/lib/services/pipeline.ts
@@ -331,7 +331,9 @@ export async function executeCompletion(opts: {
     updatedIssue = transitionResult.issue;
   }
 
-  const runPostActions = transitioned && effectiveTo === rule.to;
+  // Post-actions are allowed only when we actually transition to the rule's
+  // intended state (rule.to) AND the terminal guard did not block.
+  const runPostActions = !terminalBlocked && transitioned && effectiveTo === rule.to;
   if (runPostActions) {
     for (const action of rule.actions) {
       switch (action) {

--- a/lib/services/pipeline.ts
+++ b/lib/services/pipeline.ts
@@ -21,6 +21,7 @@ import { log as auditLog } from "../audit.js";
 import { loadConfig } from "../config/index.js";
 import { detectStepRouting } from "./queue-scan.js";
 import { ciDiagnostics, getCiStatusWithRetry } from "./ci-gate.js";
+import { guardTerminalCompletion } from "./terminal-guard.js";
 import {
   Action,
   DEFAULT_WORKFLOW,
@@ -29,6 +30,7 @@ import {
   getStateLabels,
   getNextStateDescription,
   resolveNotifyChannel,
+  findStateByLabel,
   type CompletionRule,
   type WorkflowConfig,
 } from "../workflow/index.js";
@@ -105,6 +107,8 @@ export async function executeCompletion(opts: {
   let prTitle: string | undefined;
   let sourceBranch: string | undefined;
   let ciOverrideToLabel: string | null = null;
+  let terminalGuardOverrideToLabel: string | null = null;
+  let terminalGuardReason: string | null = null;
 
   for (const action of rule.actions) {
     switch (action) {
@@ -222,8 +226,59 @@ export async function executeCompletion(opts: {
 
   const issueBefore = await provider.getIssue(issueId);
   const notifyTarget = resolveNotifyChannel(issueBefore.labels, channels);
-  const nextState = getNextStateDescription(workflow, role, result);
+  let nextState = getNextStateDescription(workflow, role, result);
   const notifyConfig = getNotificationConfig(pluginConfig);
+
+  // Pre-terminal guard (covers pipeline-driven transitions too, not only heartbeat):
+  // never allow terminal completion if PR is conflicting, and when auto-merge is off
+  // do not close until provider reports PR merged.
+  const intendedTargetState = findStateByLabel(workflow, rule.to);
+  if (intendedTargetState) {
+    const guard = await guardTerminalCompletion({
+      workflow,
+      provider,
+      issueId,
+      fromLabel: rule.from,
+      toState: intendedTargetState,
+      actions: rule.actions,
+    });
+
+    if (!guard.allow) {
+      const pr = guard.prStatus;
+      const prUrl = pr?.url ?? null;
+      terminalGuardReason = guard.reason;
+      terminalGuardOverrideToLabel = guard.toLabel ?? rule.from;
+
+      try {
+        if (guard.reason === "merge_conflict") {
+          await provider.addComment(issueId, `⚠️ DevClaw blocked terminal completion: PR has merge conflicts (${prUrl ?? "no PR url"}).`);
+        } else if (guard.reason === "pr_not_merged_auto_merge_off") {
+          await provider.addComment(issueId, `⏸️ DevClaw blocked terminal completion: auto-merge is off and PR is not merged yet (${prUrl ?? "no PR url"}). Merge the PR, then DevClaw will close this issue.`);
+        } else if (guard.reason === "pr_closed_unmerged") {
+          await provider.addComment(issueId, `⚠️ DevClaw blocked terminal completion: PR was closed without merging (${prUrl ?? "no PR url"}).`);
+        } else {
+          await provider.addComment(issueId, "⚠️ DevClaw blocked terminal completion: unable to verify PR mergeability/merge state.");
+        }
+      } catch {
+        /* best-effort */
+      }
+
+      await auditLog(workspaceDir, "terminal_completion_blocked", {
+        project: projectName,
+        issueId,
+        from: rule.from,
+        intendedTo: rule.to,
+        reason: guard.reason,
+        prUrl,
+        prState: pr?.state,
+        mergeable: pr?.mergeable,
+        correlationId,
+        path: "pipeline",
+      }).catch(() => {});
+
+      nextState = `blocked: ${guard.reason}`;
+    }
+  }
 
   let workerName: string | undefined;
   try {
@@ -237,7 +292,7 @@ export async function executeCompletion(opts: {
     // best-effort
   }
 
-  const effectiveTo = ciOverrideToLabel ?? (rule.to as StateLabel);
+  const effectiveTo = (terminalGuardOverrideToLabel ?? ciOverrideToLabel ?? (rule.to as StateLabel)) as StateLabel;
   const transitioned = effectiveTo !== rule.from;
 
   let updatedIssue = issueBefore;
@@ -391,9 +446,11 @@ export async function executeCompletion(opts: {
     }
   }
   const effectiveNextState =
-    ciOverrideToLabel && ciOverrideToLabel !== rule.to
-      ? `CI gate applied (${rule.from} → ${ciOverrideToLabel})`
-      : nextState;
+    terminalGuardReason
+      ? `Terminal guard blocked completion (${terminalGuardReason})`
+      : (ciOverrideToLabel && ciOverrideToLabel !== rule.to
+        ? `CI gate applied (${rule.from} → ${ciOverrideToLabel})`
+        : nextState);
 
   announcement += `\n${effectiveNextState}.`;
 

--- a/lib/services/terminal-guard.ts
+++ b/lib/services/terminal-guard.ts
@@ -1,0 +1,115 @@
+/**
+ * terminal-guard.ts — Shared guard that prevents terminal completion when PR state makes it unsafe.
+ *
+ * Invariants:
+ * - Never allow terminal completion if PR is conflicting (mergeable === false).
+ * - When auto-merge is off for the completion path (no mergePr action), do not allow
+ *   terminal completion until provider reports PR is merged.
+ */
+
+import type { IssueProvider, PrStatus } from "../providers/provider.js";
+import { PrState } from "../providers/provider.js";
+import {
+  Action,
+  StateType,
+  type StateConfig,
+  type WorkflowConfig,
+} from "../workflow/index.js";
+import { findStateByLabel, getRevertLabel } from "../workflow/queries.js";
+
+export type TerminalGuardDecision =
+  | {
+      allow: true;
+      prStatus?: PrStatus;
+    }
+  | {
+      allow: false;
+      /** Suggested label to transition to (optional). If omitted, caller should stay put. */
+      toLabel?: string;
+      reason:
+        | "merge_conflict"
+        | "pr_not_merged_auto_merge_off"
+        | "pr_closed_unmerged"
+        | "pr_status_unavailable";
+      prStatus?: PrStatus;
+    };
+
+function getFeedbackLabel(workflow: WorkflowConfig): string {
+  // Prefer canonical label if present.
+  const toImprove = findStateByLabel(workflow, "To Improve");
+  if (toImprove) return toImprove.label;
+  // Fallback: developer revert queue.
+  try {
+    return getRevertLabel(workflow, "developer");
+  } catch {
+    return "To Improve";
+  }
+}
+
+function isTerminalPath(toState: StateConfig, actions: string[] | undefined): boolean {
+  if (toState.type === StateType.TERMINAL) return true;
+  if ((actions ?? []).includes(Action.CLOSE_ISSUE)) return true;
+  return false;
+}
+
+/**
+ * Decide whether a transition that would complete an issue is allowed.
+ */
+export async function guardTerminalCompletion(opts: {
+  workflow: WorkflowConfig;
+  provider: IssueProvider;
+  issueId: number;
+  fromLabel: string;
+  toState: StateConfig;
+  actions?: string[];
+}): Promise<TerminalGuardDecision> {
+  const { workflow, provider, issueId, toState, actions } = opts;
+
+  if (!isTerminalPath(toState, actions)) return { allow: true };
+
+  let prStatus: PrStatus;
+  try {
+    prStatus = await provider.getPrStatus(issueId);
+  } catch {
+    return {
+      allow: false,
+      reason: "pr_status_unavailable",
+    };
+  }
+
+  // No PR associated (or provider couldn't find one): allow completion.
+  if (!prStatus.url) return { allow: true, prStatus };
+
+  // Conflicts always block and route to feedback.
+  if (prStatus.mergeable === false) {
+    return {
+      allow: false,
+      toLabel: getFeedbackLabel(workflow),
+      reason: "merge_conflict",
+      prStatus,
+    };
+  }
+
+  // Closed but not merged: treat as unmerged and route to feedback.
+  if (prStatus.state === PrState.CLOSED) {
+    return {
+      allow: false,
+      toLabel: getFeedbackLabel(workflow),
+      reason: "pr_closed_unmerged",
+      prStatus,
+    };
+  }
+
+  // Auto-merge is considered "on" for this path only if mergePr is present.
+  const autoMergeEnabled = (actions ?? []).includes(Action.MERGE_PR);
+
+  if (!autoMergeEnabled && prStatus.state !== PrState.MERGED) {
+    return {
+      allow: false,
+      reason: "pr_not_merged_auto_merge_off",
+      prStatus,
+    };
+  }
+
+  return { allow: true, prStatus };
+}


### PR DESCRIPTION
Addresses issue #34.

- Adds a shared pre-terminal guard used by pipeline and heartbeat transitions.
- Blocks terminal completion when PR is merge-conflicting (mergeable=false) and routes to feedback (To Improve).
- When auto-merge is off for the completion path (no mergePr action), blocks terminal completion until provider reports PR merged.
- Adds regression tests for test:skip heartbeat paths (conflicting / unmerged / merged).

No closing keywords — DevClaw manages issue lifecycle.