### PR TITLE
Issue #70: add sendToAgent request/response envelope debug logging with field truncation

### DIFF
--- a/lib/dispatch/session.debug-logging.test.ts
+++ b/lib/dispatch/session.debug-logging.test.ts
@@ -1,0 +1,110 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { sendToAgent } from "./session.js";
+
+describe("sendToAgent debug envelope logging", () => {
+  it("logs request/response envelopes with field-level truncation markers", async () => {
+    const workspaceDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "devclaw-session-debug-"),
+    );
+    try {
+      const longMessage = "m".repeat(2_800);
+      const longPrompt = "p".repeat(2_700);
+      const longOutput = "o".repeat(5_200);
+      const longRunId = "run-" + "r".repeat(5_100);
+      const responseItems = Array.from({ length: 30 }, (_, i) => `item-${i}`);
+
+      const runCommand: any = async () => ({
+        stdout: JSON.stringify({
+          status: "ok",
+          runId: longRunId,
+          result: {
+            output: longOutput,
+            items: responseItems,
+          },
+        }),
+        stderr: "",
+        code: 0,
+        signal: null,
+        killed: false,
+        termination: { type: "exit", code: 0 },
+      });
+
+      const out = await sendToAgent(
+        "agent:test:subagent:proj-dev-senior",
+        longMessage,
+        {
+          projectName: "proj",
+          issueId: 70,
+          role: "developer",
+          level: "senior",
+          slotIndex: 0,
+          dispatchAttempt: 1,
+          workspaceDir,
+          extraSystemPrompt: longPrompt,
+          runCommand,
+        },
+      );
+
+      assert.equal(out.accepted, true);
+      assert.equal(out.status, "accepted");
+      assert.equal(out.mode, "final-ok");
+      assert.equal(out.runId, longRunId);
+
+      const auditPath = path.join(workspaceDir, "devclaw", "log", "audit.log");
+      const raw = await fs.readFile(auditPath, "utf-8");
+      const events = raw
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+
+      const reqEvent = events.find(
+        (e) => e.event === "dispatch_debug" && e.step === "sendToAgent.request",
+      );
+      const resEvent = events.find(
+        (e) =>
+          e.event === "dispatch_debug" && e.step === "sendToAgent.response",
+      );
+
+      assert.ok(reqEvent, "request debug event should exist");
+      assert.ok(resEvent, "response debug event should exist");
+
+      assert.equal(reqEvent.envelope.agentId, "devclaw");
+      assert.equal(
+        reqEvent.envelope.sessionKey,
+        "agent:test:subagent:proj-dev-senior",
+      );
+      assert.equal(reqEvent.envelope.lane, "subagent");
+      assert.match(
+        String(reqEvent.envelope.message),
+        /\[truncated originalLength=2800 keptLength=2000\]$/,
+      );
+      assert.match(
+        String(reqEvent.envelope.extraSystemPrompt),
+        /\[truncated originalLength=2700 keptLength=2000\]$/,
+      );
+
+      assert.equal(resEvent.status, "accepted");
+      assert.equal(resEvent.runId, longRunId);
+      assert.equal(resEvent.mode, "final-ok");
+      assert.equal(resEvent.envelope.status, "ok");
+      assert.equal(resEvent.envelope.runId, longRunId);
+      assert.match(
+        String(resEvent.envelope.result.output),
+        /\[truncated originalLength=5200 keptLength=4000\]$/,
+      );
+      assert.equal(resEvent.envelope.result.items.length, 21);
+      assert.deepEqual(resEvent.envelope.result.items[20], {
+        __truncated: true,
+        kind: "array",
+        originalLength: 30,
+        keptLength: 20,
+      });
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/lib/dispatch/session.ts
+++ b/lib/dispatch/session.ts
@@ -5,6 +5,20 @@ import type { RunCommand } from "../context.js";
 import { log as auditLog } from "../audit.js";
 import { fetchGatewaySessions } from "../services/gateway-sessions.js";
 
+const REQUEST_TEXT_TRUNCATE_AT = 2_000;
+const RESPONSE_TEXT_TRUNCATE_AT = 4_000;
+const RESPONSE_ARRAY_TRUNCATE_AT = 20;
+const NON_TRUNCATED_DIAGNOSTIC_FIELDS = new Set([
+  "idempotencyKey",
+  "agentId",
+  "sessionKey",
+  "lane",
+  "status",
+  "runId",
+  "reason",
+  "mode",
+]);
+
 // ---------------------------------------------------------------------------
 // Context budget management
 // ---------------------------------------------------------------------------
@@ -140,7 +154,7 @@ export async function sendToAgent(
   },
 ): Promise<DispatchAcceptance> {
   const rc = opts.runCommand;
-  const gatewayParams = JSON.stringify({
+  const gatewayParamsObj = {
     idempotencyKey: `devclaw-${opts.projectName}-${opts.issueId}-${opts.role}-${opts.level ?? "unknown"}-${opts.slotIndex ?? 0}-${opts.dispatchAttempt ?? 0}-${sessionKey}`,
     agentId: opts.agentId ?? "devclaw",
     sessionKey,
@@ -154,6 +168,13 @@ export async function sendToAgent(
       ? { extraSystemPrompt: opts.extraSystemPrompt }
       : {}),
     ...(opts.model ? { model: opts.model } : {}),
+  };
+  const gatewayParams = JSON.stringify(gatewayParamsObj);
+  await auditLog(opts.workspaceDir, "dispatch_debug", {
+    step: "sendToAgent.request",
+    issue: opts.issueId,
+    role: opts.role,
+    envelope: sanitizeRequestEnvelopeForLog(gatewayParamsObj),
   });
 
   try {
@@ -170,7 +191,19 @@ export async function sendToAgent(
       ],
       { timeoutMs: opts.dispatchTimeoutMs ?? 600_000 },
     );
-    return parseDispatchAcceptance(result.stdout);
+    const parsedStdout = tryParseJson(result.stdout);
+    const acceptance = parseDispatchAcceptance(result.stdout);
+    await auditLog(opts.workspaceDir, "dispatch_debug", {
+      step: "sendToAgent.response",
+      issue: opts.issueId,
+      role: opts.role,
+      envelope: sanitizeResponseEnvelopeForLog(parsedStdout ?? result.stdout),
+      status: acceptance.status,
+      runId: acceptance.runId,
+      reason: acceptance.reason,
+      mode: acceptance.mode,
+    });
+    return acceptance;
   } catch (err) {
     const msg = (err as Error).message ?? String(err);
     const timeout = /timeout|timed out/i.test(msg);
@@ -337,4 +370,85 @@ function normalizeStatus(
   if (s === "unavailable" || s === "offline") return "unavailable";
   if (s === "timeout" || s === "timed_out") return "timeout";
   return "failed";
+}
+
+function sanitizeRequestEnvelopeForLog(
+  envelope: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(envelope)) {
+    if (
+      (key === "message" || key === "extraSystemPrompt") &&
+      typeof value === "string"
+    ) {
+      out[key] = truncateStringWithMarker(value, REQUEST_TEXT_TRUNCATE_AT);
+      continue;
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+function sanitizeResponseEnvelopeForLog(envelope: unknown): unknown {
+  return sanitizeResponseValueForLog(envelope);
+}
+
+function sanitizeResponseValueForLog(
+  value: unknown,
+  keyHint?: string,
+): unknown {
+  if (
+    keyHint &&
+    NON_TRUNCATED_DIAGNOSTIC_FIELDS.has(keyHint) &&
+    (typeof value === "string" ||
+      typeof value === "number" ||
+      typeof value === "boolean" ||
+      value == null)
+  ) {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    return truncateStringWithMarker(value, RESPONSE_TEXT_TRUNCATE_AT);
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length <= RESPONSE_ARRAY_TRUNCATE_AT) {
+      return value.map((item) => sanitizeResponseValueForLog(item));
+    }
+    const kept = value
+      .slice(0, RESPONSE_ARRAY_TRUNCATE_AT)
+      .map((item) => sanitizeResponseValueForLog(item));
+    kept.push({
+      __truncated: true,
+      kind: "array",
+      originalLength: value.length,
+      keptLength: RESPONSE_ARRAY_TRUNCATE_AT,
+    });
+    return kept;
+  }
+
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = sanitizeResponseValueForLog(v, k);
+    }
+    return out;
+  }
+
+  return value;
+}
+
+function truncateStringWithMarker(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, maxLength)}...[truncated originalLength=${value.length} keptLength=${maxLength}]`;
+}
+
+function tryParseJson(input: string): unknown | undefined {
+  if (!input) return undefined;
+  try {
+    return JSON.parse(input);
+  } catch {
+    return undefined;
+  }
 }


### PR DESCRIPTION
## Summary

Implements #70 by adding dispatch RPC observability in `sendToAgent` with size-limited raw envelope logging.

### What was added
- Audit event for outbound request envelope (`sendToAgent.request`)
- Audit event for inbound/raw response envelope (`sendToAgent.response`)
- Field-level truncation (preserves structure, trims known high-volume text)
- Truncation metadata markers and original/kept lengths

### Truncation behavior
- Request fields truncated: `message`, `extraSystemPrompt`
- Response sanitization truncates large strings and large arrays recursively
- Key diagnostic fields remain intact where possible (`idempotencyKey`, `agentId`, `sessionKey`, `lane`, `status`, `runId`, `reason`, `mode`)

### Safety
Logging-only change. Dispatch acceptance/decision behavior is unchanged.

### Validation
- session acceptance/idempotency/debug tests pass
- typecheck passes

Closes #70
