### PR TITLE
fix(dispatch): harden acceptance parsing for --expect-final envelopes (#27)

### DIFF
--- a/lib/dispatch/session.acceptance.test.ts
+++ b/lib/dispatch/session.acceptance.test.ts
@@ -86,7 +86,7 @@ describe("sendToAgent acceptance parsing", () => {
     assert.strictEqual(out.mode, "accepted-flag");
   });
 
-  it("fails closed for malformed final-mode responses", async () => {
+  it("accepts final envelope when status=ok + runId (no result payload)", async () => {
     const out = await sendToAgent("agent:test:subagent:proj-dev", "msg", {
       projectName: "proj",
       issueId: 25,
@@ -96,9 +96,44 @@ describe("sendToAgent acceptance parsing", () => {
       runCommand: mkRunCommand('{"status":"ok","runId":"run-final"}'),
     });
 
+    assert.strictEqual(out.accepted, true);
+    assert.strictEqual(out.status, "accepted");
+    assert.strictEqual(out.runId, "run-final");
+    assert.strictEqual(out.mode, "final-ok");
+  });
+
+  it("fails closed when status=ok but runId is missing", async () => {
+    const out = await sendToAgent("agent:test:subagent:proj-dev", "msg", {
+      projectName: "proj",
+      issueId: 25,
+      role: "developer",
+      level: "medior",
+      workspaceDir: "/tmp",
+      runCommand: mkRunCommand('{"status":"ok"}'),
+    });
+
     assert.strictEqual(out.accepted, false);
     assert.strictEqual(out.status, "failed");
     assert.match(String(out.reason), /did not include acceptance status/i);
     assert.strictEqual(out.mode, "invalid");
+  });
+
+  it("does not mask explicit top-level failures even when runId exists", async () => {
+    const out = await sendToAgent("agent:test:subagent:proj-dev", "msg", {
+      projectName: "proj",
+      issueId: 25,
+      role: "developer",
+      level: "medior",
+      workspaceDir: "/tmp",
+      runCommand: mkRunCommand(
+        '{"status":"rejected","runId":"run-final","reason":"policy denied"}',
+      ),
+    });
+
+    assert.strictEqual(out.accepted, false);
+    assert.strictEqual(out.status, "rejected");
+    assert.strictEqual(out.runId, "run-final");
+    assert.strictEqual(out.reason, "policy denied");
+    assert.strictEqual(out.mode, "explicit-failure");
   });
 });

--- a/lib/dispatch/session.ts
+++ b/lib/dispatch/session.ts
@@ -242,7 +242,13 @@ function parseDispatchAcceptance(stdout: string): DispatchAcceptance {
   }
 
   if (topStatus === "accepted" || topStatus === "started") {
-    return { accepted: true, status: topStatus, runId, mode: "early-status", raw: parsed };
+    return {
+      accepted: true,
+      status: topStatus,
+      runId,
+      mode: "early-status",
+      raw: parsed,
+    };
   }
 
   if (
@@ -284,11 +290,19 @@ function parseDispatchAcceptance(stdout: string): DispatchAcceptance {
   }
 
   // --expect-final compatibility:
-  // gateway call can return final lifecycle envelope like:
+  // gateway call can return final lifecycle envelopes like:
+  // { status: "ok", runId: "..." }
   // { status: "ok", runId: "...", result: { ... } }
-  // Treat as accepted only when runId exists and result payload is present.
-  if (topStatusRaw === "ok" && runId && result && typeof result === "object") {
-    return { accepted: true, status: "accepted", runId, mode: "final-ok", raw: parsed };
+  // Treat as accepted when transport-level status is ok and runId exists.
+  // Explicit nested failures are handled above, so they cannot be masked here.
+  if (topStatusRaw === "ok" && runId) {
+    return {
+      accepted: true,
+      status: "accepted",
+      runId,
+      mode: "final-ok",
+      raw: parsed,
+    };
   }
 
   if (runId && (o.ok === true || result?.ok === true)) {


### PR DESCRIPTION
## Summary
Fixes #27 by hardening `sendToAgent()` acceptance parsing for `openclaw gateway call agent --expect-final --json` response variants.

Specifically:
- Accepts valid final envelopes with transport success (`status: "ok"`) + `runId`, even when `result` is omitted.
- Preserves fail-closed behavior for malformed/unknown responses.
- Preserves explicit-failure precedence for `rejected` / `deduped` / `unavailable` / `timeout` (top-level or nested).

## What changed
### Code
- **`lib/dispatch/session.ts`**
  - In `parseDispatchAcceptance()`, relaxed final-envelope acceptance from:
    - `status === "ok" && runId && result is object`
  - to:
    - `status === "ok" && runId`
  - Kept parser ordering so explicit nested/top-level failure statuses are evaluated first and cannot be masked by transport-level `ok`.

### Tests
- **`lib/dispatch/session.acceptance.test.ts`**
  - Updated coverage to reflect real response variants:
    - ✅ accepts `{ "status": "ok", "runId": "..." }`
    - ✅ accepts `{ "status": "ok", "runId": "...", "result": {...} }`
    - ❌ fails closed for `{ "status": "ok" }` (missing `runId`)
    - ❌ keeps explicit failure when top-level is rejected even with `runId`
    - ❌ keeps explicit nested failure (`result.status: rejected`)
    - ❌ keeps explicit nested `accepted:false`

## Response-shape matrix (captured)
| Shape | Example | Decision | Mode | Safety rationale |
|---|---|---|---|---|
| Early accepted | `{status:"accepted", runId}` | accept | `early-status` | explicit acceptance signal |
| Early started | `{status:"started", runId}` | accept | `early-status` | explicit acceptance signal |
| Final ok + runId + result | `{status:"ok", runId, result:{...}}` | accept | `final-ok` | transport success + run identity |
| Final ok + runId (no result) | `{status:"ok", runId}` | accept | `final-ok` | valid observed gateway variant; run identity present |
| Final nested rejected | `{status:"ok", runId, result:{status:"rejected"}}` | reject | `explicit-failure` | explicit failure outranks transport success |
| Final nested accepted false | `{status:"ok", runId, result:{accepted:false}}` | reject | `accepted-flag` | explicit non-acceptance signal |
| Top-level rejected | `{status:"rejected", runId}` | reject | `explicit-failure` | explicit failure |
| Top-level deduped | `{status:"deduped", runId}` | reject | `explicit-failure` | explicit non-accepting terminal |
| ok without runId | `{status:"ok"}` | fail closed | `invalid` | cannot correlate to accepted run |
| Unknown/malformed | invalid JSON / unknown schema | fail closed | `invalid` | defensive default |

## Why this is safe
- Parser still fails closed unless a recognized acceptance signal exists.
- `status:"ok"` only counts as acceptance when tied to `runId`.
- Explicit negative signals (status failure or `accepted:false`) are checked **before** final-ok compatibility, so failures are never misclassified as accepted.

## Validation run
- `npx tsx --test lib/dispatch/session.acceptance.test.ts` ✅ (7/7)
- `npx tsx --test lib/dispatch/index.acceptance-gating.test.ts` ✅ (7/7)
- `npm run check` (tsc --noEmit) ✅
