### PR TITLE
fix: refresh heartbeat scaffolding once per workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Heartbeat scaffold refresh cadence** — Heartbeat now refreshes package-owned workspace scaffold files only once per process/workspace instead of every tick, preventing repeated AGENTS.md/HEARTBEAT.md/TOOLS.md rewrites and `.bak` churn in runtime workspaces (#53).
 - **Critical:** work_finish now re-validates PR mergeable status during conflict resolution cycles, preventing infinite loops where developers claim "fixed" without pushing changes (#482, #480, #464, #483)
 
 ### Improved

--- a/lib/services/heartbeat/index.test.ts
+++ b/lib/services/heartbeat/index.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { discoverAgents } from "./agent-discovery.js";
+import {
+  refreshWorkspaceScaffolding,
+  resetRefreshedWorkspacesForTests,
+} from "./index.js";
+
+afterEach(() => {
+  resetRefreshedWorkspacesForTests();
+});
+
+describe("heartbeat workspace refresh cadence", () => {
+  it("refreshes each workspace at most once across multiple ticks", async () => {
+    const calls: string[] = [];
+    const logger = {
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+    };
+
+    const agents = [
+      { agentId: "devclaw", workspace: "/tmp/ws-a" },
+      { agentId: "devclaw-2", workspace: "/tmp/ws-a" },
+    ];
+
+    await refreshWorkspaceScaffolding(agents, logger, async (workspaceDir) => {
+      calls.push(workspaceDir);
+    });
+    await refreshWorkspaceScaffolding(agents, logger, async (workspaceDir) => {
+      calls.push(workspaceDir);
+    });
+
+    assert.deepEqual(calls, ["/tmp/ws-a"]);
+  });
+
+  it("does not refresh agents.defaults.workspace when runtime binding resolves elsewhere", async () => {
+    const boundWs = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-bound-refresh-"));
+    const defaultWs = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-default-refresh-"));
+
+    // Marker path that previously caused confusion when defaults workspace was scanned.
+    await fs.mkdir(path.join(defaultWs, "devclaw"), { recursive: true });
+    await fs.writeFile(
+      path.join(defaultWs, "devclaw", "projects.json"),
+      JSON.stringify({ marker: true }),
+      "utf-8",
+    );
+
+    const logger = {
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+    };
+
+    try {
+      const { agents, resolution } = discoverAgents(
+        {
+          agents: {
+            list: [{ id: "devclaw", workspace: boundWs }],
+            defaults: { workspace: defaultWs },
+          },
+        } as any,
+        {
+          runtimeWorkspace: { agentId: "devclaw", workspaceDir: boundWs },
+        },
+      );
+
+      assert.equal(resolution.ok, true);
+
+      const calls: string[] = [];
+      await refreshWorkspaceScaffolding(agents, logger, async (workspaceDir) => {
+        calls.push(workspaceDir);
+      });
+
+      assert.deepEqual(calls, [boundWs]);
+      assert.equal(calls.includes(defaultWs), false);
+    } finally {
+      await Promise.all([
+        fs.rm(boundWs, { recursive: true, force: true }),
+        fs.rm(defaultWs, { recursive: true, force: true }),
+      ]);
+    }
+  });
+});

--- a/lib/services/heartbeat/index.ts
+++ b/lib/services/heartbeat/index.ts
@@ -91,6 +91,7 @@ export function registerHeartbeatService(api: OpenClawPluginApi, pluginCtx: Plug
  * (setInterval + async means the next tick can fire while the previous awaits).
  */
 let _tickRunning = false;
+const refreshedWorkspaces = new Set<string>();
 
 async function runHeartbeatTick(
   ctx: PluginContext,
@@ -147,17 +148,8 @@ async function processAllAgents(
     totalTestSkipTransitions: 0,
   };
 
-  // Ensure defaults are fresh on every startup (prompts, workflow, etc.)
-  const refreshedWorkspaces = new Set<string>();
-  for (const { workspace } of agents) {
-    if (refreshedWorkspaces.has(workspace)) continue;
-    refreshedWorkspaces.add(workspace);
-    try {
-      await ensureDefaultFiles(workspace);
-    } catch (err) {
-      logger.warn(`Workspace refresh failed for ${workspace}: ${(err as Error).message}`);
-    }
-  }
+  // Refresh scaffold files once per process/workspace (not once per tick).
+  await refreshWorkspaceScaffolding(agents, logger);
 
   // Fetch gateway sessions once for all agents/projects
   const sessions = await fetchGatewaySessions(undefined, runCommand);
@@ -186,6 +178,26 @@ async function processAllAgents(
   }
 
   return result;
+}
+
+export async function refreshWorkspaceScaffolding(
+  agents: Agent[],
+  logger: ServiceContext["logger"],
+  ensureDefaultFilesImpl: (workspaceDir: string) => Promise<void> = ensureDefaultFiles,
+): Promise<void> {
+  for (const { workspace } of agents) {
+    if (refreshedWorkspaces.has(workspace)) continue;
+    refreshedWorkspaces.add(workspace);
+    try {
+      await ensureDefaultFilesImpl(workspace);
+    } catch (err) {
+      logger.warn(`Workspace refresh failed for ${workspace}: ${(err as Error).message}`);
+    }
+  }
+}
+
+export function resetRefreshedWorkspacesForTests(): void {
+  refreshedWorkspaces.clear();
 }
 
 /**


### PR DESCRIPTION
## Summary
- move heartbeat workspace scaffold refresh out of per-tick behavior by caching refreshed workspaces at module scope
- add explicit refresh helper + test reset hook to support deterministic heartbeat cadence tests
- add regression tests covering two-tick behavior and guarding against touching `agents.defaults.workspace` when runtime binding points elsewhere
- document behavior change in changelog

Addresses issue #53.

## Validation
- npm run check
- npx tsx --test lib/services/heartbeat/index.test.ts lib/services/heartbeat/agent-discovery.test.ts
