### PR TITLE
fix: use blockedBy/blocking for GitHub dependencies (#45)

### DIFF
--- a/docs/dependency-gating.md
+++ b/docs/dependency-gating.md
@@ -15,6 +15,7 @@ Resolution rules:
 ## Provider failures (fail-closed)
 
 Dependency status is fetched from the issue provider (GitHub/GitLab).
+For GitHub, dependency edges are read from GraphQL `blockedBy` (blockers) and `blocking` (dependents).
 
 - **Transient failures** are retried.
 - If dependency lookup remains unavailable, DevClaw **fails closed** and treats the issue as blocked (it will not dispatch).

--- a/lib/providers/github.ts
+++ b/lib/providers/github.ts
@@ -238,10 +238,10 @@ export class GitHubProvider implements IssueProvider {
     const query = `{
       repository(owner: "${repo.owner}", name: "${repo.name}") {
         issue(number: ${issueId}) {
-          trackedInIssues(first: 100) {
+          blockedBy(first: 100) {
             nodes { number title state url labels(first: 20) { nodes { name } } }
           }
-          trackedIssues(first: 100) {
+          blocking(first: 100) {
             nodes { number title state url labels(first: 20) { nodes { name } } }
           }
         }
@@ -253,7 +253,7 @@ export class GitHubProvider implements IssueProvider {
     const issue = data?.data?.repository?.issue;
     if (!issue) throw new Error(`Issue #${issueId} not found in repository ${repo.owner}/${repo.name}`);
 
-    const blockers = (issue.trackedInIssues?.nodes ?? []).map((dep: any) => ({
+    const blockers = (issue.blockedBy?.nodes ?? []).map((dep: any) => ({
       iid: dep.number,
       title: dep.title ?? "",
       state: dep.state ?? "",
@@ -262,7 +262,7 @@ export class GitHubProvider implements IssueProvider {
       relation: "blocked_by" as const,
     }));
 
-    const dependents = (issue.trackedIssues?.nodes ?? []).map((dep: any) => ({
+    const dependents = (issue.blocking?.nodes ?? []).map((dep: any) => ({
       iid: dep.number,
       title: dep.title ?? "",
       state: dep.state ?? "",

--- a/lib/providers/provider-issue-dependencies.test.ts
+++ b/lib/providers/provider-issue-dependencies.test.ts
@@ -10,12 +10,12 @@ import { GitHubProvider } from "./github.js";
 import { GitLabProvider } from "./gitlab.js";
 
 function createGitHubRunCommand(opts: {
-  trackedInIssues?: Array<{ number: number; title: string; state: string; url: string }>;
-  trackedIssues?: Array<{ number: number; title: string; state: string; url: string }>;
+  blockedBy?: Array<{ number: number; title: string; state: string; url: string }>;
+  blocking?: Array<{ number: number; title: string; state: string; url: string }>;
   failGraphql?: boolean;
 }): RunCommand {
-  const trackedInIssues = opts.trackedInIssues ?? [];
-  const trackedIssues = opts.trackedIssues ?? [];
+  const blockedBy = opts.blockedBy ?? [];
+  const blocking = opts.blocking ?? [];
 
   return (async (command: string[]) => {
     const rendered = command.join(" ");
@@ -34,13 +34,16 @@ function createGitHubRunCommand(opts: {
 
     if (rendered.includes("gh api graphql")) {
       if (opts.failGraphql) throw new Error("GraphQL is down");
+      assert.match(rendered, /\bblockedBy\(first: 100\)/);
+      assert.match(rendered, /\bblocking\(first: 100\)/);
+      assert.doesNotMatch(rendered, /trackedInIssues|trackedIssues/);
       return {
         stdout: JSON.stringify({
           data: {
             repository: {
               issue: {
-                trackedInIssues: { nodes: trackedInIssues },
-                trackedIssues: { nodes: trackedIssues },
+                blockedBy: { nodes: blockedBy },
+                blocking: { nodes: blocking },
               },
             },
           },
@@ -76,7 +79,7 @@ describe("GitHubProvider.getIssueDependencies", () => {
     const provider = new GitHubProvider({
       repoPath: "/fake",
       runCommand: createGitHubRunCommand({
-        trackedInIssues: [
+        blockedBy: [
           { number: 1, title: "Parent", state: "OPEN", url: "https://github.com/o/r/issues/1" },
         ],
       }),
@@ -94,11 +97,11 @@ describe("GitHubProvider.getIssueDependencies", () => {
     const provider = new GitHubProvider({
       repoPath: "/fake",
       runCommand: createGitHubRunCommand({
-        trackedInIssues: [
+        blockedBy: [
           { number: 1, title: "Blocker A", state: "OPEN", url: "https://github.com/o/r/issues/1" },
           { number: 3, title: "Blocker B", state: "OPEN", url: "https://github.com/o/r/issues/3" },
         ],
-        trackedIssues: [
+        blocking: [
           { number: 7, title: "Dependent", state: "OPEN", url: "https://github.com/o/r/issues/7" },
         ],
       }),


### PR DESCRIPTION
Implements breaking change for GitHub dependency provider.

- blockers now sourced from GraphQL: issue.blockedBy.nodes
- dependents now sourced from GraphQL: issue.blocking.nodes
- removed all trackedInIssues/trackedIssues dependency reads (no compatibility fallback)
- updated provider dependency tests + docs

Fixes #45