### PR TITLE
Fix reviewer queue scan hardening

### DIFF
--- a/lib/services/queue-scan-dependencies.test.ts
+++ b/lib/services/queue-scan-dependencies.test.ts
@@ -208,4 +208,46 @@ describe("findNextIssueForRole dependency gating", () => {
     assert.strictEqual(next, null);
     assert.deepStrictEqual(transitions, [{ issueId: 1, from: "To Do", to: "Refining" }]);
   });
+
+  it("continues scanning when isEligible throws for one issue", async () => {
+    const provider: QueueProvider = {
+      async listIssuesByLabel() {
+        return [issue(1), issue(2)];
+      },
+      async getIssueDependencies(issueId: number): Promise<IssueDependencies> {
+        return { issueId, blockers: [], dependents: [] };
+      },
+    };
+
+    const next = await findNextIssueForRole(provider, "developer", DEFAULT_WORKFLOW, undefined, {
+      isEligible: ({ issue }) => {
+        if (issue.iid === 2) throw new Error("boom");
+        return true;
+      },
+    });
+
+    assert.ok(next);
+    assert.strictEqual(next!.issue.iid, 1);
+  });
+
+  it("continues scanning when onIneligible throws for one issue", async () => {
+    const provider: QueueProvider = {
+      async listIssuesByLabel() {
+        return [issue(1), issue(2)];
+      },
+      async getIssueDependencies(issueId: number): Promise<IssueDependencies> {
+        return { issueId, blockers: [], dependents: [] };
+      },
+    };
+
+    const next = await findNextIssueForRole(provider, "developer", DEFAULT_WORKFLOW, undefined, {
+      isEligible: ({ issue }) => ({ ok: issue.iid === 1, reason: "not-ready" }),
+      onIneligible: async () => {
+        throw new Error("callback failed");
+      },
+    });
+
+    assert.ok(next);
+    assert.strictEqual(next!.issue.iid, 1);
+  });
 });

--- a/lib/services/queue-scan.ts
+++ b/lib/services/queue-scan.ts
@@ -104,6 +104,12 @@ export type DependencyGateStatus = {
   kind?: "dependency" | "cycle" | "uncertain";
 };
 
+function toErrorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "string") return err;
+  return "unknown error";
+}
+
 // ---------------------------------------------------------------------------
 // Issue queue queries
 // ---------------------------------------------------------------------------
@@ -157,7 +163,10 @@ export async function findNextIssueForRole(
         ? issues.filter((i) => isOwnedByOrUnclaimed(i.labels, instanceName))
         : issues;
 
-      for (const issue of eligible.slice().reverse()) {
+      // Providers typically return queue issues newest-first; scan oldest-first
+      // to preserve FIFO semantics within each label queue.
+      const queueOrder = eligible.slice().reverse();
+      for (const issue of queueOrder) {
         const gate = await getDependencyGateStatus(provider, issue, workflow);
         if (gate.blocked) {
           if (
@@ -178,12 +187,26 @@ export async function findNextIssueForRole(
         }
 
         if (opts?.isEligible) {
-          const res = await opts.isEligible({ issue, label });
-          const ok = typeof res === "boolean" ? res : res.ok;
-          const reason = typeof res === "boolean" ? undefined : res.reason;
-          if (!ok) {
-            if (opts.onIneligible)
-              await opts.onIneligible({ issue, label, reason });
+          try {
+            const res = await opts.isEligible({ issue, label });
+            const ok = typeof res === "boolean" ? res : res.ok;
+            const reason = typeof res === "boolean" ? undefined : res.reason;
+            if (!ok) {
+              if (opts.onIneligible) {
+                try {
+                  await opts.onIneligible({ issue, label, reason });
+                } catch (err) {
+                  console.warn(
+                    `[queue-scan] onIneligible failed for #${issue.iid} (${label}): ${toErrorMessage(err)}`,
+                  );
+                }
+              }
+              continue;
+            }
+          } catch (err) {
+            console.warn(
+              `[queue-scan] isEligible failed for #${issue.iid} (${label}): ${toErrorMessage(err)}`,
+            );
             continue;
           }
         }


### PR DESCRIPTION
Addresses issue #50.

- Hardened queue scan: per-issue try/catch around isEligible/onIneligible so one bad callback won’t abort scanning remaining items in the same label queue.
- Added small FIFO ordering comment for reverse scan.
- Added regression tests ensuring scan continues when eligibility callbacks throw.

Tested: npm run test:core