### PR TITLE
Fix reviewer queue starvation (skip ineligible To Review items)

### DIFF
--- a/lib/services/queue-scan.ts
+++ b/lib/services/queue-scan.ts
@@ -4,7 +4,12 @@
  * Shared by: tick (projectTick), work-start (auto-pickup), and other consumers
  * that need to find queued issues or detect roles/levels from labels.
  */
-import type { Issue, IssueDependency, IssueDependencies, StateLabel } from "../providers/provider.js";
+import type {
+  Issue,
+  IssueDependency,
+  IssueDependencies,
+  StateLabel,
+} from "../providers/provider.js";
 import type { IssueProvider } from "../providers/provider.js";
 import { getLevelsForRole, getAllLevels } from "../roles/index.js";
 import {
@@ -74,7 +79,8 @@ export function detectRoleLevelFromLabels(
  * Returns the routing value for the given step, or null if no routing label exists.
  */
 export function detectStepRouting(
-  labels: string[], step: string,
+  labels: string[],
+  step: string,
 ): string | null {
   const prefix = `${step}:`;
   const match = labels.find((l) => l.toLowerCase().startsWith(prefix));
@@ -109,11 +115,37 @@ export async function findNextIssueForRole(
   workflow: WorkflowConfig,
   instanceName?: string,
   opts?: {
+    /**
+     * Called when a dependency cycle is detected and the caller wants to take
+     * action (e.g. move issue to Refining).
+     */
     onCycleDetected?: (args: {
       issue: Issue;
       label: StateLabel;
       cyclePath: number[];
       reason: string;
+    }) => Promise<void>;
+
+    /**
+     * Optional eligibility predicate for role-specific gates beyond dependency
+     * checks (e.g. review:human, test:skip).
+     *
+     * If it returns false, the scan continues to the next issue.
+     */
+    isEligible?: (args: {
+      issue: Issue;
+      label: StateLabel;
+    }) =>
+      | boolean
+      | Promise<boolean>
+      | { ok: boolean; reason?: string }
+      | Promise<{ ok: boolean; reason?: string }>;
+
+    /** Called when an issue is skipped due to isEligible returning false. */
+    onIneligible?: (args: {
+      issue: Issue;
+      label: StateLabel;
+      reason?: string;
     }) => Promise<void>;
   },
 ): Promise<{ issue: Issue; label: StateLabel } | null> {
@@ -127,18 +159,40 @@ export async function findNextIssueForRole(
 
       for (const issue of eligible.slice().reverse()) {
         const gate = await getDependencyGateStatus(provider, issue, workflow);
-        if (!gate.blocked) return { issue, label };
-
-        if (gate.kind === "cycle" && gate.cyclePath && opts?.onCycleDetected) {
-          await opts.onCycleDetected({
-            issue,
-            label,
-            cyclePath: gate.cyclePath,
-            reason: gate.reason ?? `Dependency cycle detected: ${gate.cyclePath.join(" → ")}`,
-          });
+        if (gate.blocked) {
+          if (
+            gate.kind === "cycle" &&
+            gate.cyclePath &&
+            opts?.onCycleDetected
+          ) {
+            await opts.onCycleDetected({
+              issue,
+              label,
+              cyclePath: gate.cyclePath,
+              reason:
+                gate.reason ??
+                `Dependency cycle detected: ${gate.cyclePath.join(" → ")}`,
+            });
+          }
+          continue;
         }
+
+        if (opts?.isEligible) {
+          const res = await opts.isEligible({ issue, label });
+          const ok = typeof res === "boolean" ? res : res.ok;
+          const reason = typeof res === "boolean" ? undefined : res.reason;
+          if (!ok) {
+            if (opts.onIneligible)
+              await opts.onIneligible({ issue, label, reason });
+            continue;
+          }
+        }
+
+        return { issue, label };
       }
-    } catch { /* continue */ }
+    } catch {
+      /* continue */
+    }
   }
   return null;
 }
@@ -159,10 +213,17 @@ export async function getDependencyGateStatus(
   }
   depCache.set(issue.iid, deps);
 
-  const unresolved = deps.blockers.filter((blocker) => !isResolvedBlocker(blocker, workflow));
+  const unresolved = deps.blockers.filter(
+    (blocker) => !isResolvedBlocker(blocker, workflow),
+  );
   if (unresolved.length === 0) return { blocked: false };
 
-  const cyclePath = await detectCyclePath(provider, issue.iid, workflow, depCache);
+  const cyclePath = await detectCyclePath(
+    provider,
+    issue.iid,
+    workflow,
+    depCache,
+  );
   if (cyclePath) {
     return {
       blocked: true,
@@ -180,7 +241,10 @@ export async function getDependencyGateStatus(
   };
 }
 
-function isResolvedBlocker(blocker: IssueDependency, workflow: WorkflowConfig): boolean {
+function isResolvedBlocker(
+  blocker: IssueDependency,
+  workflow: WorkflowConfig,
+): boolean {
   const labels = blocker.labels ?? [];
 
   // Explicit requirement: Rejected blockers remain blocking.
@@ -206,7 +270,10 @@ async function detectCyclePath(
 ): Promise<number[] | null> {
   const visited = new Set<number>([startIssueId]);
 
-  const dfs = async (nodeId: number, path: number[]): Promise<number[] | null> => {
+  const dfs = async (
+    nodeId: number,
+    path: number[],
+  ): Promise<number[] | null> => {
     let deps = cache.get(nodeId);
     if (deps === undefined) {
       deps = await getIssueDependenciesWithRetry(provider, nodeId, 3);
@@ -214,7 +281,9 @@ async function detectCyclePath(
     }
     if (!deps) return null;
 
-    for (const blocker of deps.blockers.filter((b) => !isResolvedBlocker(b, workflow))) {
+    for (const blocker of deps.blockers.filter(
+      (b) => !isResolvedBlocker(b, workflow),
+    )) {
       if (blocker.iid === startIssueId) return [...path, startIssueId];
       if (visited.has(blocker.iid)) continue;
       visited.add(blocker.iid);
@@ -262,8 +331,11 @@ export async function findNextIssue(
       const eligible = instanceName
         ? issues.filter((i) => isOwnedByOrUnclaimed(i.labels, instanceName))
         : issues;
-      if (eligible.length > 0) return { issue: eligible[eligible.length - 1]!, label };
-    } catch { /* continue */ }
+      if (eligible.length > 0)
+        return { issue: eligible[eligible.length - 1]!, label };
+    } catch {
+      /* continue */
+    }
   }
   return null;
 }

--- a/lib/services/tick.reviewer-starvation.test.ts
+++ b/lib/services/tick.reviewer-starvation.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { projectTick } from "./tick.js";
+import { DEFAULT_WORKFLOW, ReviewPolicy } from "../workflow/index.js";
+import { createTestHarness } from "../testing/index.js";
+
+/**
+ * Regression test for Issue #50: reviewer head-of-line blocking.
+ *
+ * If the first scanned `To Review` issue is ineligible for reviewer dispatch
+ * (e.g. `review:human`), the scan must continue until it finds an eligible
+ * one (e.g. `review:agent`).
+ */
+describe("projectTick — reviewer queue starvation", () => {
+  it("skips ineligible items and continues scanning To Review", async () => {
+    const h = await createTestHarness();
+
+    // Seed in an order that reproduces head-of-line blocking:
+    // the scan iterates the provider list in reverse order.
+    h.provider.seedIssue({
+      iid: 410,
+      title: "Eligible agent review",
+      labels: ["To Review", "review:agent"],
+    });
+    h.provider.seedIssue({
+      iid: 411,
+      title: "Human review A",
+      labels: ["To Review", "review:human"],
+    });
+    h.provider.seedIssue({
+      iid: 412,
+      title: "Human review B",
+      labels: ["To Review", "review:human"],
+    });
+
+    const result = await projectTick({
+      workspaceDir: h.workspaceDir,
+      projectSlug: h.project.slug,
+      agentId: "test-agent",
+      targetRole: "reviewer",
+      workflow: { ...DEFAULT_WORKFLOW, reviewPolicy: ReviewPolicy.AGENT },
+      provider: h.provider,
+      runCommand: h.runCommand,
+    });
+
+    assert.equal(result.pickups.length, 1);
+    assert.equal(result.pickups[0].role, "reviewer");
+    assert.equal(result.pickups[0].issueId, 410);
+
+    const reviewerSkips = result.skipped
+      .filter((s) => s.role === "reviewer")
+      .map((s) => s.reason)
+      .join("\n");
+
+    assert.ok(
+      reviewerSkips.includes("review:human"),
+      `expected skip reasons to include review:human, got:\n${reviewerSkips}`,
+    );
+  });
+});

--- a/lib/services/tick.ts
+++ b/lib/services/tick.ts
@@ -9,7 +9,14 @@ import type { RunCommand } from "../context.js";
 import type { Issue, IssueProvider } from "../providers/provider.js";
 import { createProvider } from "../providers/index.js";
 import { selectLevel } from "../roles/model-selector.js";
-import { getRoleWorker, getProject, readProjects, findFreeSlot, countActiveSlots, reconcileSlots } from "../projects/index.js";
+import {
+  getRoleWorker,
+  getProject,
+  readProjects,
+  findFreeSlot,
+  countActiveSlots,
+  reconcileSlots,
+} from "../projects/index.js";
 import { dispatchTask } from "../dispatch/index.js";
 import { getLevelsForRole } from "../roles/index.js";
 import { loadConfig } from "../config/index.js";
@@ -22,7 +29,11 @@ import {
   type WorkflowConfig,
   type Role,
 } from "../workflow/index.js";
-import { detectRoleLevelFromLabels, detectStepRouting, findNextIssueForRole } from "./queue-scan.js";
+import {
+  detectRoleLevelFromLabels,
+  detectStepRouting,
+  findNextIssueForRole,
+} from "./queue-scan.js";
 
 // ---------------------------------------------------------------------------
 // projectTick
@@ -73,17 +84,38 @@ export async function projectTick(opts: {
   runCommand?: RunCommand;
 }): Promise<TickResult> {
   const {
-    workspaceDir, projectSlug, agentId, sessionKey, pluginConfig, dryRun,
-    maxPickups, targetRole, runtime, instanceName, runCommand,
+    workspaceDir,
+    projectSlug,
+    agentId,
+    sessionKey,
+    pluginConfig,
+    dryRun,
+    maxPickups,
+    targetRole,
+    runtime,
+    instanceName,
+    runCommand,
   } = opts;
 
   const project = getProject(await readProjects(workspaceDir), projectSlug);
-  if (!project) return { pickups: [], skipped: [{ reason: `Project not found: ${projectSlug}` }] };
+  if (!project)
+    return {
+      pickups: [],
+      skipped: [{ reason: `Project not found: ${projectSlug}` }],
+    };
 
   const resolvedConfig = await loadConfig(workspaceDir, project.name);
   const workflow = opts.workflow ?? resolvedConfig.workflow;
 
-  const provider = opts.provider ?? (await createProvider({ repo: project.repo, provider: project.provider, runCommand: runCommand! })).provider;
+  const provider =
+    opts.provider ??
+    (
+      await createProvider({
+        repo: project.repo,
+        provider: project.provider,
+        runCommand: runCommand!,
+      })
+    ).provider;
   const roleExecution = workflow.roleExecution ?? ExecutionMode.PARALLEL;
   const enabledRoles = Object.entries(resolvedConfig.roles)
     .filter(([, r]) => r.enabled)
@@ -110,7 +142,12 @@ export async function projectTick(opts: {
 
     // Check sequential role execution: any other role must be inactive
     const otherRoles = enabledRoles.filter((r: string) => r !== role);
-    if (roleExecution === ExecutionMode.SEQUENTIAL && otherRoles.some((r: string) => countActiveSlots(getRoleWorker(fresh, r)) > 0)) {
+    if (
+      roleExecution === ExecutionMode.SEQUENTIAL &&
+      otherRoles.some(
+        (r: string) => countActiveSlots(getRoleWorker(fresh, r)) > 0,
+      )
+    ) {
       skipped.push({ role, reason: "Sequential: other role active" });
       continue;
     }
@@ -119,11 +156,18 @@ export async function projectTick(opts: {
     if (role === "reviewer") {
       const policy = workflow.reviewPolicy ?? ReviewPolicy.HUMAN;
       if (policy === ReviewPolicy.HUMAN) {
-        skipped.push({ role, reason: "Review policy: human (heartbeat handles via PR polling)" });
+        skipped.push({
+          role,
+          reason: "Review policy: human (heartbeat handles via PR polling)",
+        });
         continue;
       }
       if (policy === ReviewPolicy.SKIP) {
-        skipped.push({ role, reason: "Review policy: skip (heartbeat handles via review-skip pass)" });
+        skipped.push({
+          role,
+          reason:
+            "Review policy: skip (heartbeat handles via review-skip pass)",
+        });
         continue;
       }
     }
@@ -132,48 +176,77 @@ export async function projectTick(opts: {
     if (role === "tester") {
       const policy = workflow.testPolicy ?? TestPolicy.SKIP;
       if (policy === TestPolicy.SKIP) {
-        skipped.push({ role, reason: "Test policy: skip (heartbeat handles via test-skip pass)" });
+        skipped.push({
+          role,
+          reason: "Test policy: skip (heartbeat handles via test-skip pass)",
+        });
         continue;
       }
     }
 
-    const refiningLabel = Object.values(workflow.states)
-      .find((s) => s.type === StateType.HOLD && s.label.toLowerCase() === "refining")?.label ?? "Refining";
+    const refiningLabel =
+      Object.values(workflow.states).find(
+        (s) =>
+          s.type === StateType.HOLD && s.label.toLowerCase() === "refining",
+      )?.label ?? "Refining";
 
-    const next = await findNextIssueForRole(provider, role, workflow, instanceName, {
-      onCycleDetected: async ({ issue, label: currentLabel, reason }) => {
-        try {
-          await provider.transitionLabel(issue.iid, currentLabel, refiningLabel);
-          await provider.addComment(
-            issue.iid,
-            `⚠️ ${reason}\n\nMoved to **${refiningLabel}** automatically. Break the dependency loop, then run \`task_start\` to queue it again.`,
-          );
-          skipped.push({ role, reason: `Issue #${issue.iid} moved to ${refiningLabel}: ${reason}` });
-        } catch (err) {
-          skipped.push({ role, reason: `Issue #${issue.iid} has dependency cycle but auto-move failed: ${(err as Error).message}` });
-        }
+    const next = await findNextIssueForRole(
+      provider,
+      role,
+      workflow,
+      instanceName,
+      {
+        // Step routing: check for review:human / review:skip / test:skip labels.
+        // IMPORTANT: this must be part of the queue scan (not post-selection),
+        // otherwise a single ineligible head-of-queue issue can starve eligible
+        // items behind it.
+        isEligible: ({ issue }) => {
+          if (role === "reviewer") {
+            const routing = detectStepRouting(issue.labels, "review");
+            if (routing === "human" || routing === "skip")
+              return { ok: false, reason: `review:${routing} label` };
+          }
+          if (role === "tester") {
+            const routing = detectStepRouting(issue.labels, "test");
+            if (routing === "skip")
+              return { ok: false, reason: "test:skip label" };
+          }
+          return { ok: true };
+        },
+        onIneligible: async ({ issue, reason }) => {
+          skipped.push({
+            role,
+            reason: `Issue #${issue.iid}: ${reason ?? "ineligible"}`,
+          });
+        },
+        onCycleDetected: async ({ issue, label: currentLabel, reason }) => {
+          try {
+            await provider.transitionLabel(
+              issue.iid,
+              currentLabel,
+              refiningLabel,
+            );
+            await provider.addComment(
+              issue.iid,
+              `⚠️ ${reason}\n\nMoved to **${refiningLabel}** automatically. Break the dependency loop, then run \`task_start\` to queue it again.`,
+            );
+            skipped.push({
+              role,
+              reason: `Issue #${issue.iid} moved to ${refiningLabel}: ${reason}`,
+            });
+          } catch (err) {
+            skipped.push({
+              role,
+              reason: `Issue #${issue.iid} has dependency cycle but auto-move failed: ${(err as Error).message}`,
+            });
+          }
+        },
       },
-    });
+    );
     if (!next) continue;
 
     const { issue, label: currentLabel } = next;
     const targetLabel = getActiveLabel(workflow, role);
-
-    // Step routing: check for review:human / review:skip / test:skip labels
-    if (role === "reviewer") {
-      const routing = detectStepRouting(issue.labels, "review");
-      if (routing === "human" || routing === "skip") {
-        skipped.push({ role, reason: `review:${routing} label` });
-        continue;
-      }
-    }
-    if (role === "tester") {
-      const routing = detectStepRouting(issue.labels, "test");
-      if (routing === "skip") {
-        skipped.push({ role, reason: "test:skip label" });
-        continue;
-      }
-    }
 
     // Level selection: label → heuristic (must happen before free slot check)
     const selectedLevel = resolveLevelForIssue(issue, role);
@@ -186,19 +259,33 @@ export async function projectTick(opts: {
     }
 
     if (dryRun) {
-      const existingSession = roleWorker.levels[selectedLevel]?.[freeSlot]?.sessionKey;
+      const existingSession =
+        roleWorker.levels[selectedLevel]?.[freeSlot]?.sessionKey;
       pickups.push({
-        project: project.name, projectSlug, issueId: issue.iid, issueTitle: issue.title, issueUrl: issue.web_url,
-        role, level: selectedLevel,
+        project: project.name,
+        projectSlug,
+        issueId: issue.iid,
+        issueTitle: issue.title,
+        issueUrl: issue.web_url,
+        role,
+        level: selectedLevel,
         sessionAction: existingSession ? "send" : "spawn",
         announcement: `[DRY RUN] Would pick up #${issue.iid}`,
       });
     } else {
       try {
         const dr = await dispatchTask({
-          workspaceDir, agentId, project: fresh, issueId: issue.iid,
-          issueTitle: issue.title, issueDescription: issue.description ?? "", issueUrl: issue.web_url,
-          role, level: selectedLevel, fromLabel: currentLabel, toLabel: targetLabel,
+          workspaceDir,
+          agentId,
+          project: fresh,
+          issueId: issue.iid,
+          issueTitle: issue.title,
+          issueDescription: issue.description ?? "",
+          issueUrl: issue.web_url,
+          role,
+          level: selectedLevel,
+          fromLabel: currentLabel,
+          toLabel: targetLabel,
           provider,
           pluginConfig,
           sessionKey,
@@ -208,11 +295,21 @@ export async function projectTick(opts: {
           runCommand: runCommand!,
         });
         pickups.push({
-          project: project.name, projectSlug, issueId: issue.iid, issueTitle: issue.title, issueUrl: issue.web_url,
-          role, level: dr.level, sessionAction: dr.sessionAction, announcement: dr.announcement,
+          project: project.name,
+          projectSlug,
+          issueId: issue.iid,
+          issueTitle: issue.title,
+          issueUrl: issue.web_url,
+          role,
+          level: dr.level,
+          sessionAction: dr.sessionAction,
+          announcement: dr.announcement,
         });
       } catch (err) {
-        skipped.push({ role, reason: `Dispatch failed: ${(err as Error).message}` });
+        skipped.push({
+          role,
+          reason: `Dispatch failed: ${(err as Error).message}`,
+        });
         continue;
       }
     }


### PR DESCRIPTION
Addresses issue #50.

- Move step-routing eligibility (review:human / review:skip / test:skip) into the To Review/Test queue scan so ineligible head-of-queue items don't starve eligible ones.
- Log skipped ineligible issues with per-issue reasons.
- Add regression test for reviewer head-of-line blocking scenario.