### PR TITLE
chore: address runtime isolation review nits

### DIFF
--- a/lib/audit.ts
+++ b/lib/audit.ts
@@ -23,6 +23,8 @@ export async function log(
  * Global audit log for runtime failures that happen *before* a workspace binding
  * can be resolved.
  *
+ * Location: ~/.openclaw/devclaw-runtime/audit.log
+ *
  * Intentionally NOT written into any OpenClaw workspace to avoid accidental drift.
  */
 export async function logGlobal(
@@ -51,6 +53,7 @@ async function append(
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       await mkdir(dirname(filePath), { recursive: true });
       await appendFile(filePath, entry + "\n");
+      await truncateIfNeeded(filePath);
     }
     // Audit logging should never break the tool — silently ignore other errors
   }

--- a/lib/services/heartbeat/index.ts
+++ b/lib/services/heartbeat/index.ts
@@ -114,7 +114,7 @@ async function runHeartbeatTick(
     }
 
     if (resolution.ok && resolution.source === "legacy") {
-      logger.warn("work_heartbeat: using legacy DevClaw workspace resolution (agents.list devclaw). Run setup to write plugins.entries.devclaw.config.runtimeWorkspace.");
+      logger.warn("work_heartbeat: using legacy DevClaw workspace resolution (agents.list devclaw). Re-run `devclaw setup` to write plugins.entries.devclaw.config.runtimeWorkspace.");
     }
 
     const result = await processAllAgents(agents, config, ctx.pluginConfig, logger, ctx.runCommand, ctx.runtime, resolution);


### PR DESCRIPTION
Addresses issue #49.

Follow-up on reviewer suggestions from PR #52:

- ensure shared audit append path preserves truncation behavior after ENOENT recovery
- document global audit path in code comment (`~/.openclaw/devclaw-runtime/audit.log`)
- make legacy heartbeat warning more actionable by explicitly suggesting `devclaw setup` while retaining the config key path

## Notes
- Attempted to run tests, but local install failed due missing `cmake` while building `node-llama-cpp` in postinstall.
