### PR TITLE
Enforce DevClaw runtime workspace isolation

### DIFF
--- a/lib/audit.ts
+++ b/lib/audit.ts
@@ -5,6 +5,7 @@
  */
 import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
 import { join, dirname } from "node:path";
+import { homedir } from "node:os";
 import { DATA_DIR } from "./setup/migrate-layout.js";
 
 const MAX_LOG_LINES = 50;
@@ -15,6 +16,28 @@ export async function log(
   data: Record<string, unknown>,
 ): Promise<void> {
   const filePath = join(workspaceDir, DATA_DIR, "log", "audit.log");
+  await append(filePath, event, data);
+}
+
+/**
+ * Global audit log for runtime failures that happen *before* a workspace binding
+ * can be resolved.
+ *
+ * Intentionally NOT written into any OpenClaw workspace to avoid accidental drift.
+ */
+export async function logGlobal(
+  event: string,
+  data: Record<string, unknown>,
+): Promise<void> {
+  const filePath = join(homedir(), ".openclaw", "devclaw-runtime", "audit.log");
+  await append(filePath, event, data);
+}
+
+async function append(
+  filePath: string,
+  event: string,
+  data: Record<string, unknown>,
+): Promise<void> {
   const entry = JSON.stringify({
     ts: new Date().toISOString(),
     event,

--- a/lib/dispatch/attachment-hook.test.ts
+++ b/lib/dispatch/attachment-hook.test.ts
@@ -1,0 +1,19 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+describe("attachment hook workspace isolation", () => {
+  it("does not fall back to agents.defaults.workspace or ~/.openclaw/workspace-devclaw", () => {
+    const filePath = path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "attachment-hook.ts",
+    );
+    const src = fs.readFileSync(filePath, "utf-8");
+
+    assert.match(src, /resolveRuntimeWorkspace\(/, "should use canonical resolver");
+    assert.doesNotMatch(src, /agents\.defaults\.workspace/, "should not reference agents.defaults.workspace");
+    assert.doesNotMatch(src, /workspace-devclaw/, "should not reference hardcoded workspace-devclaw fallback");
+  });
+});

--- a/lib/dispatch/attachment-hook.ts
+++ b/lib/dispatch/attachment-hook.ts
@@ -8,8 +8,8 @@
  * Listens for incoming messages with media and issue references (#N).
  * When both are present, reads the local file and associates it with the issue.
  */
-import { homedir } from "node:os";
-import path from "node:path";
+import { resolveRuntimeWorkspace } from "../runtime/workspace-resolution.js";
+import { logGlobal as auditLogGlobal } from "../audit.js";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../context.js";
 import {
@@ -50,18 +50,6 @@ async function resolveProjectFromChannel(
 }
 
 /**
- * Resolve the workspace directory from OpenClaw config.
- * Checks agents.defaults.workspace, then falls back to ~/.openclaw/workspace-devclaw.
- */
-function resolveWorkspaceDir(config: Record<string, unknown>): string | null {
-  const agents = config.agents as { defaults?: { workspace?: string }; list?: Array<{ id: string; workspace?: string }> } | undefined;
-  if (agents?.defaults?.workspace) return agents.defaults.workspace;
-  const devclaw = agents?.list?.find((a) => a.id === "devclaw");
-  if (devclaw?.workspace) return devclaw.workspace;
-  return path.join(homedir(), ".openclaw", "workspace-devclaw");
-}
-
-/**
  * Register the message_received hook for attachment handling.
  *
  * Channel-agnostic: OpenClaw downloads media from all channels and stores
@@ -80,9 +68,21 @@ export function registerAttachmentHook(api: OpenClawPluginApi, ctx: PluginContex
     const issueIds = extractIssueReferences(event.content ?? "");
     if (issueIds.length === 0) return;
 
-    // Resolve workspace directory
-    const workspaceDir = resolveWorkspaceDir(ctx.config as unknown as Record<string, unknown>);
-    if (!workspaceDir) return;
+    // Resolve DevClaw runtime workspace binding (fail closed)
+    const resolution = resolveRuntimeWorkspace({
+      config: ctx.config as any,
+      pluginConfig: ctx.pluginConfig,
+      requireExists: true,
+    });
+    if (!resolution.ok) {
+      ctx.logger.error(`Attachment hook skipped: ${resolution.error}`);
+      await auditLogGlobal("attachment_hook_skipped", {
+        reason: resolution.error,
+      }).catch(() => {});
+      return;
+    }
+
+    const workspaceDir = resolution.workspaceDir;
 
     const conversationId = eventCtx.conversationId;
     if (!conversationId) return;

--- a/lib/runtime/workspace-resolution.test.ts
+++ b/lib/runtime/workspace-resolution.test.ts
@@ -1,0 +1,99 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { resolveRuntimeWorkspace } from "./workspace-resolution.js";
+
+describe("runtime workspace resolution", () => {
+  it("prefers explicit plugin config runtimeWorkspace binding", async () => {
+    const ws = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-ws-binding-"));
+    try {
+      const res = resolveRuntimeWorkspace({
+        pluginConfig: {
+          runtimeWorkspace: { agentId: "devclaw", workspaceDir: ws },
+        },
+        config: {
+          agents: { list: [{ id: "devclaw", workspace: ws }] },
+        },
+        requireExists: true,
+      });
+
+      assert.equal(res.ok, true);
+      if (!res.ok) return;
+      assert.equal(res.source, "binding");
+      assert.equal(res.agentId, "devclaw");
+      assert.equal(res.workspaceDir, ws);
+    } finally {
+      await fs.rm(ws, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to legacy agents.list devclaw workspace (but never defaults)", async () => {
+    const legacyWs = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-ws-legacy-"));
+    const defaultWs = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-ws-default-"));
+    try {
+      const res = resolveRuntimeWorkspace({
+        pluginConfig: {},
+        config: {
+          agents: {
+            list: [{ id: "devclaw", workspace: legacyWs }],
+            defaults: { workspace: defaultWs },
+          },
+        },
+        requireExists: true,
+      });
+
+      assert.equal(res.ok, true);
+      if (!res.ok) return;
+      assert.equal(res.source, "legacy");
+      assert.equal(res.workspaceDir, legacyWs);
+    } finally {
+      await Promise.all([
+        fs.rm(legacyWs, { recursive: true, force: true }),
+        fs.rm(defaultWs, { recursive: true, force: true }),
+      ]);
+    }
+  });
+
+  it("fails closed when no binding is present (even if defaults workspace is set)", async () => {
+    const defaultWs = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-ws-default-only-"));
+    try {
+      const res = resolveRuntimeWorkspace({
+        pluginConfig: {},
+        config: {
+          agents: {
+            list: [],
+            defaults: { workspace: defaultWs },
+          },
+        },
+        requireExists: true,
+      });
+
+      assert.equal(res.ok, false);
+      if (res.ok) return;
+      assert.equal(res.source, "error");
+      assert.match(res.error, /could not be resolved/i);
+    } finally {
+      await fs.rm(defaultWs, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when binding workspaceDir does not exist", () => {
+    const missing = path.join(os.tmpdir(), `devclaw-missing-${Date.now()}`);
+    const res = resolveRuntimeWorkspace({
+      pluginConfig: {
+        runtimeWorkspace: { agentId: "devclaw", workspaceDir: missing },
+      },
+      config: {
+        agents: { list: [{ id: "devclaw", workspace: missing }] },
+      },
+      requireExists: true,
+    });
+
+    assert.equal(res.ok, false);
+    if (res.ok) return;
+    assert.match(res.error, /does not exist/i);
+  });
+});

--- a/lib/runtime/workspace-resolution.ts
+++ b/lib/runtime/workspace-resolution.ts
@@ -1,0 +1,142 @@
+/**
+ * runtime/workspace-resolution.ts — Canonical DevClaw runtime workspace resolver.
+ *
+ * Goal: prevent DevClaw runtime from "drifting" into other OpenClaw workspaces.
+ * Runtime must resolve a single authoritative workspace binding and fail closed
+ * if it cannot.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { homedir } from "node:os";
+
+export type WorkspaceResolutionSource = "binding" | "legacy" | "error";
+
+export type WorkspaceResolutionOk = {
+  ok: true;
+  agentId: string;
+  workspaceDir: string;
+  source: Exclude<WorkspaceResolutionSource, "error">;
+};
+
+export type WorkspaceResolutionErr = {
+  ok: false;
+  agentId: null;
+  workspaceDir: null;
+  source: "error";
+  error: string;
+};
+
+export type WorkspaceResolutionResult = WorkspaceResolutionOk | WorkspaceResolutionErr;
+
+export type OpenClawConfigLike = {
+  agents?: {
+    list?: Array<{ id: string; workspace?: string }>;
+    defaults?: { workspace?: string };
+  };
+};
+
+export type DevClawPluginConfigLike = {
+  /** Preferred: written by DevClaw setup into openclaw.json plugin config. */
+  runtimeWorkspace?: {
+    agentId?: string;
+    workspaceDir?: string;
+  };
+};
+
+function expandHome(p: string): string {
+  if (p === "~") return homedir();
+  if (p.startsWith("~/")) return path.join(homedir(), p.slice(2));
+  return p;
+}
+
+function normalizeWorkspaceDir(p: string): string {
+  // Expand ~ then resolve to an absolute path.
+  const expanded = expandHome(p.trim());
+  return path.resolve(expanded);
+}
+
+function isExistingDirectory(p: string): boolean {
+  try {
+    return fs.statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function err(message: string): WorkspaceResolutionErr {
+  return {
+    ok: false,
+    agentId: null,
+    workspaceDir: null,
+    source: "error",
+    error: message,
+  };
+}
+
+/**
+ * Resolve DevClaw runtime workspace binding.
+ *
+ * Resolution order:
+ *  1) Plugin config binding: pluginConfig.runtimeWorkspace { agentId, workspaceDir }
+ *  2) Legacy fallback: agents.list entry for id === "devclaw" (explicit agent workspace)
+ *
+ * Explicitly NOT allowed:
+ *  - agents.defaults.workspace
+ *  - hardcoded ~/.openclaw/workspace-devclaw fallbacks
+ */
+export function resolveRuntimeWorkspace(opts: {
+  pluginConfig?: Record<string, unknown> | undefined;
+  config?: OpenClawConfigLike | undefined;
+  /** If true (default), workspaceDir must exist as a directory. */
+  requireExists?: boolean;
+}): WorkspaceResolutionResult {
+  const requireExists = opts.requireExists ?? true;
+  const pluginCfg = (opts.pluginConfig ?? {}) as DevClawPluginConfigLike;
+  const fullCfg = (opts.config ?? {}) as OpenClawConfigLike;
+
+  // 1) Authoritative binding (preferred)
+  const binding = pluginCfg.runtimeWorkspace;
+  if (binding && (binding.agentId || binding.workspaceDir)) {
+    const agentId = String(binding.agentId ?? "").trim();
+    const rawWs = String(binding.workspaceDir ?? "").trim();
+    if (!agentId) return err("DevClaw runtime workspace binding is missing agentId (plugins.entries.devclaw.config.runtimeWorkspace.agentId)");
+    if (!rawWs) return err("DevClaw runtime workspace binding is missing workspaceDir (plugins.entries.devclaw.config.runtimeWorkspace.workspaceDir)");
+
+    const workspaceDir = normalizeWorkspaceDir(rawWs);
+
+    if (requireExists && !isExistingDirectory(workspaceDir)) {
+      return err(
+        `DevClaw runtime workspace directory does not exist: ${workspaceDir}. Re-run DevClaw setup for agent "${agentId}".`,
+      );
+    }
+
+    // Cross-check against agent list if present — prevents stale/mismatched binding.
+    const agentEntry = fullCfg.agents?.list?.find((a) => a.id === agentId);
+    if (agentEntry?.workspace) {
+      const agentWorkspace = normalizeWorkspaceDir(agentEntry.workspace);
+      if (agentWorkspace !== workspaceDir) {
+        return err(
+          `DevClaw runtime workspace binding mismatch for agent "${agentId}": pluginConfig=${workspaceDir} but agents.list=${agentWorkspace}`,
+        );
+      }
+    }
+
+    return { ok: true, agentId, workspaceDir, source: "binding" };
+  }
+
+  // 2) Legacy: explicit devclaw agent workspace in agents.list
+  const legacy = fullCfg.agents?.list?.find((a) => a.id === "devclaw");
+  if (legacy?.workspace) {
+    const workspaceDir = normalizeWorkspaceDir(legacy.workspace);
+    if (requireExists && !isExistingDirectory(workspaceDir)) {
+      return err(
+        `Legacy DevClaw agent workspace does not exist: ${workspaceDir}. Re-run DevClaw setup to write an explicit runtimeWorkspace binding.`,
+      );
+    }
+    return { ok: true, agentId: legacy.id, workspaceDir, source: "legacy" };
+  }
+
+  return err(
+    "DevClaw runtime workspace binding could not be resolved. Run the DevClaw setup tool to bind runtimeWorkspace (agentId + workspaceDir).",
+  );
+}

--- a/lib/services/heartbeat/agent-discovery.test.ts
+++ b/lib/services/heartbeat/agent-discovery.test.ts
@@ -1,0 +1,60 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { discoverAgents } from "./agent-discovery.js";
+
+describe("heartbeat agent discovery", () => {
+  it("returns only the bound workspace (does not scan defaults workspace)", async () => {
+    const boundWs = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-bound-ws-"));
+    const defaultWs = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-default-ws-"));
+
+    try {
+      const { agents, resolution } = discoverAgents(
+        {
+          agents: {
+            list: [{ id: "devclaw", workspace: boundWs }],
+            defaults: { workspace: defaultWs },
+          },
+        } as any,
+        {
+          runtimeWorkspace: { agentId: "devclaw", workspaceDir: boundWs },
+        },
+      );
+
+      assert.equal(resolution.ok, true);
+      assert.equal(agents.length, 1);
+      assert.equal(agents[0].workspace, boundWs);
+    } finally {
+      await Promise.all([
+        fs.rm(boundWs, { recursive: true, force: true }),
+        fs.rm(defaultWs, { recursive: true, force: true }),
+      ]);
+    }
+  });
+
+  it("fails closed when no binding is resolvable (even if defaults is set)", async () => {
+    const defaultWs = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-default-ws-only-"));
+
+    try {
+      const { agents, resolution } = discoverAgents(
+        {
+          agents: {
+            list: [],
+            defaults: { workspace: defaultWs },
+          },
+        } as any,
+        {},
+      );
+
+      assert.equal(agents.length, 0);
+      assert.equal(resolution.ok, false);
+      if (resolution.ok) return;
+      assert.match(resolution.error, /could not be resolved/i);
+    } finally {
+      await fs.rm(defaultWs, { recursive: true, force: true });
+    }
+  });
+});

--- a/lib/services/heartbeat/agent-discovery.ts
+++ b/lib/services/heartbeat/agent-discovery.ts
@@ -1,70 +1,37 @@
 /**
- * Agent discovery — scan workspaces to find active DevClaw agents.
+ * Agent discovery — resolve the single authoritative DevClaw runtime workspace.
+ *
+ * DevClaw runtime must NOT scan arbitrary workspaces, must NOT fall back to
+ * agents.defaults.workspace, and must NOT infer a workspace from "devclaw markers".
  */
-import fs from "node:fs";
-import path from "node:path";
-import { DATA_DIR } from "../../setup/migrate-layout.js";
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
+import { resolveRuntimeWorkspace, type WorkspaceResolutionResult } from "../../runtime/workspace-resolution.js";
 
 export type Agent = {
   agentId: string;
   workspace: string;
 };
 
-// ---------------------------------------------------------------------------
-// Discovery
-// ---------------------------------------------------------------------------
-
 /**
- * Discover DevClaw agents by scanning which agent workspaces have projects.
- * Self-discovering: any agent whose workspace contains projects.json is processed.
- * Also checks the default workspace (agents.defaults.workspace) for projects.
+ * Discover DevClaw runtime agent(s).
+ *
+ * Returns at most one agent: the bound DevClaw runtime workspace.
  */
-export function discoverAgents(config: {
-  agents?: {
-    list?: Array<{ id: string; workspace?: string }>;
-    defaults?: { workspace?: string };
+export function discoverAgents(
+  config: any,
+  pluginConfig?: Record<string, unknown>,
+): { agents: Agent[]; resolution: WorkspaceResolutionResult } {
+  const resolution = resolveRuntimeWorkspace({
+    config: config as any,
+    pluginConfig,
+    requireExists: true,
+  });
+
+  if (!resolution.ok) {
+    return { agents: [], resolution };
+  }
+
+  return {
+    agents: [{ agentId: resolution.agentId, workspace: resolution.workspaceDir }],
+    resolution,
   };
-}): Agent[] {
-  const seen = new Set<string>();
-  const agents: Agent[] = [];
-
-  // Check explicit agent list
-  for (const a of config.agents?.list || []) {
-    if (!a.workspace) continue;
-    try {
-      if (hasProjects(a.workspace)) {
-        agents.push({ agentId: a.id, workspace: a.workspace });
-        seen.add(a.workspace);
-      }
-    } catch {
-      /* skip */
-    }
-  }
-
-  // Check default workspace (used when no explicit agents are registered)
-  const defaultWorkspace = config.agents?.defaults?.workspace;
-  if (defaultWorkspace && !seen.has(defaultWorkspace)) {
-    try {
-      if (hasProjects(defaultWorkspace)) {
-        agents.push({ agentId: "main", workspace: defaultWorkspace });
-      }
-    } catch {
-      /* skip */
-    }
-  }
-
-  return agents;
-}
-
-/** Check if a workspace has a projects.json (new or old locations). */
-export function hasProjects(workspace: string): boolean {
-  return (
-    fs.existsSync(path.join(workspace, DATA_DIR, "projects.json")) ||
-    fs.existsSync(path.join(workspace, "projects.json")) ||
-    fs.existsSync(path.join(workspace, "projects", "projects.json"))
-  );
 }

--- a/lib/services/heartbeat/index.ts
+++ b/lib/services/heartbeat/index.ts
@@ -18,6 +18,8 @@ import {
 } from "./health.js";
 import type { Agent } from "./agent-discovery.js";
 import { discoverAgents } from "./agent-discovery.js";
+import { logGlobal as auditLogGlobal } from "../../audit.js";
+import type { WorkspaceResolutionResult } from "../../runtime/workspace-resolution.js";
 import { HEARTBEAT_DEFAULTS, resolveHeartbeatConfig } from "./config.js";
 import type { HeartbeatConfig } from "./config.js";
 
@@ -100,10 +102,22 @@ async function runHeartbeatTick(
     const config = resolveHeartbeatConfig(ctx.pluginConfig);
     if (!config.enabled) return;
 
-    const agents = discoverAgents(ctx.config);
-    if (agents.length === 0) return;
+    const { agents, resolution } = discoverAgents(ctx.config, ctx.pluginConfig);
+    if (agents.length === 0) {
+      // Fail closed: do not scan defaults or infer workspaces.
+      logger.error(`work_heartbeat tick skipped: ${resolution.ok ? "no agents" : resolution.error}`);
+      await auditLogGlobal("heartbeat_tick_skipped", {
+        reason: resolution.ok ? "no agents resolved" : resolution.error,
+        resolutionSource: resolution.ok ? resolution.source : "error",
+      }).catch(() => {});
+      return;
+    }
 
-    const result = await processAllAgents(agents, config, ctx.pluginConfig, logger, ctx.runCommand, ctx.runtime);
+    if (resolution.ok && resolution.source === "legacy") {
+      logger.warn("work_heartbeat: using legacy DevClaw workspace resolution (agents.list devclaw). Run setup to write plugins.entries.devclaw.config.runtimeWorkspace.");
+    }
+
+    const result = await processAllAgents(agents, config, ctx.pluginConfig, logger, ctx.runCommand, ctx.runtime, resolution);
     logTickResult(result, logger);
   } catch (err) {
     logger.error(`work_heartbeat tick failed: ${err}`);
@@ -121,7 +135,8 @@ async function processAllAgents(
   pluginConfig: Record<string, unknown> | undefined,
   logger: ServiceContext["logger"],
   runCommand: import("../../context.js").RunCommand,
-  runtime?: PluginRuntime,
+  runtime: PluginRuntime | undefined,
+  resolution: WorkspaceResolutionResult,
 ): Promise<TickResult> {
   const result: TickResult = {
     totalPickups: 0,
@@ -151,6 +166,9 @@ async function processAllAgents(
     const agentResult = await tick({
       workspaceDir: workspace,
       agentId,
+      resolvedWorkspaceDir: workspace,
+      resolvedAgentId: agentId,
+      resolutionSource: resolution.ok ? resolution.source : "error",
       config,
       pluginConfig,
       sessions,

--- a/lib/services/heartbeat/tick-runner.audit.test.ts
+++ b/lib/services/heartbeat/tick-runner.audit.test.ts
@@ -1,0 +1,48 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { tick } from "./tick-runner.js";
+
+const noopRunCommand = (async () => ({
+  stdout: "{}",
+  stderr: "",
+  code: 0,
+  signal: null,
+  killed: false,
+})) as any;
+
+describe("heartbeat tick audit payload", () => {
+  it("includes resolved workspace fields in heartbeat_tick audit event", async () => {
+    const ws = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-tick-audit-"));
+    try {
+      await tick({
+        workspaceDir: ws,
+        agentId: "devclaw",
+        resolvedWorkspaceDir: ws,
+        resolvedAgentId: "devclaw",
+        resolutionSource: "binding",
+        config: { intervalSeconds: 60, enabled: true, maxPickupsPerTick: 1 } as any,
+        pluginConfig: {},
+        sessions: null,
+        logger: { info() {}, warn() {} },
+        runtime: undefined,
+        runCommand: noopRunCommand,
+      });
+
+      const auditPath = path.join(ws, "devclaw", "log", "audit.log");
+      const raw = await fs.readFile(auditPath, "utf-8");
+      const lines = raw.trim().split("\n");
+      const last = JSON.parse(lines[lines.length - 1]);
+
+      assert.equal(last.event, "heartbeat_tick");
+      assert.equal(last.resolvedWorkspaceDir, ws);
+      assert.equal(last.resolvedAgentId, "devclaw");
+      assert.equal(last.resolutionSource, "binding");
+    } finally {
+      await fs.rm(ws, { recursive: true, force: true });
+    }
+  });
+});

--- a/lib/services/heartbeat/tick-runner.ts
+++ b/lib/services/heartbeat/tick-runner.ts
@@ -45,6 +45,10 @@ export type TickResult = {
 export async function tick(opts: {
   workspaceDir: string;
   agentId?: string;
+  /** Explicit workspace resolution metadata for auditing. */
+  resolvedWorkspaceDir?: string;
+  resolvedAgentId?: string;
+  resolutionSource?: "binding" | "legacy" | "error";
   config: HeartbeatConfig;
   pluginConfig?: Record<string, unknown>;
   sessions: SessionLookup | null;
@@ -72,17 +76,6 @@ export async function tick(opts: {
   const data = await readProjects(workspaceDir);
   const slugs = Object.keys(data.projects);
 
-  if (slugs.length === 0) {
-    return {
-      totalPickups: 0,
-      totalHealthFixes: 0,
-      totalSkipped: 0,
-      totalReviewTransitions: 0,
-      totalReviewSkipTransitions: 0,
-      totalTestSkipTransitions: 0,
-    };
-  }
-
   const result: TickResult = {
     totalPickups: 0,
     totalHealthFixes: 0,
@@ -91,6 +84,24 @@ export async function tick(opts: {
     totalReviewSkipTransitions: 0,
     totalTestSkipTransitions: 0,
   };
+
+  // If there are no projects yet, still emit an audited tick for visibility.
+  if (slugs.length === 0) {
+    await auditLog(workspaceDir, "heartbeat_tick", {
+      resolvedWorkspaceDir: opts.resolvedWorkspaceDir ?? workspaceDir,
+      resolvedAgentId: opts.resolvedAgentId ?? agentId ?? null,
+      resolutionSource: opts.resolutionSource ?? null,
+      projectsScanned: 0,
+      healthFixes: 0,
+      reviewTransitions: 0,
+      reviewSkipTransitions: 0,
+      testSkipTransitions: 0,
+      pickups: 0,
+      skipped: 0,
+    });
+
+    return result;
+  }
 
   const projectExecution =
     (pluginConfig?.projectExecution as string) ?? ExecutionMode.PARALLEL;
@@ -196,6 +207,9 @@ export async function tick(opts: {
   }
 
   await auditLog(workspaceDir, "heartbeat_tick", {
+    resolvedWorkspaceDir: opts.resolvedWorkspaceDir ?? workspaceDir,
+    resolvedAgentId: opts.resolvedAgentId ?? agentId ?? null,
+    resolutionSource: opts.resolutionSource ?? null,
     projectsScanned: slugs.length,
     healthFixes: result.totalHealthFixes,
     reviewTransitions: result.totalReviewTransitions,

--- a/lib/setup/config.ts
+++ b/lib/setup/config.ts
@@ -23,6 +23,7 @@ export async function writePluginConfig(
   runtime: PluginRuntime,
   agentId?: string,
   projectExecution?: ExecutionMode,
+  workspaceDir?: string,
 ): Promise<void> {
   const config = runtime.config.loadConfig() as Record<string, unknown>;
 
@@ -30,6 +31,14 @@ export async function writePluginConfig(
 
   if (projectExecution) {
     (config as any).plugins.entries.devclaw.config.projectExecution = projectExecution;
+  }
+
+  // Authoritative runtime workspace binding (used by heartbeat + hooks)
+  if (agentId && workspaceDir) {
+    (config as any).plugins.entries.devclaw.config.runtimeWorkspace = {
+      agentId,
+      workspaceDir,
+    };
   }
 
   // Clean up legacy models from openclaw.json (moved to workflow.yaml)

--- a/lib/setup/index.ts
+++ b/lib/setup/index.ts
@@ -67,7 +67,7 @@ export async function runSetup(opts: SetupOpts): Promise<SetupResult> {
   const { agentId, workspacePath, agentCreated, bindingMigrated } =
     await resolveOrCreateAgent(opts, warnings);
 
-  await writePluginConfig(opts.runtime, agentId, opts.projectExecution);
+  await writePluginConfig(opts.runtime, agentId, opts.projectExecution, workspacePath);
 
   const defaultWorkspacePath = getDefaultWorkspacePath(opts.runtime);
   const filesWritten = await scaffoldWorkspace(workspacePath, defaultWorkspacePath);


### PR DESCRIPTION
Addresses issue #49.

## What changed
- Added canonical runtime workspace resolver (binding-first, legacy explicit agent fallback; no defaults / no hardcoded workspace-devclaw).
- Setup now writes an explicit runtimeWorkspace binding (agentId + workspaceDir) into DevClaw plugin config.
- Heartbeat processes ONLY the resolved workspace, and emits audited workspace resolution fields on each tick.
- Heartbeat emits a global audit event when a tick is skipped due to unresolved binding.
- Attachment hook now uses the canonical resolver and fails closed if runtime workspace cannot be resolved.

## Tests
- Added resolver + discovery + audit payload regression tests.