### PR TITLE
fix(dispatch): add 30s gateway timeout to sendToAgent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - rj-main
 
 jobs:
   quality:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Heartbeat scaffold refresh cadence** — Heartbeat now refreshes package-owned workspace scaffold files only once per process/workspace instead of every tick, preventing repeated AGENTS.md/HEARTBEAT.md/TOOLS.md rewrites and `.bak` churn in runtime workspaces (#53).
 - **Critical:** work_finish now re-validates PR mergeable status during conflict resolution cycles, preventing infinite loops where developers claim "fixed" without pushing changes (#482, #480, #464, #483)
 
 ### Improved

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,90 @@
+# Contributing
+
+Thanks for helping improve DevClaw.
+
+## Prerequisites
+
+- **Node.js >= 22** (see `package.json#engines`)
+- npm (bundled with Node)
+
+## Install
+
+```bash
+npm ci
+```
+
+If `npm ci` fails during a native `postinstall` step (for example, due to missing `cmake`), you can either:
+
+- install the missing system dependency (recommended), or
+- for running the TypeScript/test toolchain only, install with scripts disabled:
+
+```bash
+npm ci --ignore-scripts
+```
+
+## Common scripts
+
+### Typecheck / lint
+
+DevClaw uses TypeScript typechecking as its primary lint step:
+
+```bash
+npm run lint
+# or
+npm run check
+```
+
+### Tests
+
+Run the default (core) test suite:
+
+```bash
+npm test
+# or
+npm run test:core
+```
+
+Run the extended / slower tests:
+
+```bash
+npm run test:extended
+```
+
+Run everything:
+
+```bash
+npm run test:all
+```
+
+### Build
+
+```bash
+npm run build
+```
+
+### Formatting
+
+Prettier is used for formatting a small curated set of files.
+
+```bash
+npm run format
+```
+
+Check formatting (CI-friendly):
+
+```bash
+npm run format-check
+```
+
+### Full local validation
+
+This is the closest approximation of what CI expects:
+
+```bash
+npm run validate
+```
+
+## Notes
+
+- `npm run build` produces the `dist/` output consumed by OpenClaw.
+- If you add new files that should be formatted, update the `format` / `format-check` scripts in `package.json` accordingly.

--- a/README.md
+++ b/README.md
@@ -578,17 +578,17 @@ Full parameters and usage in the [Tools Reference](docs/TOOLS.md).
 
 ## Documentation
 
-|                                             |                                                              |
-| ------------------------------------------- | ------------------------------------------------------------ |
-| **[Architecture](docs/ARCHITECTURE.md)**    | System design, session model, data flow, end-to-end diagrams |
-| **[Workflow](docs/WORKFLOW.md)**            | State machine, review policies, optional test phase          |
-| **[Tools Reference](docs/TOOLS.md)**        | Complete reference for all tools                             |
-| **[Configuration](docs/CONFIGURATION.md)**  | `openclaw.json`, `projects.json`, roles, timeouts            |
-| **[Onboarding Guide](docs/ONBOARDING.md)**  | Full step-by-step setup                                      |
-| **[Testing](docs/TESTING.md)**              | Test suite, fixtures, CI/CD                                  |
-| **[Dependency gating](docs/dependency-gating.md)** | Blocking rules, fail-closed behavior, cycle handling     |
-| **[Management Theory](docs/MANAGEMENT.md)** | The delegation model behind the design                       |
-| **[Roadmap](docs/ROADMAP.md)**              | What's coming next                                           |
+|                                                    |                                                              |
+| -------------------------------------------------- | ------------------------------------------------------------ |
+| **[Architecture](docs/ARCHITECTURE.md)**           | System design, session model, data flow, end-to-end diagrams |
+| **[Workflow](docs/WORKFLOW.md)**                   | State machine, review policies, optional test phase          |
+| **[Tools Reference](docs/TOOLS.md)**               | Complete reference for all tools                             |
+| **[Configuration](docs/CONFIGURATION.md)**         | `openclaw.json`, `projects.json`, roles, timeouts            |
+| **[Onboarding Guide](docs/ONBOARDING.md)**         | Full step-by-step setup                                      |
+| **[Testing](docs/TESTING.md)**                     | Test suite, fixtures, CI/CD                                  |
+| **[Dependency gating](docs/dependency-gating.md)** | Blocking rules, fail-closed behavior, cycle handling         |
+| **[Management Theory](docs/MANAGEMENT.md)**        | The delegation model behind the design                       |
+| **[Roadmap](docs/ROADMAP.md)**                     | What's coming next                                           |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -586,6 +586,7 @@ Full parameters and usage in the [Tools Reference](docs/TOOLS.md).
 | **[Configuration](docs/CONFIGURATION.md)**  | `openclaw.json`, `projects.json`, roles, timeouts            |
 | **[Onboarding Guide](docs/ONBOARDING.md)**  | Full step-by-step setup                                      |
 | **[Testing](docs/TESTING.md)**              | Test suite, fixtures, CI/CD                                  |
+| **[Dependency gating](docs/dependency-gating.md)** | Blocking rules, fail-closed behavior, cycle handling     |
 | **[Management Theory](docs/MANAGEMENT.md)** | The delegation model behind the design                       |
 | **[Roadmap](docs/ROADMAP.md)**              | What's coming next                                           |
 

--- a/README.md
+++ b/README.md
@@ -562,7 +562,7 @@ DevClaw gives the orchestrator 23 tools. These aren't just convenience wrappers 
 | `health`               | Detect zombie workers, stale sessions, state inconsistencies                            |
 | `project_register`     | One-time project setup: creates labels, scaffolds instructions, initializes state       |
 | `sync_labels`          | Sync GitHub/GitLab labels with workflow config after editing `workflow.yaml`            |
-| `channel_link`         | Link a chat/channel to a project (auto-detaches previous project)                      |
+| `channel_link`         | Link a chat/channel to a project (auto-detaches previous project)                       |
 | `channel_unlink`       | Remove a channel from a project                                                         |
 | `channel_list`         | List channels for a project or all projects                                             |
 | `setup`                | Agent + workspace initialization                                                        |

--- a/docs/dependency-gating.md
+++ b/docs/dependency-gating.md
@@ -1,0 +1,39 @@
+# Dependency gating
+
+DevClaw supports **dependency gating** for queued issues: if an issue has unresolved blockers, it will not be dispatched to workers.
+
+## What counts as a blocker?
+
+An issue is considered **blocked** when any dependency marked as **“blocked by”** is not resolved.
+
+Resolution rules:
+
+- If the blocker has the **`Rejected`** label, it is treated as **still blocking** (explicitly fail-closed).
+- If the blocker has any workflow **terminal** state label (e.g. `Done`), it is **not blocking**.
+- If labels are unavailable, DevClaw falls back to the provider’s issue state (`closed` / `done` / `merged` are treated as resolved).
+
+## Provider failures (fail-closed)
+
+Dependency status is fetched from the issue provider (GitHub/GitLab).
+
+- **Transient failures** are retried.
+- If dependency lookup remains unavailable, DevClaw **fails closed** and treats the issue as blocked (it will not dispatch).
+
+Troubleshooting:
+
+- Ensure your provider tooling can access the repo (e.g. `gh auth status` for GitHub).
+- Check rate limits and GraphQL/API availability.
+
+## Circular dependency detection
+
+If DevClaw can prove a **dependency cycle** (e.g. `#1 blocked by #2` and `#2 blocked by #1`), the issue cannot be actioned as-is.
+
+Best-effort behavior:
+
+- DevClaw transitions the queued issue to **`Refining`** so a human can break the cycle.
+- If the provider supports comments, DevClaw leaves a short note explaining why.
+
+How to fix:
+
+- Remove the circular “blocked by” links in the issue tracker, or
+- Close/resolve one side if it’s no longer relevant.

--- a/docs/dependency-gating.md
+++ b/docs/dependency-gating.md
@@ -15,6 +15,7 @@ Resolution rules:
 ## Provider failures (fail-closed)
 
 Dependency status is fetched from the issue provider (GitHub/GitLab).
+For GitHub, dependency edges are read from GraphQL `blockedBy` (blockers) and `blocking` (dependents).
 
 - **Transient failures** are retried.
 - If dependency lookup remains unavailable, DevClaw **fails closed** and treats the issue as blocked (it will not dispatch).

--- a/lib/audit.ts
+++ b/lib/audit.ts
@@ -5,6 +5,7 @@
  */
 import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
 import { join, dirname } from "node:path";
+import { homedir } from "node:os";
 import { DATA_DIR } from "./setup/migrate-layout.js";
 
 const MAX_LOG_LINES = 50;
@@ -15,6 +16,28 @@ export async function log(
   data: Record<string, unknown>,
 ): Promise<void> {
   const filePath = join(workspaceDir, DATA_DIR, "log", "audit.log");
+  await append(filePath, event, data);
+}
+
+/**
+ * Global audit log for runtime failures that happen *before* a workspace binding
+ * can be resolved.
+ *
+ * Intentionally NOT written into any OpenClaw workspace to avoid accidental drift.
+ */
+export async function logGlobal(
+  event: string,
+  data: Record<string, unknown>,
+): Promise<void> {
+  const filePath = join(homedir(), ".openclaw", "devclaw-runtime", "audit.log");
+  await append(filePath, event, data);
+}
+
+async function append(
+  filePath: string,
+  event: string,
+  data: Record<string, unknown>,
+): Promise<void> {
   const entry = JSON.stringify({
     ts: new Date().toISOString(),
     event,

--- a/lib/audit.ts
+++ b/lib/audit.ts
@@ -23,6 +23,8 @@ export async function log(
  * Global audit log for runtime failures that happen *before* a workspace binding
  * can be resolved.
  *
+ * Location: ~/.openclaw/devclaw-runtime/audit.log
+ *
  * Intentionally NOT written into any OpenClaw workspace to avoid accidental drift.
  */
 export async function logGlobal(
@@ -51,6 +53,7 @@ async function append(
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       await mkdir(dirname(filePath), { recursive: true });
       await appendFile(filePath, entry + "\n");
+      await truncateIfNeeded(filePath);
     }
     // Audit logging should never break the tool — silently ignore other errors
   }

--- a/lib/dispatch/attachment-hook.test.ts
+++ b/lib/dispatch/attachment-hook.test.ts
@@ -1,0 +1,19 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+describe("attachment hook workspace isolation", () => {
+  it("does not fall back to agents.defaults.workspace or ~/.openclaw/workspace-devclaw", () => {
+    const filePath = path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "attachment-hook.ts",
+    );
+    const src = fs.readFileSync(filePath, "utf-8");
+
+    assert.match(src, /resolveRuntimeWorkspace\(/, "should use canonical resolver");
+    assert.doesNotMatch(src, /agents\.defaults\.workspace/, "should not reference agents.defaults.workspace");
+    assert.doesNotMatch(src, /workspace-devclaw/, "should not reference hardcoded workspace-devclaw fallback");
+  });
+});

--- a/lib/dispatch/attachment-hook.ts
+++ b/lib/dispatch/attachment-hook.ts
@@ -8,8 +8,8 @@
  * Listens for incoming messages with media and issue references (#N).
  * When both are present, reads the local file and associates it with the issue.
  */
-import { homedir } from "node:os";
-import path from "node:path";
+import { resolveRuntimeWorkspace } from "../runtime/workspace-resolution.js";
+import { logGlobal as auditLogGlobal } from "../audit.js";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { PluginContext } from "../context.js";
 import {
@@ -50,18 +50,6 @@ async function resolveProjectFromChannel(
 }
 
 /**
- * Resolve the workspace directory from OpenClaw config.
- * Checks agents.defaults.workspace, then falls back to ~/.openclaw/workspace-devclaw.
- */
-function resolveWorkspaceDir(config: Record<string, unknown>): string | null {
-  const agents = config.agents as { defaults?: { workspace?: string }; list?: Array<{ id: string; workspace?: string }> } | undefined;
-  if (agents?.defaults?.workspace) return agents.defaults.workspace;
-  const devclaw = agents?.list?.find((a) => a.id === "devclaw");
-  if (devclaw?.workspace) return devclaw.workspace;
-  return path.join(homedir(), ".openclaw", "workspace-devclaw");
-}
-
-/**
  * Register the message_received hook for attachment handling.
  *
  * Channel-agnostic: OpenClaw downloads media from all channels and stores
@@ -80,9 +68,21 @@ export function registerAttachmentHook(api: OpenClawPluginApi, ctx: PluginContex
     const issueIds = extractIssueReferences(event.content ?? "");
     if (issueIds.length === 0) return;
 
-    // Resolve workspace directory
-    const workspaceDir = resolveWorkspaceDir(ctx.config as unknown as Record<string, unknown>);
-    if (!workspaceDir) return;
+    // Resolve DevClaw runtime workspace binding (fail closed)
+    const resolution = resolveRuntimeWorkspace({
+      config: ctx.config as any,
+      pluginConfig: ctx.pluginConfig,
+      requireExists: true,
+    });
+    if (!resolution.ok) {
+      ctx.logger.error(`Attachment hook skipped: ${resolution.error}`);
+      await auditLogGlobal("attachment_hook_skipped", {
+        reason: resolution.error,
+      }).catch(() => {});
+      return;
+    }
+
+    const workspaceDir = resolution.workspaceDir;
 
     const conversationId = eventCtx.conversationId;
     if (!conversationId) return;

--- a/lib/dispatch/bootstrap-hook.test.ts
+++ b/lib/dispatch/bootstrap-hook.test.ts
@@ -81,11 +81,11 @@ describe("loadRoleInstructions", () => {
     await fs.rm(tmpDir, { recursive: true });
   });
 
-  it("should return empty string when no instructions exist", async () => {
+  it("should fall back to package default instructions when no workspace instructions exist", async () => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-test-"));
 
     const result = await loadRoleInstructions(tmpDir, "missing", "developer");
-    assert.strictEqual(result, "");
+    assert.ok(result.includes("# DEVELOPER Worker Instructions"));
 
     await fs.rm(tmpDir, { recursive: true });
   });

--- a/lib/dispatch/index.acceptance-gating.test.ts
+++ b/lib/dispatch/index.acceptance-gating.test.ts
@@ -1,0 +1,264 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { dispatchTask } from "./index.js";
+import { createTestHarness } from "../testing/index.js";
+
+function withAgentStatus(
+  base: any,
+  status: "accepted" | "deduped" | "rejected" | "unavailable" | "timeout",
+) {
+  return (async (argv: string[], opts: any) => {
+    if (
+      argv[0] === "openclaw" &&
+      argv[1] === "gateway" &&
+      argv[2] === "call" &&
+      argv[3] === "agent"
+    ) {
+      if (status === "timeout")
+        throw new Error("gateway timeout while waiting for final event");
+      return {
+        stdout: JSON.stringify({ status, runId: `run-${status}` }),
+        stderr: "",
+        code: 0,
+        signal: null,
+        killed: false,
+      };
+    }
+    return base(argv, opts);
+  }) as any;
+}
+
+describe("dispatchTask acceptance gating", () => {
+  it("keeps issue in To Do and slot inactive when dispatch is deduped", async () => {
+    const h = await createTestHarness();
+    try {
+      h.provider.seedIssue({
+        iid: 21,
+        title: "Gate dispatch",
+        labels: ["To Do"],
+      });
+
+      await assert.rejects(
+        () =>
+          dispatchTask({
+            workspaceDir: h.workspaceDir,
+            project: h.project,
+            issueId: 21,
+            issueTitle: "Gate dispatch",
+            issueDescription: "",
+            issueUrl: "https://example.com/issues/21",
+            role: "developer",
+            level: "medior",
+            fromLabel: "To Do",
+            toLabel: "Doing",
+            provider: h.provider,
+            runCommand: withAgentStatus(h.runCommand, "deduped"),
+          }),
+        /dispatch deduped/i,
+      );
+
+      const issue = await h.provider.getIssue(21);
+      assert.ok(issue.labels.includes("To Do"));
+      assert.ok(!issue.labels.includes("Doing"));
+    } finally {
+      await h.cleanup();
+    }
+  });
+
+  it("increments idempotency nonce across failed attempts", async () => {
+    const h = await createTestHarness();
+    const seenKeys: string[] = [];
+    const rc = (async (argv: string[], opts: any) => {
+      if (
+        argv[0] === "openclaw" &&
+        argv[1] === "gateway" &&
+        argv[2] === "call" &&
+        argv[3] === "agent"
+      ) {
+        const params = JSON.parse(argv[argv.indexOf("--params") + 1]!);
+        seenKeys.push(params.idempotencyKey);
+        return {
+          stdout: JSON.stringify({ status: "deduped" }),
+          stderr: "",
+          code: 0,
+          signal: null,
+          killed: false,
+        };
+      }
+      return h.runCommand(argv, opts);
+    }) as any;
+
+    try {
+      h.provider.seedIssue({
+        iid: 24,
+        title: "nonce retry",
+        labels: ["To Do"],
+      });
+      await assert.rejects(() =>
+        dispatchTask({
+          workspaceDir: h.workspaceDir,
+          project: h.project,
+          issueId: 24,
+          issueTitle: "nonce retry",
+          issueDescription: "",
+          issueUrl: "https://example.com/issues/24",
+          role: "developer",
+          level: "medior",
+          fromLabel: "To Do",
+          toLabel: "Doing",
+          provider: h.provider,
+          runCommand: rc,
+        }),
+      );
+      await assert.rejects(() =>
+        dispatchTask({
+          workspaceDir: h.workspaceDir,
+          project: h.project,
+          issueId: 24,
+          issueTitle: "nonce retry",
+          issueDescription: "",
+          issueUrl: "https://example.com/issues/24",
+          role: "developer",
+          level: "medior",
+          fromLabel: "To Do",
+          toLabel: "Doing",
+          provider: h.provider,
+          runCommand: rc,
+        }),
+      );
+
+      assert.strictEqual(seenKeys.length, 2);
+      assert.notStrictEqual(seenKeys[0], seenKeys[1]);
+    } finally {
+      await h.cleanup();
+    }
+  });
+
+  it("marks slot active when label transition fails after acceptance", async () => {
+    const h = await createTestHarness();
+    try {
+      h.provider.seedIssue({
+        iid: 25,
+        title: "transition fail",
+        labels: ["To Do"],
+      });
+      const originalTransition = h.provider.transitionLabel.bind(h.provider);
+      h.provider.transitionLabel = async (
+        issueId: number,
+        from: any,
+        to: any,
+      ) => {
+        if (issueId === 25 && from === "To Do" && to === "Doing") {
+          throw new Error("provider outage");
+        }
+        return originalTransition(issueId, from, to);
+      };
+
+      await assert.rejects(
+        () =>
+          dispatchTask({
+            workspaceDir: h.workspaceDir,
+            project: h.project,
+            issueId: 25,
+            issueTitle: "transition fail",
+            issueDescription: "",
+            issueUrl: "https://example.com/issues/25",
+            role: "developer",
+            level: "medior",
+            fromLabel: "To Do",
+            toLabel: "Doing",
+            provider: h.provider,
+            runCommand: withAgentStatus(h.runCommand, "accepted"),
+          }),
+        /dispatch accepted but failed to transition/i,
+      );
+
+      const slot = h.project.workers.developer?.levels.medior?.[0];
+      assert.ok(
+        slot?.active,
+        "slot should be marked active after accepted dispatch",
+      );
+      assert.strictEqual(slot?.issueId, "25");
+
+      const issue = await h.provider.getIssue(25);
+      assert.ok(issue.labels.includes("To Do"));
+      assert.ok(!issue.labels.includes("Doing"));
+    } finally {
+      await h.cleanup();
+    }
+  });
+
+  for (const status of ["rejected", "unavailable", "timeout"] as const) {
+    it(`keeps issue in To Do when dispatch is ${status}`, async () => {
+      const h = await createTestHarness();
+      try {
+        h.provider.seedIssue({
+          iid: 22,
+          title: `Status ${status}`,
+          labels: ["To Do"],
+        });
+
+        await assert.rejects(
+          () =>
+            dispatchTask({
+              workspaceDir: h.workspaceDir,
+              project: h.project,
+              issueId: 22,
+              issueTitle: `Status ${status}`,
+              issueDescription: "",
+              issueUrl: "https://example.com/issues/22",
+              role: "developer",
+              level: "medior",
+              fromLabel: "To Do",
+              toLabel: "Doing",
+              provider: h.provider,
+              runCommand: withAgentStatus(h.runCommand, status),
+            }),
+          new RegExp(`dispatch ${status}`, "i"),
+        );
+
+        const issue = await h.provider.getIssue(22);
+        assert.ok(
+          issue.labels.includes("To Do"),
+          `labels: ${issue.labels.join(",")}`,
+        );
+        assert.ok(!issue.labels.includes("Doing"));
+      } finally {
+        await h.cleanup();
+      }
+    });
+  }
+
+  it("transitions to Doing only after accepted response", async () => {
+    const h = await createTestHarness();
+    try {
+      h.provider.seedIssue({
+        iid: 23,
+        title: "Accepted path",
+        labels: ["To Do"],
+      });
+
+      const out = await dispatchTask({
+        workspaceDir: h.workspaceDir,
+        project: h.project,
+        issueId: 23,
+        issueTitle: "Accepted path",
+        issueDescription: "",
+        issueUrl: "https://example.com/issues/23",
+        role: "developer",
+        level: "medior",
+        fromLabel: "To Do",
+        toLabel: "Doing",
+        provider: h.provider,
+        runCommand: withAgentStatus(h.runCommand, "accepted"),
+      });
+
+      assert.ok(out.sessionKey);
+      const issue = await h.provider.getIssue(23);
+      assert.ok(issue.labels.includes("Doing"));
+      assert.ok(!issue.labels.includes("To Do"));
+    } finally {
+      await h.cleanup();
+    }
+  });
+});

--- a/lib/dispatch/index.ts
+++ b/lib/dispatch/index.ts
@@ -17,14 +17,43 @@ import {
 import { resolveModel } from "../roles/index.js";
 import { notify, getNotificationConfig } from "./notify.js";
 import { loadConfig, type ResolvedRoleConfig } from "../config/index.js";
-import { ReviewPolicy, TestPolicy, resolveReviewRouting, resolveTestRouting, resolveNotifyChannel, isFeedbackState, hasReviewCheck, producesReviewableWork, hasTestPhase, detectOwner, getOwnerLabel, OWNER_LABEL_COLOR, getRoleLabelColor, STEP_ROUTING_COLOR, getStateLabels } from "../workflow/index.js";
-import { fetchPrFeedback, fetchPrContext, type PrFeedback, type PrContext } from "./pr-context.js";
+import {
+  ReviewPolicy,
+  TestPolicy,
+  resolveReviewRouting,
+  resolveTestRouting,
+  resolveNotifyChannel,
+  isFeedbackState,
+  hasReviewCheck,
+  producesReviewableWork,
+  hasTestPhase,
+  detectOwner,
+  getOwnerLabel,
+  OWNER_LABEL_COLOR,
+  getRoleLabelColor,
+  STEP_ROUTING_COLOR,
+} from "../workflow/index.js";
+import {
+  fetchPrFeedback,
+  fetchPrContext,
+  type PrFeedback,
+  type PrContext,
+} from "./pr-context.js";
 import { formatAttachmentsForTask } from "./attachments.js";
 import { loadRoleInstructions } from "./bootstrap-hook.js";
 import { slotName } from "../names.js";
 
-import { buildTaskMessage, buildConflictFixMessage, buildAnnouncement, formatSessionLabel } from "./message-builder.js";
-import { ensureSessionFireAndForget, sendToAgent, shouldClearSession } from "./session.js";
+import {
+  buildTaskMessage,
+  buildAnnouncement,
+  formatSessionLabel,
+} from "./message-builder.js";
+import {
+  ensureSessionFireAndForget,
+  sendToAgent,
+  shouldClearSession,
+  type DispatchAcceptance,
+} from "./session.js";
 import { acknowledgeComments, EYES_EMOJI } from "./acknowledge.js";
 
 export type DispatchOpts = {
@@ -84,9 +113,20 @@ export async function dispatchTask(
   opts: DispatchOpts,
 ): Promise<DispatchResult> {
   const {
-    workspaceDir, agentId, project, issueId, issueTitle,
-    issueDescription, issueUrl, role, level, fromLabel, toLabel,
-    provider, pluginConfig, runtime,
+    workspaceDir,
+    agentId,
+    project,
+    issueId,
+    issueTitle,
+    issueDescription,
+    issueUrl,
+    role,
+    level,
+    fromLabel,
+    toLabel,
+    provider,
+    pluginConfig,
+    runtime,
   } = opts;
 
   const slotIndex = opts.slotIndex ?? 0;
@@ -101,24 +141,18 @@ export async function dispatchTask(
   const slot = roleWorker.levels[level]?.[slotIndex] ?? emptySlot();
   let existingSessionKey = slot.sessionKey;
 
-  // Deactivated slot (issueId null) means session belongs to a previous issue — don't reuse
-  if (existingSessionKey && !slot.issueId) {
-    rc(
-      ["openclaw", "gateway", "call", "sessions.delete", "--params", JSON.stringify({ key: existingSessionKey })],
-      { timeoutMs: 10_000 },
-    ).catch(() => {});
-    existingSessionKey = null;
-  }
-
   // Context budget check: clear session if over budget (unless same issue — feedback cycle)
   if (existingSessionKey && timeouts.sessionContextBudget < 1) {
-    const shouldClear = await shouldClearSession(existingSessionKey, slot.issueId, issueId, timeouts, workspaceDir, project.name, rc);
+    const shouldClear = await shouldClearSession(
+      existingSessionKey,
+      slot.issueId,
+      issueId,
+      timeouts,
+      workspaceDir,
+      project.name,
+      rc,
+    );
     if (shouldClear) {
-      // Delete the gateway session (fire-and-forget)
-      rc(
-        ["openclaw", "gateway", "call", "sessions.delete", "--params", JSON.stringify({ key: existingSessionKey })],
-        { timeoutMs: 10_000 },
-      ).catch(() => {});
       await updateSlot(workspaceDir, project.slug, role, level, slotIndex, {
         sessionKey: null,
       });
@@ -136,7 +170,14 @@ export async function dispatchTask(
   if (existingSessionKey && existingSessionKey !== sessionKey) {
     // Delete the orphaned gateway session (fire-and-forget)
     rc(
-      ["openclaw", "gateway", "call", "sessions.delete", "--params", JSON.stringify({ key: existingSessionKey })],
+      [
+        "openclaw",
+        "gateway",
+        "call",
+        "sessions.delete",
+        "--params",
+        JSON.stringify({ key: existingSessionKey }),
+      ],
       { timeoutMs: 10_000 },
     ).catch(() => {});
     existingSessionKey = null;
@@ -151,42 +192,169 @@ export async function dispatchTask(
   // Fetch PR context based on workflow role semantics (no hardcoded role/label checks)
   const { workflow } = resolvedConfig;
   const prFeedback = isFeedbackState(workflow, fromLabel)
-    ? await fetchPrFeedback(provider, issueId) : undefined;
+    ? await fetchPrFeedback(provider, issueId)
+    : undefined;
   const prContext = hasReviewCheck(workflow, role)
-    ? await fetchPrContext(provider, issueId) : undefined;
+    ? await fetchPrContext(provider, issueId)
+    : undefined;
 
   // Fetch attachment context (best-effort — never blocks dispatch)
   let attachmentContext: string | undefined;
   try {
-    attachmentContext = await formatAttachmentsForTask(workspaceDir, project.slug, issueId) || undefined;
-  } catch { /* best-effort */ }
+    attachmentContext =
+      (await formatAttachmentsForTask(workspaceDir, project.slug, issueId)) ||
+      undefined;
+  } catch {
+    /* best-effort */
+  }
 
   const primaryChannelId = project.channels[0]?.channelId ?? project.slug;
-  const isConflictFix = prFeedback?.reason === "merge_conflict";
-  const taskMessage = isConflictFix && prFeedback
-    ? buildConflictFixMessage({
-        projectName: project.name, channelId: primaryChannelId, role, issueId,
-        issueTitle, issueUrl,
-        repo: project.repo, baseBranch: project.baseBranch,
-        resolvedRole, prFeedback,
-      })
-    : buildTaskMessage({
-        projectName: project.name, channelId: primaryChannelId, role, issueId,
-        issueTitle, issueDescription, issueUrl,
-        repo: project.repo, baseBranch: project.baseBranch,
-        comments, resolvedRole, prContext, prFeedback, attachmentContext,
-      });
+  const taskMessage = buildTaskMessage({
+    projectName: project.name,
+    channelId: primaryChannelId,
+    role,
+    issueId,
+    issueTitle,
+    issueDescription,
+    issueUrl,
+    repo: project.repo,
+    baseBranch: project.baseBranch,
+    comments,
+    resolvedRole,
+    prContext,
+    prFeedback,
+    attachmentContext,
+  });
 
   // Load role-specific instructions to inject into the worker's system prompt
-  const roleInstructions = await loadRoleInstructions(workspaceDir, project.name, role);
+  const roleInstructions = await loadRoleInstructions(
+    workspaceDir,
+    project.name,
+    role,
+  );
 
-  // ── Commitment point — transition label (issue leaves queue) ────────
-  await provider.transitionLabel(issueId, fromLabel, toLabel);
+  await auditLog(workspaceDir, "dispatch_attempt", {
+    project: project.name,
+    issue: issueId,
+    issueTitle,
+    role,
+    level,
+    sessionAction,
+    sessionKey,
+    fromLabel,
+    toLabel,
+    dispatchAttempt,
+  });
+
+  // Step 1: Ensure session exists (fire-and-forget)
+  const sessionLabel = formatSessionLabel(project.name, role, level, botName);
+  ensureSessionFireAndForget(
+    sessionKey,
+    model,
+    workspaceDir,
+    rc,
+    timeouts.sessionPatchMs,
+    sessionLabel,
+  );
+
+  // Step 2 (phase A): Attempt dispatch and require explicit acceptance
+  const acceptance = await sendToAgent(sessionKey, taskMessage, {
+    agentId,
+    projectName: project.name,
+    issueId,
+    role,
+    level,
+    slotIndex,
+    dispatchAttempt,
+    orchestratorSessionKey: opts.sessionKey,
+    workspaceDir,
+    dispatchTimeoutMs: timeouts.dispatchMs,
+    extraSystemPrompt: roleInstructions.trim() || undefined,
+    model,
+    runCommand: rc,
+  });
+
+  if (!acceptance.accepted) {
+    // Persist nonce progression so retries use a fresh idempotency key.
+    setInMemoryDispatchAttempt(
+      project,
+      role,
+      level,
+      slotIndex,
+      dispatchAttempt,
+    );
+    await updateSlot(workspaceDir, project.slug, role, level, slotIndex, {
+      dispatchAttempt,
+    }).catch(() => {});
+    await auditDispatchFailure(workspaceDir, {
+      project: project.name,
+      issueId,
+      role,
+      level,
+      fromLabel,
+      toLabel,
+      sessionKey,
+      dispatchAttempt,
+      acceptance,
+    });
+    throw new Error(
+      `dispatch ${acceptance.status}: ${acceptance.reason || "worker did not accept task"}`,
+    );
+  }
+
+  // Step 3 (phase B): transition label now that acceptance is confirmed
+  try {
+    await provider.transitionLabel(issueId, fromLabel, toLabel);
+  } catch (err) {
+    // Worker already accepted task. Mark slot active anyway to prevent duplicate pickups.
+    setInMemoryActiveState(project, role, level, slotIndex, {
+      issueId,
+      sessionKey,
+      previousLabel: fromLabel,
+      name: botName,
+      dispatchAttempt,
+    });
+    try {
+      await recordWorkerState(workspaceDir, project.slug, role, slotIndex, {
+        issueId,
+        level,
+        sessionKey,
+        sessionAction,
+        fromLabel,
+        name: botName,
+        dispatchAttempt,
+      });
+    } catch (stateErr) {
+      await auditLog(workspaceDir, "dispatch_warning", {
+        step: "recordWorkerState_after_transition_failure",
+        issue: issueId,
+        role,
+        sessionKey,
+        error: (stateErr as Error).message ?? String(stateErr),
+      });
+    }
+    await auditLog(workspaceDir, "dispatch_warning", {
+      step: "transitionLabel_after_accept",
+      issue: issueId,
+      role,
+      sessionKey,
+      error: (err as Error).message ?? String(err),
+    });
+    throw new Error(
+      `dispatch accepted but failed to transition ${fromLabel} → ${toLabel}: ${(err as Error).message ?? String(err)}`,
+    );
+  }
 
   // Mark issue + PR as managed and all consumed comments as seen (fire-and-forget)
   provider.reactToIssue(issueId, EYES_EMOJI).catch(() => {});
   provider.reactToPr(issueId, EYES_EMOJI).catch(() => {});
-  acknowledgeComments(provider, issueId, comments, prFeedback, workspaceDir).catch((err) => {
+  acknowledgeComments(
+    provider,
+    issueId,
+    comments,
+    prFeedback,
+    workspaceDir,
+  ).catch((err) => {
     auditLog(workspaceDir, "dispatch_warning", {
       step: "acknowledgeComments",
       issue: issueId,
@@ -195,48 +363,41 @@ export async function dispatchTask(
   });
 
   // Apply role:level label (best-effort — failure must not abort dispatch)
-  // IMPORTANT: Never pass state labels to removeLabels() — state transitions are
-  // handled exclusively by transitionLabel(). Accidentally removing a state label
-  // makes the issue invisible to the queue scanner. See #473 for context.
   let issue: { labels: string[] } | undefined;
   try {
     issue = await provider.getIssue(issueId);
-    const stateLabels = getStateLabels(workflow);
-
     const oldRoleLabels = issue.labels.filter((l) => l.startsWith(`${role}:`));
-    const safeRoleLabels = filterNonStateLabels(oldRoleLabels, stateLabels);
-    if (safeRoleLabels.length > 0) {
-      await provider.removeLabels(issueId, safeRoleLabels);
+    if (oldRoleLabels.length > 0) {
+      await provider.removeLabels(issueId, oldRoleLabels);
     }
     const roleLabel = `${role}:${level}:${botName}`;
     await provider.ensureLabel(roleLabel, getRoleLabelColor(role));
     await provider.addLabel(issueId, roleLabel);
 
-    // Apply review routing label when role produces reviewable work (best-effort)
     if (producesReviewableWork(workflow, role)) {
       const reviewLabel = resolveReviewRouting(
-        workflow.reviewPolicy ?? ReviewPolicy.HUMAN, level,
+        workflow.reviewPolicy ?? ReviewPolicy.HUMAN,
+        level,
       );
       const oldRouting = issue.labels.filter((l) => l.startsWith("review:"));
-      const safeRouting = filterNonStateLabels(oldRouting, stateLabels);
-      if (safeRouting.length > 0) await provider.removeLabels(issueId, safeRouting);
+      if (oldRouting.length > 0)
+        await provider.removeLabels(issueId, oldRouting);
       await provider.ensureLabel(reviewLabel, STEP_ROUTING_COLOR);
       await provider.addLabel(issueId, reviewLabel);
     }
 
-    // Apply test routing label when workflow has a test phase (best-effort)
     if (hasTestPhase(workflow)) {
       const testLabel = resolveTestRouting(
-        workflow.testPolicy ?? TestPolicy.SKIP, level,
+        workflow.testPolicy ?? TestPolicy.SKIP,
+        level,
       );
       const oldTestRouting = issue.labels.filter((l) => l.startsWith("test:"));
-      const safeTestRouting = filterNonStateLabels(oldTestRouting, stateLabels);
-      if (safeTestRouting.length > 0) await provider.removeLabels(issueId, safeTestRouting);
+      if (oldTestRouting.length > 0)
+        await provider.removeLabels(issueId, oldTestRouting);
       await provider.ensureLabel(testLabel, STEP_ROUTING_COLOR);
       await provider.addLabel(issueId, testLabel);
     }
 
-    // Apply owner label if issue is unclaimed (auto-claim on pickup)
     if (opts.instanceName && !detectOwner(issue.labels)) {
       const ownerLabel = getOwnerLabel(opts.instanceName);
       await provider.ensureLabel(ownerLabel, OWNER_LABEL_COLOR);
@@ -246,10 +407,12 @@ export async function dispatchTask(
     // Best-effort — label failure must not abort dispatch
   }
 
-  // Step 2: Send notification early (before session dispatch which can timeout)
-  // This ensures users see the notification even if gateway is slow
+  // Step 4: Worker-start notification only after acceptance+transition
   const notifyConfig = getNotificationConfig(pluginConfig);
-  const notifyTarget = resolveNotifyChannel(issue?.labels ?? [], project.channels);
+  const notifyTarget = resolveNotifyChannel(
+    issue?.labels ?? [],
+    project.channels,
+  );
   notify(
     {
       type: "workerStart",
@@ -273,57 +436,140 @@ export async function dispatchTask(
     },
   ).catch((err) => {
     auditLog(workspaceDir, "dispatch_warning", {
-      step: "notify", issue: issueId, role,
+      step: "notify",
+      issue: issueId,
+      role,
       error: (err as Error).message ?? String(err),
     }).catch(() => {});
-  });
-
-  // Step 3: Ensure session exists (fire-and-forget — don't wait for gateway)
-  // Session key is deterministic, so we can proceed immediately
-  const sessionLabel = formatSessionLabel(project.name, role, level, botName);
-  ensureSessionFireAndForget(sessionKey, model, workspaceDir, rc, timeouts.sessionPatchMs, sessionLabel);
-
-  // Step 4: Send task to agent (fire-and-forget)
-  // Model is set on the session via sessions.patch (step 3), not on the agent RPC —
-  // the gateway's agent endpoint rejects unknown properties like 'model'.
-  sendToAgent(sessionKey, taskMessage, {
-    agentId, projectName: project.name, issueId, role, level, slotIndex,
-    dispatchAttempt,
-    orchestratorSessionKey: opts.sessionKey, workspaceDir,
-    dispatchTimeoutMs: timeouts.dispatchMs,
-    extraSystemPrompt: roleInstructions.trim() || undefined,
-    runCommand: rc,
   });
 
   // Step 5: Update worker state
   try {
     await recordWorkerState(workspaceDir, project.slug, role, slotIndex, {
-      issueId, level, sessionKey, sessionAction, fromLabel, name: botName, dispatchAttempt,
+      issueId,
+      level,
+      sessionKey,
+      sessionAction,
+      fromLabel,
+      name: botName,
+      dispatchAttempt,
     });
   } catch (err) {
     // Session is already dispatched — log warning but don't fail
     await auditLog(workspaceDir, "dispatch", {
-      project: project.name, issue: issueId, role,
+      project: project.name,
+      issue: issueId,
+      role,
       warning: "State update failed after successful dispatch",
-      error: (err as Error).message, sessionKey,
+      error: (err as Error).message,
+      sessionKey,
     });
   }
 
   // Step 6: Audit
   await auditDispatch(workspaceDir, {
-    project: project.name, issueId, issueTitle,
-    role, level, model, sessionAction, sessionKey,
-    fromLabel, toLabel,
+    project: project.name,
+    issueId,
+    issueTitle,
+    role,
+    level,
+    model,
+    sessionAction,
+    sessionKey,
+    fromLabel,
+    toLabel,
   });
 
-  const announcement = buildAnnouncement(level, role, sessionAction, issueId, issueTitle, issueUrl, resolvedRole, botName);
+  const announcement = buildAnnouncement(
+    level,
+    role,
+    sessionAction,
+    issueId,
+    issueTitle,
+    issueUrl,
+    resolvedRole,
+    botName,
+  );
 
   return { sessionAction, sessionKey, level, model, announcement };
 }
 
+function ensureInMemorySlot(
+  project: Project,
+  role: string,
+  level: string,
+  slotIndex: number,
+): {
+  active: boolean;
+  issueId: string | null;
+  sessionKey: string | null;
+  startTime: string | null;
+  previousLabel?: string | null;
+  name?: string;
+  dispatchAttempt?: number;
+} {
+  if (!project.workers[role]) project.workers[role] = { levels: {} };
+  if (!project.workers[role]!.levels[level])
+    project.workers[role]!.levels[level] = [];
+  const slots = project.workers[role]!.levels[level]!;
+  while (slots.length <= slotIndex)
+    slots.push({
+      active: false,
+      issueId: null,
+      sessionKey: null,
+      startTime: null,
+    });
+  return slots[slotIndex]!;
+}
+
+function setInMemoryDispatchAttempt(
+  project: Project,
+  role: string,
+  level: string,
+  slotIndex: number,
+  dispatchAttempt: number,
+): void {
+  const slot = ensureInMemorySlot(project, role, level, slotIndex);
+  slot.dispatchAttempt = dispatchAttempt;
+}
+
+function setInMemoryActiveState(
+  project: Project,
+  role: string,
+  level: string,
+  slotIndex: number,
+  opts: {
+    issueId: number;
+    sessionKey: string;
+    previousLabel?: string;
+    name?: string;
+    dispatchAttempt: number;
+  },
+): void {
+  const slot = ensureInMemorySlot(project, role, level, slotIndex);
+  slot.active = true;
+  slot.issueId = String(opts.issueId);
+  slot.sessionKey = opts.sessionKey;
+  slot.startTime = new Date().toISOString();
+  slot.previousLabel = opts.previousLabel;
+  slot.name = opts.name;
+  slot.dispatchAttempt = opts.dispatchAttempt;
+}
+
 async function recordWorkerState(
-  workspaceDir: string, slug: string, role: string, slotIndex: number,
-  opts: { issueId: number; level: string; sessionKey: string; sessionAction: "spawn" | "send"; fromLabel?: string; name?: string; dispatchAttempt: number },
+  workspaceDir: string,
+  slug: string,
+  role: string,
+  slotIndex: number,
+  opts: {
+    issueId: number;
+    level: string;
+    sessionKey: string;
+    sessionAction: "spawn" | "send";
+    fromLabel?: string;
+    name?: string;
+    dispatchAttempt: number;
+  },
 ): Promise<void> {
   await activateWorker(workspaceDir, slug, role, {
     issueId: String(opts.issueId),
@@ -337,31 +583,79 @@ async function recordWorkerState(
   });
 }
 
-/**
- * Filter out state labels from a label array to prevent accidental state loss.
- * State labels should only be modified via transitionLabel(). See #473.
- */
-function filterNonStateLabels(labels: string[], stateLabels: string[]): string[] {
-  return labels.filter((l) => !stateLabels.includes(l));
-}
-
 async function auditDispatch(
   workspaceDir: string,
   opts: {
-    project: string; issueId: number; issueTitle: string;
-    role: string; level: string; model: string; sessionAction: string;
-    sessionKey: string; fromLabel: string; toLabel: string;
+    project: string;
+    issueId: number;
+    issueTitle: string;
+    role: string;
+    level: string;
+    model: string;
+    sessionAction: string;
+    sessionKey: string;
+    fromLabel: string;
+    toLabel: string;
   },
 ): Promise<void> {
+  await auditLog(workspaceDir, "dispatch_accepted", {
+    project: opts.project,
+    issue: opts.issueId,
+    issueTitle: opts.issueTitle,
+    role: opts.role,
+    level: opts.level,
+    sessionAction: opts.sessionAction,
+    sessionKey: opts.sessionKey,
+    labelTransition: `${opts.fromLabel} → ${opts.toLabel}`,
+  });
   await auditLog(workspaceDir, "dispatch", {
     project: opts.project,
-    issue: opts.issueId, issueTitle: opts.issueTitle,
-    role: opts.role, level: opts.level,
-    sessionAction: opts.sessionAction, sessionKey: opts.sessionKey,
+    issue: opts.issueId,
+    issueTitle: opts.issueTitle,
+    role: opts.role,
+    level: opts.level,
+    sessionAction: opts.sessionAction,
+    sessionKey: opts.sessionKey,
     labelTransition: `${opts.fromLabel} → ${opts.toLabel}`,
   });
   await auditLog(workspaceDir, "model_selection", {
-    issue: opts.issueId, role: opts.role, level: opts.level, model: opts.model,
+    issue: opts.issueId,
+    role: opts.role,
+    level: opts.level,
+    model: opts.model,
   });
 }
 
+async function auditDispatchFailure(
+  workspaceDir: string,
+  opts: {
+    project: string;
+    issueId: number;
+    role: string;
+    level: string;
+    fromLabel: string;
+    toLabel: string;
+    sessionKey: string;
+    dispatchAttempt: number;
+    acceptance: DispatchAcceptance;
+  },
+): Promise<void> {
+  const event =
+    opts.acceptance.status === "rejected" ||
+    opts.acceptance.status === "deduped"
+      ? "dispatch_rejected"
+      : "dispatch_failed";
+  await auditLog(workspaceDir, event, {
+    project: opts.project,
+    issue: opts.issueId,
+    role: opts.role,
+    level: opts.level,
+    sessionKey: opts.sessionKey,
+    dispatchAttempt: opts.dispatchAttempt,
+    fromLabel: opts.fromLabel,
+    toLabel: opts.toLabel,
+    status: opts.acceptance.status,
+    runId: opts.acceptance.runId,
+    reason: opts.acceptance.reason,
+  });
+}

--- a/lib/dispatch/index.ts
+++ b/lib/dispatch/index.ts
@@ -478,6 +478,7 @@ export async function dispatchTask(
     sessionKey,
     fromLabel,
     toLabel,
+    acceptanceMode: acceptance.mode,
   });
 
   const announcement = buildAnnouncement(
@@ -596,6 +597,7 @@ async function auditDispatch(
     sessionKey: string;
     fromLabel: string;
     toLabel: string;
+    acceptanceMode?: DispatchAcceptance["mode"];
   },
 ): Promise<void> {
   await auditLog(workspaceDir, "dispatch_accepted", {
@@ -607,6 +609,7 @@ async function auditDispatch(
     sessionAction: opts.sessionAction,
     sessionKey: opts.sessionKey,
     labelTransition: `${opts.fromLabel} → ${opts.toLabel}`,
+    acceptanceMode: opts.acceptanceMode,
   });
   await auditLog(workspaceDir, "dispatch", {
     project: opts.project,
@@ -617,6 +620,7 @@ async function auditDispatch(
     sessionAction: opts.sessionAction,
     sessionKey: opts.sessionKey,
     labelTransition: `${opts.fromLabel} → ${opts.toLabel}`,
+    acceptanceMode: opts.acceptanceMode,
   });
   await auditLog(workspaceDir, "model_selection", {
     issue: opts.issueId,
@@ -657,5 +661,6 @@ async function auditDispatchFailure(
     status: opts.acceptance.status,
     runId: opts.acceptance.runId,
     reason: opts.acceptance.reason,
+    acceptanceMode: opts.acceptance.mode,
   });
 }

--- a/lib/dispatch/pr-context.test.ts
+++ b/lib/dispatch/pr-context.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from "vitest";
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
 import { formatPrFeedback, type PrFeedback } from "./pr-context.js";
 
 describe("formatPrFeedback", () => {
@@ -10,7 +11,7 @@ describe("formatPrFeedback", () => {
       comments: [],
     };
     const result = formatPrFeedback(feedback, "main");
-    expect(result).toEqual([]);
+    assert.deepEqual(result, []);
   });
 
   it("includes branch name in conflict resolution instructions", () => {
@@ -30,10 +31,10 @@ describe("formatPrFeedback", () => {
     const result = formatPrFeedback(feedback, "main");
     const text = result.join("\n");
 
-    expect(text).toContain("feature/456-test");
-    expect(text).toContain("🔹 Branch: `feature/456-test`");
-    expect(text).toContain("git checkout feature/456-test");
-    expect(text).toContain("git push --force-with-lease origin feature/456-test");
+    assert.ok(text.includes("feature/456-test"));
+    assert.ok(text.includes("🔹 Branch: `feature/456-test`"));
+    assert.ok(text.includes("git checkout feature/456-test"));
+    assert.ok(text.includes("git push --force-with-lease origin feature/456-test"));
   });
 
   it("uses fallback branch name when not provided", () => {
@@ -52,8 +53,8 @@ describe("formatPrFeedback", () => {
     const result = formatPrFeedback(feedback, "main");
     const text = result.join("\n");
 
-    expect(text).toContain("your-branch");
-    expect(text).toContain("🔹 Branch: `your-branch`");
+    assert.ok(text.includes("your-branch"));
+    assert.ok(text.includes("🔹 Branch: `your-branch`"));
   });
 
   it("includes step-by-step instructions for conflict resolution", () => {
@@ -73,17 +74,15 @@ describe("formatPrFeedback", () => {
     const result = formatPrFeedback(feedback, "develop");
     const text = result.join("\n");
 
-    // Check all steps are present
-    expect(text).toContain("1. Fetch and check out the PR branch");
-    expect(text).toContain("2. Rebase onto `develop`");
-    expect(text).toContain("3. Resolve any conflicts");
-    expect(text).toContain("4. Force-push to the SAME branch");
-    expect(text).toContain("5. Verify the PR shows as mergeable");
+    assert.ok(text.includes("1. Fetch and check out the PR branch"));
+    assert.ok(text.includes("2. Rebase onto `develop`"));
+    assert.ok(text.includes("3. Resolve any conflicts"));
+    assert.ok(text.includes("4. Force-push to the SAME branch"));
+    assert.ok(text.includes("5. Verify the PR shows as mergeable"));
 
-    // Check warning about not creating new PR
-    expect(text).toContain("⚠️ Do NOT create a new PR");
-    expect(text).toContain("Do NOT switch branches");
-    expect(text).toContain("Update THIS PR only");
+    assert.ok(text.includes("⚠️ Do NOT create a new PR"));
+    assert.ok(text.includes("Do NOT switch branches"));
+    assert.ok(text.includes("Update THIS PR only"));
   });
 
   it("correctly formats changes_requested feedback", () => {
@@ -103,10 +102,9 @@ describe("formatPrFeedback", () => {
     const result = formatPrFeedback(feedback, "main");
     const text = result.join("\n");
 
-    expect(text).toContain("⚠️ Changes were requested");
-    expect(text).toContain("Please make these changes");
-    // Should NOT have conflict resolution instructions
-    expect(text).not.toContain("Conflict Resolution Instructions");
+    assert.ok(text.includes("⚠️ Changes were requested"));
+    assert.ok(text.includes("Please make these changes"));
+    assert.ok(!text.includes("Conflict Resolution Instructions"));
   });
 
   it("includes comment location information when available", () => {
@@ -128,7 +126,7 @@ describe("formatPrFeedback", () => {
     const result = formatPrFeedback(feedback, "main");
     const text = result.join("\n");
 
-    expect(text).toContain("(src/index.ts:42)");
+    assert.ok(text.includes("(src/index.ts:42)"));
   });
 
   it("uses correct base branch in rebase command", () => {
@@ -146,14 +144,12 @@ describe("formatPrFeedback", () => {
       ],
     };
 
-    // Test with "main" base branch
     let result = formatPrFeedback(feedback, "main");
     let text = result.join("\n");
-    expect(text).toContain("git rebase main");
+    assert.ok(text.includes("git rebase main"));
 
-    // Test with "develop" base branch
     result = formatPrFeedback(feedback, "develop");
     text = result.join("\n");
-    expect(text).toContain("git rebase develop");
+    assert.ok(text.includes("git rebase develop"));
   });
 });

--- a/lib/dispatch/session.acceptance.test.ts
+++ b/lib/dispatch/session.acceptance.test.ts
@@ -1,0 +1,66 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { sendToAgent } from "./session.js";
+
+function mkRunCommand(stdout: string): any {
+  return async () => ({
+    stdout,
+    stderr: "",
+    code: 0,
+    signal: null,
+    killed: false,
+    termination: { type: "exit", code: 0 },
+  });
+}
+
+describe("sendToAgent acceptance parsing", () => {
+  it("accepts early-ack gateway response shape", async () => {
+    const out = await sendToAgent("agent:test:subagent:proj-dev", "msg", {
+      projectName: "proj",
+      issueId: 25,
+      role: "developer",
+      level: "medior",
+      workspaceDir: "/tmp",
+      runCommand: mkRunCommand('{"status":"accepted","runId":"run-early"}'),
+    });
+
+    assert.strictEqual(out.accepted, true);
+    assert.strictEqual(out.status, "accepted");
+    assert.strictEqual(out.runId, "run-early");
+    assert.strictEqual(out.mode, "early-status");
+  });
+
+  it("accepts --expect-final response shape (status ok + runId + result)", async () => {
+    const out = await sendToAgent("agent:test:subagent:proj-dev", "msg", {
+      projectName: "proj",
+      issueId: 25,
+      role: "developer",
+      level: "medior",
+      workspaceDir: "/tmp",
+      runCommand: mkRunCommand(
+        '{"status":"ok","runId":"run-final","result":{"summary":"completed","output":"done"}}',
+      ),
+    });
+
+    assert.strictEqual(out.accepted, true);
+    assert.strictEqual(out.status, "accepted");
+    assert.strictEqual(out.runId, "run-final");
+    assert.strictEqual(out.mode, "final-ok");
+  });
+
+  it("fails closed for malformed final-mode responses", async () => {
+    const out = await sendToAgent("agent:test:subagent:proj-dev", "msg", {
+      projectName: "proj",
+      issueId: 25,
+      role: "developer",
+      level: "medior",
+      workspaceDir: "/tmp",
+      runCommand: mkRunCommand('{"status":"ok","runId":"run-final"}'),
+    });
+
+    assert.strictEqual(out.accepted, false);
+    assert.strictEqual(out.status, "failed");
+    assert.match(String(out.reason), /did not include acceptance status/i);
+    assert.strictEqual(out.mode, "invalid");
+  });
+});

--- a/lib/dispatch/session.acceptance.test.ts
+++ b/lib/dispatch/session.acceptance.test.ts
@@ -48,6 +48,44 @@ describe("sendToAgent acceptance parsing", () => {
     assert.strictEqual(out.mode, "final-ok");
   });
 
+  it("does not treat final envelope as accepted when nested status is rejected", async () => {
+    const out = await sendToAgent("agent:test:subagent:proj-dev", "msg", {
+      projectName: "proj",
+      issueId: 25,
+      role: "developer",
+      level: "medior",
+      workspaceDir: "/tmp",
+      runCommand: mkRunCommand(
+        '{"status":"ok","runId":"run-final","result":{"status":"rejected","reason":"duplicate"}}',
+      ),
+    });
+
+    assert.strictEqual(out.accepted, false);
+    assert.strictEqual(out.status, "rejected");
+    assert.strictEqual(out.runId, "run-final");
+    assert.strictEqual(out.reason, "duplicate");
+    assert.strictEqual(out.mode, "explicit-failure");
+  });
+
+  it("does not treat final envelope as accepted when nested accepted=false", async () => {
+    const out = await sendToAgent("agent:test:subagent:proj-dev", "msg", {
+      projectName: "proj",
+      issueId: 25,
+      role: "developer",
+      level: "medior",
+      workspaceDir: "/tmp",
+      runCommand: mkRunCommand(
+        '{"status":"ok","runId":"run-final","result":{"accepted":false,"reason":"deduped"}}',
+      ),
+    });
+
+    assert.strictEqual(out.accepted, false);
+    assert.strictEqual(out.status, "rejected");
+    assert.strictEqual(out.runId, "run-final");
+    assert.strictEqual(out.reason, "deduped");
+    assert.strictEqual(out.mode, "accepted-flag");
+  });
+
   it("fails closed for malformed final-mode responses", async () => {
     const out = await sendToAgent("agent:test:subagent:proj-dev", "msg", {
       projectName: "proj",

--- a/lib/dispatch/session.acceptance.test.ts
+++ b/lib/dispatch/session.acceptance.test.ts
@@ -86,7 +86,7 @@ describe("sendToAgent acceptance parsing", () => {
     assert.strictEqual(out.mode, "accepted-flag");
   });
 
-  it("fails closed for malformed final-mode responses", async () => {
+  it("accepts final envelope when status=ok + runId (no result payload)", async () => {
     const out = await sendToAgent("agent:test:subagent:proj-dev", "msg", {
       projectName: "proj",
       issueId: 25,
@@ -96,9 +96,44 @@ describe("sendToAgent acceptance parsing", () => {
       runCommand: mkRunCommand('{"status":"ok","runId":"run-final"}'),
     });
 
+    assert.strictEqual(out.accepted, true);
+    assert.strictEqual(out.status, "accepted");
+    assert.strictEqual(out.runId, "run-final");
+    assert.strictEqual(out.mode, "final-ok");
+  });
+
+  it("fails closed when status=ok but runId is missing", async () => {
+    const out = await sendToAgent("agent:test:subagent:proj-dev", "msg", {
+      projectName: "proj",
+      issueId: 25,
+      role: "developer",
+      level: "medior",
+      workspaceDir: "/tmp",
+      runCommand: mkRunCommand('{"status":"ok"}'),
+    });
+
     assert.strictEqual(out.accepted, false);
     assert.strictEqual(out.status, "failed");
     assert.match(String(out.reason), /did not include acceptance status/i);
     assert.strictEqual(out.mode, "invalid");
+  });
+
+  it("does not mask explicit top-level failures even when runId exists", async () => {
+    const out = await sendToAgent("agent:test:subagent:proj-dev", "msg", {
+      projectName: "proj",
+      issueId: 25,
+      role: "developer",
+      level: "medior",
+      workspaceDir: "/tmp",
+      runCommand: mkRunCommand(
+        '{"status":"rejected","runId":"run-final","reason":"policy denied"}',
+      ),
+    });
+
+    assert.strictEqual(out.accepted, false);
+    assert.strictEqual(out.status, "rejected");
+    assert.strictEqual(out.runId, "run-final");
+    assert.strictEqual(out.reason, "policy denied");
+    assert.strictEqual(out.mode, "explicit-failure");
   });
 });

--- a/lib/dispatch/session.debug-logging.test.ts
+++ b/lib/dispatch/session.debug-logging.test.ts
@@ -1,0 +1,110 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { sendToAgent } from "./session.js";
+
+describe("sendToAgent debug envelope logging", () => {
+  it("logs request/response envelopes with field-level truncation markers", async () => {
+    const workspaceDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "devclaw-session-debug-"),
+    );
+    try {
+      const longMessage = "m".repeat(2_800);
+      const longPrompt = "p".repeat(2_700);
+      const longOutput = "o".repeat(5_200);
+      const longRunId = "run-" + "r".repeat(5_100);
+      const responseItems = Array.from({ length: 30 }, (_, i) => `item-${i}`);
+
+      const runCommand: any = async () => ({
+        stdout: JSON.stringify({
+          status: "ok",
+          runId: longRunId,
+          result: {
+            output: longOutput,
+            items: responseItems,
+          },
+        }),
+        stderr: "",
+        code: 0,
+        signal: null,
+        killed: false,
+        termination: { type: "exit", code: 0 },
+      });
+
+      const out = await sendToAgent(
+        "agent:test:subagent:proj-dev-senior",
+        longMessage,
+        {
+          projectName: "proj",
+          issueId: 70,
+          role: "developer",
+          level: "senior",
+          slotIndex: 0,
+          dispatchAttempt: 1,
+          workspaceDir,
+          extraSystemPrompt: longPrompt,
+          runCommand,
+        },
+      );
+
+      assert.equal(out.accepted, true);
+      assert.equal(out.status, "accepted");
+      assert.equal(out.mode, "final-ok");
+      assert.equal(out.runId, longRunId);
+
+      const auditPath = path.join(workspaceDir, "devclaw", "log", "audit.log");
+      const raw = await fs.readFile(auditPath, "utf-8");
+      const events = raw
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+
+      const reqEvent = events.find(
+        (e) => e.event === "dispatch_debug" && e.step === "sendToAgent.request",
+      );
+      const resEvent = events.find(
+        (e) =>
+          e.event === "dispatch_debug" && e.step === "sendToAgent.response",
+      );
+
+      assert.ok(reqEvent, "request debug event should exist");
+      assert.ok(resEvent, "response debug event should exist");
+
+      assert.equal(reqEvent.envelope.agentId, "devclaw");
+      assert.equal(
+        reqEvent.envelope.sessionKey,
+        "agent:test:subagent:proj-dev-senior",
+      );
+      assert.equal(reqEvent.envelope.lane, "subagent");
+      assert.match(
+        String(reqEvent.envelope.message),
+        /\[truncated originalLength=2800 keptLength=2000\]$/,
+      );
+      assert.match(
+        String(reqEvent.envelope.extraSystemPrompt),
+        /\[truncated originalLength=2700 keptLength=2000\]$/,
+      );
+
+      assert.equal(resEvent.status, "accepted");
+      assert.equal(resEvent.runId, longRunId);
+      assert.equal(resEvent.mode, "final-ok");
+      assert.equal(resEvent.envelope.status, "ok");
+      assert.equal(resEvent.envelope.runId, longRunId);
+      assert.match(
+        String(resEvent.envelope.result.output),
+        /\[truncated originalLength=5200 keptLength=4000\]$/,
+      );
+      assert.equal(resEvent.envelope.result.items.length, 21);
+      assert.deepEqual(resEvent.envelope.result.items[20], {
+        __truncated: true,
+        kind: "array",
+        originalLength: 30,
+        keptLength: 20,
+      });
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/lib/dispatch/session.idempotency.test.ts
+++ b/lib/dispatch/session.idempotency.test.ts
@@ -3,8 +3,9 @@ import assert from "node:assert";
 import { sendToAgent } from "./session.js";
 
 describe("sendToAgent idempotency key", () => {
-  it("includes dispatchAttempt nonce and differs across redispatch attempts", async () => {
+  it("includes dispatchAttempt nonce, differs across redispatch attempts, and excludes model from agent payload", async () => {
     const captured: string[] = [];
+    const rawParams: Array<Record<string, unknown>> = [];
 
     const runCommand: any = async (argv: string[], _opts: any) => {
       const paramsIdx = argv.indexOf("--params");
@@ -16,6 +17,7 @@ describe("sendToAgent idempotency key", () => {
         paramsIdx >= 0
       ) {
         const params = JSON.parse(argv[paramsIdx + 1]!);
+        rawParams.push(params);
         captured.push(params.idempotencyKey);
       }
       return {
@@ -36,6 +38,7 @@ describe("sendToAgent idempotency key", () => {
       slotIndex: 0,
       dispatchAttempt: 1,
       workspaceDir: "/tmp",
+      model: "openai/gpt-5",
       runCommand,
     });
 
@@ -47,6 +50,7 @@ describe("sendToAgent idempotency key", () => {
       slotIndex: 0,
       dispatchAttempt: 2,
       workspaceDir: "/tmp",
+      model: "openai/gpt-5",
       runCommand,
     });
 
@@ -60,5 +64,6 @@ describe("sendToAgent idempotency key", () => {
       captured[1]!.includes("-0-2-agent:test:subagent:proj-dev-senior-ada"),
     );
     assert.notStrictEqual(captured[0], captured[1]);
+    assert.ok(rawParams.every((params) => !("model" in params)));
   });
 });

--- a/lib/dispatch/session.idempotency.test.ts
+++ b/lib/dispatch/session.idempotency.test.ts
@@ -19,7 +19,7 @@ describe("sendToAgent idempotency key", () => {
         captured.push(params.idempotencyKey);
       }
       return {
-        stdout: "{}",
+        stdout: '{"status":"accepted","runId":"run-test"}',
         stderr: "",
         code: 0,
         signal: null,
@@ -28,7 +28,7 @@ describe("sendToAgent idempotency key", () => {
       };
     };
 
-    sendToAgent("agent:test:subagent:proj-dev-senior-ada", "msg", {
+    await sendToAgent("agent:test:subagent:proj-dev-senior-ada", "msg", {
       projectName: "proj",
       issueId: 17,
       role: "developer",
@@ -39,7 +39,7 @@ describe("sendToAgent idempotency key", () => {
       runCommand,
     });
 
-    sendToAgent("agent:test:subagent:proj-dev-senior-ada", "msg", {
+    await sendToAgent("agent:test:subagent:proj-dev-senior-ada", "msg", {
       projectName: "proj",
       issueId: 17,
       role: "developer",

--- a/lib/dispatch/session.idempotency.test.ts
+++ b/lib/dispatch/session.idempotency.test.ts
@@ -3,11 +3,13 @@ import assert from "node:assert";
 import { sendToAgent } from "./session.js";
 
 describe("sendToAgent idempotency key", () => {
-  it("includes dispatchAttempt nonce, differs across redispatch attempts, and excludes model from agent payload", async () => {
+  it("includes dispatchAttempt nonce, differs across redispatch attempts, excludes model from payload, and sets gateway timeout flag", async () => {
     const captured: string[] = [];
     const rawParams: Array<Record<string, unknown>> = [];
+    const argvCalls: string[][] = [];
+    const callTimeouts: number[] = [];
 
-    const runCommand: any = async (argv: string[], _opts: any) => {
+    const runCommand: any = async (argv: string[], opts: any) => {
       const paramsIdx = argv.indexOf("--params");
       if (
         argv[0] === "openclaw" &&
@@ -16,6 +18,8 @@ describe("sendToAgent idempotency key", () => {
         argv[3] === "agent" &&
         paramsIdx >= 0
       ) {
+        argvCalls.push(argv);
+        callTimeouts.push(opts?.timeoutMs);
         const params = JSON.parse(argv[paramsIdx + 1]!);
         rawParams.push(params);
         captured.push(params.idempotencyKey);
@@ -65,5 +69,15 @@ describe("sendToAgent idempotency key", () => {
     );
     assert.notStrictEqual(captured[0], captured[1]);
     assert.ok(rawParams.every((params) => !("model" in params)));
+    assert.strictEqual(argvCalls.length, 2);
+    for (const argv of argvCalls) {
+      const timeoutIdx = argv.indexOf("--timeout");
+      assert.ok(timeoutIdx >= 0, "expected --timeout flag in gateway call");
+      assert.strictEqual(argv[timeoutIdx + 1], "30000");
+    }
+    assert.ok(
+      callTimeouts.every((timeoutMs) => Number(timeoutMs) > 30_000),
+      "runCommand timeout should remain above gateway timeout",
+    );
   });
 });

--- a/lib/dispatch/session.ts
+++ b/lib/dispatch/session.ts
@@ -67,46 +67,212 @@ export async function shouldClearSession(
  * Session key is deterministic, so we don't need to wait for confirmation.
  * If this fails, health check will catch orphaned state later.
  */
-export function ensureSessionFireAndForget(sessionKey: string, model: string, workspaceDir: string, runCommand: RunCommand, timeoutMs = 30_000, label?: string): void {
+export function ensureSessionFireAndForget(
+  sessionKey: string,
+  model: string,
+  workspaceDir: string,
+  runCommand: RunCommand,
+  timeoutMs = 30_000,
+  label?: string,
+): void {
   const rc = runCommand;
   const params: Record<string, unknown> = { key: sessionKey, model };
   if (label) params.label = label;
   rc(
-    ["openclaw", "gateway", "call", "sessions.patch", "--params", JSON.stringify(params)],
+    [
+      "openclaw",
+      "gateway",
+      "call",
+      "sessions.patch",
+      "--params",
+      JSON.stringify(params),
+    ],
     { timeoutMs },
   ).catch((err) => {
     auditLog(workspaceDir, "dispatch_warning", {
-      step: "ensureSession", sessionKey,
+      step: "ensureSession",
+      sessionKey,
       error: (err as Error).message ?? String(err),
     }).catch(() => {});
   });
 }
 
-export function sendToAgent(
-  sessionKey: string, taskMessage: string,
-  opts: { agentId?: string; projectName: string; issueId: number; role: string; level?: string; slotIndex?: number; dispatchAttempt?: number; orchestratorSessionKey?: string; workspaceDir: string; dispatchTimeoutMs?: number; extraSystemPrompt?: string; runCommand: RunCommand },
-): void {
+export type DispatchAcceptance = {
+  accepted: boolean;
+  status:
+    | "accepted"
+    | "started"
+    | "deduped"
+    | "rejected"
+    | "unavailable"
+    | "timeout"
+    | "failed";
+  runId?: string;
+  reason?: string;
+  raw?: unknown;
+};
+
+export async function sendToAgent(
+  sessionKey: string,
+  taskMessage: string,
+  opts: {
+    agentId?: string;
+    projectName: string;
+    issueId: number;
+    role: string;
+    level?: string;
+    slotIndex?: number;
+    dispatchAttempt?: number;
+    orchestratorSessionKey?: string;
+    workspaceDir: string;
+    dispatchTimeoutMs?: number;
+    extraSystemPrompt?: string;
+    model?: string;
+    runCommand: RunCommand;
+  },
+): Promise<DispatchAcceptance> {
   const rc = opts.runCommand;
   const gatewayParams = JSON.stringify({
-    idempotencyKey: `devclaw-${opts.projectName}-${opts.issueId}-${opts.role}-${opts.level ?? "unknown"}-${opts.slotIndex ?? 0}-${sessionKey}`,
+    idempotencyKey: `devclaw-${opts.projectName}-${opts.issueId}-${opts.role}-${opts.level ?? "unknown"}-${opts.slotIndex ?? 0}-${opts.dispatchAttempt ?? 0}-${sessionKey}`,
     agentId: opts.agentId ?? "devclaw",
     sessionKey,
     message: taskMessage,
     deliver: false,
     lane: "subagent",
-    idempotencyKey: `devclaw-${opts.projectName}-${opts.issueId}-${opts.role}-${opts.level ?? "unknown"}-${opts.slotIndex ?? 0}-${opts.dispatchAttempt ?? 0}-${sessionKey}`,
-    ...(opts.orchestratorSessionKey ? { spawnedBy: opts.orchestratorSessionKey } : {}),
-    ...(opts.extraSystemPrompt ? { extraSystemPrompt: opts.extraSystemPrompt } : {}),
+    ...(opts.orchestratorSessionKey
+      ? { spawnedBy: opts.orchestratorSessionKey }
+      : {}),
+    ...(opts.extraSystemPrompt
+      ? { extraSystemPrompt: opts.extraSystemPrompt }
+      : {}),
+    ...(opts.model ? { model: opts.model } : {}),
   });
-  // Fire-and-forget: long-running agent turn, don't await
-  rc(
-    ["openclaw", "gateway", "call", "agent", "--params", gatewayParams, "--expect-final", "--json"],
-    { timeoutMs: opts.dispatchTimeoutMs ?? 600_000 },
-  ).catch((err) => {
-    auditLog(opts.workspaceDir, "dispatch_warning", {
-      step: "sendToAgent", sessionKey,
-      issue: opts.issueId, role: opts.role,
-      error: (err as Error).message ?? String(err),
-    }).catch(() => {});
-  });
+
+  try {
+    const result = await rc(
+      [
+        "openclaw",
+        "gateway",
+        "call",
+        "agent",
+        "--params",
+        gatewayParams,
+        "--expect-final",
+        "--json",
+      ],
+      { timeoutMs: opts.dispatchTimeoutMs ?? 600_000 },
+    );
+    return parseDispatchAcceptance(result.stdout);
+  } catch (err) {
+    const msg = (err as Error).message ?? String(err);
+    const timeout = /timeout|timed out/i.test(msg);
+    const status: DispatchAcceptance["status"] = timeout ? "timeout" : "failed";
+    await auditLog(opts.workspaceDir, "dispatch_warning", {
+      step: "sendToAgent",
+      sessionKey,
+      issue: opts.issueId,
+      role: opts.role,
+      error: msg,
+      status,
+    });
+    return { accepted: false, status, reason: msg };
+  }
+}
+
+function parseDispatchAcceptance(stdout: string): DispatchAcceptance {
+  let parsed: unknown;
+  try {
+    parsed = stdout ? JSON.parse(stdout) : undefined;
+  } catch {
+    return {
+      accepted: false,
+      status: "failed",
+      reason: "agent RPC returned invalid JSON",
+      raw: stdout,
+    };
+  }
+
+  const o = (parsed ?? {}) as Record<string, unknown>;
+  const status = normalizeStatus(
+    o.status ??
+      (o.result as Record<string, unknown> | undefined)?.status ??
+      (o.final as Record<string, unknown> | undefined)?.status,
+  );
+  const runId =
+    String(
+      o.runId ??
+        (o.result as Record<string, unknown> | undefined)?.runId ??
+        (o.final as Record<string, unknown> | undefined)?.runId ??
+        "",
+    ) || undefined;
+
+  if (status === "accepted" || status === "started") {
+    return { accepted: true, status, runId, raw: parsed };
+  }
+
+  if (
+    status === "deduped" ||
+    status === "rejected" ||
+    status === "unavailable" ||
+    status === "timeout"
+  ) {
+    return {
+      accepted: false,
+      status,
+      runId,
+      reason: String(
+        o.reason ??
+          (o.result as Record<string, unknown> | undefined)?.reason ??
+          "",
+      ),
+      raw: parsed,
+    };
+  }
+
+  const acceptedFlag =
+    o.accepted ?? (o.result as Record<string, unknown> | undefined)?.accepted;
+  if (
+    acceptedFlag === true ||
+    (runId &&
+      (o.ok === true ||
+        (o.result as Record<string, unknown> | undefined)?.ok === true))
+  ) {
+    return { accepted: true, status: "accepted", runId, raw: parsed };
+  }
+
+  if (acceptedFlag === false) {
+    return {
+      accepted: false,
+      status: "rejected",
+      runId,
+      reason: String(
+        o.reason ??
+          (o.result as Record<string, unknown> | undefined)?.reason ??
+          "",
+      ),
+      raw: parsed,
+    };
+  }
+
+  return {
+    accepted: false,
+    status: "failed",
+    runId,
+    reason: "agent RPC did not include acceptance status",
+    raw: parsed,
+  };
+}
+
+function normalizeStatus(
+  value: unknown,
+): DispatchAcceptance["status"] | undefined {
+  const s = String(value ?? "").toLowerCase();
+  if (!s) return undefined;
+  if (s === "accepted" || s === "started") return s;
+  if (s === "deduped" || s === "duplicate" || s === "idempotent_replay")
+    return "deduped";
+  if (s === "rejected" || s === "denied") return "rejected";
+  if (s === "unavailable" || s === "offline") return "unavailable";
+  if (s === "timeout" || s === "timed_out") return "timeout";
+  return "failed";
 }

--- a/lib/dispatch/session.ts
+++ b/lib/dispatch/session.ts
@@ -205,25 +205,35 @@ function parseDispatchAcceptance(stdout: string): DispatchAcceptance {
   const result = (o.result as Record<string, unknown> | undefined) ?? undefined;
   const final = (o.final as Record<string, unknown> | undefined) ?? undefined;
 
-  const status = normalizeStatus(o.status ?? result?.status ?? final?.status);
-  const topStatus = String(o.status ?? "").toLowerCase();
+  const topStatus = normalizeStatus(o.status);
+  const nestedStatus = normalizeStatus(result?.status ?? final?.status);
+  const topStatusRaw = String(o.status ?? "").toLowerCase();
   const runId =
     String(o.runId ?? result?.runId ?? final?.runId ?? "") || undefined;
-  const reason = String(o.reason ?? result?.reason ?? "");
+  const reason = String(o.reason ?? result?.reason ?? final?.reason ?? "");
 
-  if (status === "accepted" || status === "started") {
-    return { accepted: true, status, runId, mode: "early-status", raw: parsed };
+  // Respect explicit nested final statuses first. With --expect-final,
+  // top-level status is often transport-level (e.g. "ok") and must not mask
+  // result.status like "rejected"/"deduped".
+  if (nestedStatus === "accepted" || nestedStatus === "started") {
+    return {
+      accepted: true,
+      status: nestedStatus,
+      runId,
+      mode: "early-status",
+      raw: parsed,
+    };
   }
 
   if (
-    status === "deduped" ||
-    status === "rejected" ||
-    status === "unavailable" ||
-    status === "timeout"
+    nestedStatus === "deduped" ||
+    nestedStatus === "rejected" ||
+    nestedStatus === "unavailable" ||
+    nestedStatus === "timeout"
   ) {
     return {
       accepted: false,
-      status,
+      status: nestedStatus,
       runId,
       reason,
       mode: "explicit-failure",
@@ -231,15 +241,38 @@ function parseDispatchAcceptance(stdout: string): DispatchAcceptance {
     };
   }
 
-  // --expect-final compatibility:
-  // gateway call can return final lifecycle envelope like:
-  // { status: "ok", runId: "...", result: { ... } }
-  // Treat as accepted only when runId exists and result payload is present.
-  if (topStatus === "ok" && runId && result && typeof result === "object") {
-    return { accepted: true, status: "accepted", runId, mode: "final-ok", raw: parsed };
+  if (topStatus === "accepted" || topStatus === "started") {
+    return { accepted: true, status: topStatus, runId, mode: "early-status", raw: parsed };
+  }
+
+  if (
+    topStatus === "deduped" ||
+    topStatus === "rejected" ||
+    topStatus === "unavailable" ||
+    topStatus === "timeout"
+  ) {
+    return {
+      accepted: false,
+      status: topStatus,
+      runId,
+      reason,
+      mode: "explicit-failure",
+      raw: parsed,
+    };
   }
 
   const acceptedFlag = o.accepted ?? result?.accepted;
+  if (acceptedFlag === false) {
+    return {
+      accepted: false,
+      status: "rejected",
+      runId,
+      reason,
+      mode: "accepted-flag",
+      raw: parsed,
+    };
+  }
+
   if (acceptedFlag === true) {
     return {
       accepted: true,
@@ -250,23 +283,20 @@ function parseDispatchAcceptance(stdout: string): DispatchAcceptance {
     };
   }
 
+  // --expect-final compatibility:
+  // gateway call can return final lifecycle envelope like:
+  // { status: "ok", runId: "...", result: { ... } }
+  // Treat as accepted only when runId exists and result payload is present.
+  if (topStatusRaw === "ok" && runId && result && typeof result === "object") {
+    return { accepted: true, status: "accepted", runId, mode: "final-ok", raw: parsed };
+  }
+
   if (runId && (o.ok === true || result?.ok === true)) {
     return {
       accepted: true,
       status: "accepted",
       runId,
       mode: "legacy-ok",
-      raw: parsed,
-    };
-  }
-
-  if (acceptedFlag === false) {
-    return {
-      accepted: false,
-      status: "rejected",
-      runId,
-      reason,
-      mode: "accepted-flag",
       raw: parsed,
     };
   }

--- a/lib/dispatch/session.ts
+++ b/lib/dispatch/session.ts
@@ -177,6 +177,11 @@ export async function sendToAgent(
   });
 
   try {
+    const gatewayTimeoutMs = 30_000;
+    const wrapperTimeoutMs = Math.max(
+      opts.dispatchTimeoutMs ?? 600_000,
+      gatewayTimeoutMs + 5_000,
+    );
     const result = await rc(
       [
         "openclaw",
@@ -185,10 +190,12 @@ export async function sendToAgent(
         "agent",
         "--params",
         gatewayParams,
+        "--timeout",
+        String(gatewayTimeoutMs),
         "--expect-final",
         "--json",
       ],
-      { timeoutMs: opts.dispatchTimeoutMs ?? 600_000 },
+      { timeoutMs: wrapperTimeoutMs },
     );
     const parsedStdout = tryParseJson(result.stdout);
     const acceptance = parseDispatchAcceptance(result.stdout);

--- a/lib/dispatch/session.ts
+++ b/lib/dispatch/session.ts
@@ -167,7 +167,6 @@ export async function sendToAgent(
     ...(opts.extraSystemPrompt
       ? { extraSystemPrompt: opts.extraSystemPrompt }
       : {}),
-    ...(opts.model ? { model: opts.model } : {}),
   };
   const gatewayParams = JSON.stringify(gatewayParamsObj);
   await auditLog(opts.workspaceDir, "dispatch_debug", {

--- a/lib/dispatch/session.ts
+++ b/lib/dispatch/session.ts
@@ -5,6 +5,20 @@ import type { RunCommand } from "../context.js";
 import { log as auditLog } from "../audit.js";
 import { fetchGatewaySessions } from "../services/gateway-sessions.js";
 
+const REQUEST_TEXT_TRUNCATE_AT = 2_000;
+const RESPONSE_TEXT_TRUNCATE_AT = 4_000;
+const RESPONSE_ARRAY_TRUNCATE_AT = 20;
+const NON_TRUNCATED_DIAGNOSTIC_FIELDS = new Set([
+  "idempotencyKey",
+  "agentId",
+  "sessionKey",
+  "lane",
+  "status",
+  "runId",
+  "reason",
+  "mode",
+]);
+
 // ---------------------------------------------------------------------------
 // Context budget management
 // ---------------------------------------------------------------------------
@@ -140,7 +154,7 @@ export async function sendToAgent(
   },
 ): Promise<DispatchAcceptance> {
   const rc = opts.runCommand;
-  const gatewayParams = JSON.stringify({
+  const gatewayParamsObj = {
     idempotencyKey: `devclaw-${opts.projectName}-${opts.issueId}-${opts.role}-${opts.level ?? "unknown"}-${opts.slotIndex ?? 0}-${opts.dispatchAttempt ?? 0}-${sessionKey}`,
     agentId: opts.agentId ?? "devclaw",
     sessionKey,
@@ -154,6 +168,13 @@ export async function sendToAgent(
       ? { extraSystemPrompt: opts.extraSystemPrompt }
       : {}),
     ...(opts.model ? { model: opts.model } : {}),
+  };
+  const gatewayParams = JSON.stringify(gatewayParamsObj);
+  await auditLog(opts.workspaceDir, "dispatch_debug", {
+    step: "sendToAgent.request",
+    issue: opts.issueId,
+    role: opts.role,
+    envelope: sanitizeRequestEnvelopeForLog(gatewayParamsObj),
   });
 
   try {
@@ -170,7 +191,19 @@ export async function sendToAgent(
       ],
       { timeoutMs: opts.dispatchTimeoutMs ?? 600_000 },
     );
-    return parseDispatchAcceptance(result.stdout);
+    const parsedStdout = tryParseJson(result.stdout);
+    const acceptance = parseDispatchAcceptance(result.stdout);
+    await auditLog(opts.workspaceDir, "dispatch_debug", {
+      step: "sendToAgent.response",
+      issue: opts.issueId,
+      role: opts.role,
+      envelope: sanitizeResponseEnvelopeForLog(parsedStdout ?? result.stdout),
+      status: acceptance.status,
+      runId: acceptance.runId,
+      reason: acceptance.reason,
+      mode: acceptance.mode,
+    });
+    return acceptance;
   } catch (err) {
     const msg = (err as Error).message ?? String(err);
     const timeout = /timeout|timed out/i.test(msg);
@@ -337,4 +370,85 @@ function normalizeStatus(
   if (s === "unavailable" || s === "offline") return "unavailable";
   if (s === "timeout" || s === "timed_out") return "timeout";
   return "failed";
+}
+
+function sanitizeRequestEnvelopeForLog(
+  envelope: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(envelope)) {
+    if (
+      (key === "message" || key === "extraSystemPrompt") &&
+      typeof value === "string"
+    ) {
+      out[key] = truncateStringWithMarker(value, REQUEST_TEXT_TRUNCATE_AT);
+      continue;
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+function sanitizeResponseEnvelopeForLog(envelope: unknown): unknown {
+  return sanitizeResponseValueForLog(envelope);
+}
+
+function sanitizeResponseValueForLog(
+  value: unknown,
+  keyHint?: string,
+): unknown {
+  if (
+    keyHint &&
+    NON_TRUNCATED_DIAGNOSTIC_FIELDS.has(keyHint) &&
+    (typeof value === "string" ||
+      typeof value === "number" ||
+      typeof value === "boolean" ||
+      value == null)
+  ) {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    return truncateStringWithMarker(value, RESPONSE_TEXT_TRUNCATE_AT);
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length <= RESPONSE_ARRAY_TRUNCATE_AT) {
+      return value.map((item) => sanitizeResponseValueForLog(item));
+    }
+    const kept = value
+      .slice(0, RESPONSE_ARRAY_TRUNCATE_AT)
+      .map((item) => sanitizeResponseValueForLog(item));
+    kept.push({
+      __truncated: true,
+      kind: "array",
+      originalLength: value.length,
+      keptLength: RESPONSE_ARRAY_TRUNCATE_AT,
+    });
+    return kept;
+  }
+
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = sanitizeResponseValueForLog(v, k);
+    }
+    return out;
+  }
+
+  return value;
+}
+
+function truncateStringWithMarker(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, maxLength)}...[truncated originalLength=${value.length} keptLength=${maxLength}]`;
+}
+
+function tryParseJson(input: string): unknown | undefined {
+  if (!input) return undefined;
+  try {
+    return JSON.parse(input);
+  } catch {
+    return undefined;
+  }
 }

--- a/lib/dispatch/session.ts
+++ b/lib/dispatch/session.ts
@@ -242,7 +242,13 @@ function parseDispatchAcceptance(stdout: string): DispatchAcceptance {
   }
 
   if (topStatus === "accepted" || topStatus === "started") {
-    return { accepted: true, status: topStatus, runId, mode: "early-status", raw: parsed };
+    return {
+      accepted: true,
+      status: topStatus,
+      runId,
+      mode: "early-status",
+      raw: parsed,
+    };
   }
 
   if (
@@ -284,11 +290,19 @@ function parseDispatchAcceptance(stdout: string): DispatchAcceptance {
   }
 
   // --expect-final compatibility:
-  // gateway call can return final lifecycle envelope like:
+  // gateway call can return final lifecycle envelopes like:
+  // { status: "ok", runId: "..." }
   // { status: "ok", runId: "...", result: { ... } }
-  // Treat as accepted only when runId exists and result payload is present.
-  if (topStatusRaw === "ok" && runId && result && typeof result === "object") {
-    return { accepted: true, status: "accepted", runId, mode: "final-ok", raw: parsed };
+  // Treat as accepted when transport-level status is ok and runId exists.
+  // Explicit nested failures are handled above, so they cannot be masked here.
+  if (topStatusRaw === "ok" && runId) {
+    return {
+      accepted: true,
+      status: "accepted",
+      runId,
+      mode: "final-ok",
+      raw: parsed,
+    };
   }
 
   if (runId && (o.ok === true || result?.ok === true)) {

--- a/lib/dispatch/session.ts
+++ b/lib/dispatch/session.ts
@@ -109,6 +109,14 @@ export type DispatchAcceptance = {
     | "failed";
   runId?: string;
   reason?: string;
+  /** How acceptance was inferred (early ack vs final response compatibility path). */
+  mode?:
+    | "early-status"
+    | "final-ok"
+    | "accepted-flag"
+    | "legacy-ok"
+    | "explicit-failure"
+    | "invalid";
   raw?: unknown;
 };
 
@@ -188,26 +196,23 @@ function parseDispatchAcceptance(stdout: string): DispatchAcceptance {
       accepted: false,
       status: "failed",
       reason: "agent RPC returned invalid JSON",
+      mode: "invalid",
       raw: stdout,
     };
   }
 
   const o = (parsed ?? {}) as Record<string, unknown>;
-  const status = normalizeStatus(
-    o.status ??
-      (o.result as Record<string, unknown> | undefined)?.status ??
-      (o.final as Record<string, unknown> | undefined)?.status,
-  );
+  const result = (o.result as Record<string, unknown> | undefined) ?? undefined;
+  const final = (o.final as Record<string, unknown> | undefined) ?? undefined;
+
+  const status = normalizeStatus(o.status ?? result?.status ?? final?.status);
+  const topStatus = String(o.status ?? "").toLowerCase();
   const runId =
-    String(
-      o.runId ??
-        (o.result as Record<string, unknown> | undefined)?.runId ??
-        (o.final as Record<string, unknown> | undefined)?.runId ??
-        "",
-    ) || undefined;
+    String(o.runId ?? result?.runId ?? final?.runId ?? "") || undefined;
+  const reason = String(o.reason ?? result?.reason ?? "");
 
   if (status === "accepted" || status === "started") {
-    return { accepted: true, status, runId, raw: parsed };
+    return { accepted: true, status, runId, mode: "early-status", raw: parsed };
   }
 
   if (
@@ -220,24 +225,39 @@ function parseDispatchAcceptance(stdout: string): DispatchAcceptance {
       accepted: false,
       status,
       runId,
-      reason: String(
-        o.reason ??
-          (o.result as Record<string, unknown> | undefined)?.reason ??
-          "",
-      ),
+      reason,
+      mode: "explicit-failure",
       raw: parsed,
     };
   }
 
-  const acceptedFlag =
-    o.accepted ?? (o.result as Record<string, unknown> | undefined)?.accepted;
-  if (
-    acceptedFlag === true ||
-    (runId &&
-      (o.ok === true ||
-        (o.result as Record<string, unknown> | undefined)?.ok === true))
-  ) {
-    return { accepted: true, status: "accepted", runId, raw: parsed };
+  // --expect-final compatibility:
+  // gateway call can return final lifecycle envelope like:
+  // { status: "ok", runId: "...", result: { ... } }
+  // Treat as accepted only when runId exists and result payload is present.
+  if (topStatus === "ok" && runId && result && typeof result === "object") {
+    return { accepted: true, status: "accepted", runId, mode: "final-ok", raw: parsed };
+  }
+
+  const acceptedFlag = o.accepted ?? result?.accepted;
+  if (acceptedFlag === true) {
+    return {
+      accepted: true,
+      status: "accepted",
+      runId,
+      mode: "accepted-flag",
+      raw: parsed,
+    };
+  }
+
+  if (runId && (o.ok === true || result?.ok === true)) {
+    return {
+      accepted: true,
+      status: "accepted",
+      runId,
+      mode: "legacy-ok",
+      raw: parsed,
+    };
   }
 
   if (acceptedFlag === false) {
@@ -245,11 +265,8 @@ function parseDispatchAcceptance(stdout: string): DispatchAcceptance {
       accepted: false,
       status: "rejected",
       runId,
-      reason: String(
-        o.reason ??
-          (o.result as Record<string, unknown> | undefined)?.reason ??
-          "",
-      ),
+      reason,
+      mode: "accepted-flag",
       raw: parsed,
     };
   }
@@ -259,6 +276,7 @@ function parseDispatchAcceptance(stdout: string): DispatchAcceptance {
     status: "failed",
     runId,
     reason: "agent RPC did not include acceptance status",
+    mode: "invalid",
     raw: parsed,
   };
 }

--- a/lib/providers/github.ts
+++ b/lib/providers/github.ts
@@ -6,6 +6,7 @@ import {
   type Issue,
   type StateLabel,
   type IssueComment,
+  type IssueDependencies,
   type PrStatus,
   type PrReviewComment,
   type CiStatus,
@@ -228,6 +229,47 @@ export class GitHubProvider implements IssueProvider {
   async getIssue(issueId: number): Promise<Issue> {
     const raw = await this.gh(["issue", "view", String(issueId), "--json", "number,title,body,labels,state,url"]);
     return toIssue(JSON.parse(raw) as GhIssue);
+  }
+
+  async getIssueDependencies(issueId: number): Promise<IssueDependencies> {
+    const repo = await this.getRepoInfo();
+    if (!repo) throw new Error("Unable to resolve repository owner/name for dependency query");
+
+    const query = `{
+      repository(owner: "${repo.owner}", name: "${repo.name}") {
+        issue(number: ${issueId}) {
+          trackedInIssues(first: 100) {
+            nodes { number title state url }
+          }
+          trackedIssues(first: 100) {
+            nodes { number title state url }
+          }
+        }
+      }
+    }`;
+
+    const raw = await this.gh(["api", "graphql", "-f", `query=${query}`]);
+    const data = JSON.parse(raw);
+    const issue = data?.data?.repository?.issue;
+    if (!issue) throw new Error(`Issue #${issueId} not found in repository ${repo.owner}/${repo.name}`);
+
+    const blockers = (issue.trackedInIssues?.nodes ?? []).map((dep: any) => ({
+      iid: dep.number,
+      title: dep.title ?? "",
+      state: dep.state ?? "",
+      web_url: dep.url ?? "",
+      relation: "blocked_by" as const,
+    }));
+
+    const dependents = (issue.trackedIssues?.nodes ?? []).map((dep: any) => ({
+      iid: dep.number,
+      title: dep.title ?? "",
+      state: dep.state ?? "",
+      web_url: dep.url ?? "",
+      relation: "blocks" as const,
+    }));
+
+    return { issueId, blockers, dependents };
   }
 
   async listComments(issueId: number): Promise<IssueComment[]> {

--- a/lib/providers/github.ts
+++ b/lib/providers/github.ts
@@ -238,10 +238,10 @@ export class GitHubProvider implements IssueProvider {
     const query = `{
       repository(owner: "${repo.owner}", name: "${repo.name}") {
         issue(number: ${issueId}) {
-          trackedInIssues(first: 100) {
+          blockedBy(first: 100) {
             nodes { number title state url labels(first: 20) { nodes { name } } }
           }
-          trackedIssues(first: 100) {
+          blocking(first: 100) {
             nodes { number title state url labels(first: 20) { nodes { name } } }
           }
         }
@@ -253,7 +253,7 @@ export class GitHubProvider implements IssueProvider {
     const issue = data?.data?.repository?.issue;
     if (!issue) throw new Error(`Issue #${issueId} not found in repository ${repo.owner}/${repo.name}`);
 
-    const blockers = (issue.trackedInIssues?.nodes ?? []).map((dep: any) => ({
+    const blockers = (issue.blockedBy?.nodes ?? []).map((dep: any) => ({
       iid: dep.number,
       title: dep.title ?? "",
       state: dep.state ?? "",
@@ -262,7 +262,7 @@ export class GitHubProvider implements IssueProvider {
       relation: "blocked_by" as const,
     }));
 
-    const dependents = (issue.trackedIssues?.nodes ?? []).map((dep: any) => ({
+    const dependents = (issue.blocking?.nodes ?? []).map((dep: any) => ({
       iid: dep.number,
       title: dep.title ?? "",
       state: dep.state ?? "",

--- a/lib/providers/github.ts
+++ b/lib/providers/github.ts
@@ -239,10 +239,10 @@ export class GitHubProvider implements IssueProvider {
       repository(owner: "${repo.owner}", name: "${repo.name}") {
         issue(number: ${issueId}) {
           trackedInIssues(first: 100) {
-            nodes { number title state url }
+            nodes { number title state url labels(first: 20) { nodes { name } } }
           }
           trackedIssues(first: 100) {
-            nodes { number title state url }
+            nodes { number title state url labels(first: 20) { nodes { name } } }
           }
         }
       }
@@ -258,6 +258,7 @@ export class GitHubProvider implements IssueProvider {
       title: dep.title ?? "",
       state: dep.state ?? "",
       web_url: dep.url ?? "",
+      labels: (dep.labels?.nodes ?? []).map((l: any) => l.name),
       relation: "blocked_by" as const,
     }));
 
@@ -266,6 +267,7 @@ export class GitHubProvider implements IssueProvider {
       title: dep.title ?? "",
       state: dep.state ?? "",
       web_url: dep.url ?? "",
+      labels: (dep.labels?.nodes ?? []).map((l: any) => l.name),
       relation: "blocks" as const,
     }));
 

--- a/lib/providers/gitlab.ts
+++ b/lib/providers/gitlab.ts
@@ -6,6 +6,7 @@ import {
   type Issue,
   type StateLabel,
   type IssueComment,
+  type IssueDependencies,
   type PrStatus,
   type PrReviewComment,
   type CiStatus,
@@ -121,6 +122,12 @@ export class GitLabProvider implements IssueProvider {
   async getIssue(issueId: number): Promise<Issue> {
     const raw = await this.glab(["issue", "view", String(issueId), "--output", "json"]);
     return JSON.parse(raw) as Issue;
+  }
+
+  async getIssueDependencies(issueId: number): Promise<IssueDependencies> {
+    // GitLab adapter support will be added when we wire native issue-link/dependency relations.
+    // Return a normalized empty graph to preserve backward compatibility.
+    return { issueId, blockers: [], dependents: [] };
   }
 
   async listComments(issueId: number): Promise<IssueComment[]> {

--- a/lib/providers/provider-issue-dependencies.test.ts
+++ b/lib/providers/provider-issue-dependencies.test.ts
@@ -10,12 +10,12 @@ import { GitHubProvider } from "./github.js";
 import { GitLabProvider } from "./gitlab.js";
 
 function createGitHubRunCommand(opts: {
-  trackedInIssues?: Array<{ number: number; title: string; state: string; url: string }>;
-  trackedIssues?: Array<{ number: number; title: string; state: string; url: string }>;
+  blockedBy?: Array<{ number: number; title: string; state: string; url: string }>;
+  blocking?: Array<{ number: number; title: string; state: string; url: string }>;
   failGraphql?: boolean;
 }): RunCommand {
-  const trackedInIssues = opts.trackedInIssues ?? [];
-  const trackedIssues = opts.trackedIssues ?? [];
+  const blockedBy = opts.blockedBy ?? [];
+  const blocking = opts.blocking ?? [];
 
   return (async (command: string[]) => {
     const rendered = command.join(" ");
@@ -34,13 +34,16 @@ function createGitHubRunCommand(opts: {
 
     if (rendered.includes("gh api graphql")) {
       if (opts.failGraphql) throw new Error("GraphQL is down");
+      assert.match(rendered, /\bblockedBy\(first: 100\)/);
+      assert.match(rendered, /\bblocking\(first: 100\)/);
+      assert.doesNotMatch(rendered, /trackedInIssues|trackedIssues/);
       return {
         stdout: JSON.stringify({
           data: {
             repository: {
               issue: {
-                trackedInIssues: { nodes: trackedInIssues },
-                trackedIssues: { nodes: trackedIssues },
+                blockedBy: { nodes: blockedBy },
+                blocking: { nodes: blocking },
               },
             },
           },
@@ -76,7 +79,7 @@ describe("GitHubProvider.getIssueDependencies", () => {
     const provider = new GitHubProvider({
       repoPath: "/fake",
       runCommand: createGitHubRunCommand({
-        trackedInIssues: [
+        blockedBy: [
           { number: 1, title: "Parent", state: "OPEN", url: "https://github.com/o/r/issues/1" },
         ],
       }),
@@ -94,11 +97,11 @@ describe("GitHubProvider.getIssueDependencies", () => {
     const provider = new GitHubProvider({
       repoPath: "/fake",
       runCommand: createGitHubRunCommand({
-        trackedInIssues: [
+        blockedBy: [
           { number: 1, title: "Blocker A", state: "OPEN", url: "https://github.com/o/r/issues/1" },
           { number: 3, title: "Blocker B", state: "OPEN", url: "https://github.com/o/r/issues/3" },
         ],
-        trackedIssues: [
+        blocking: [
           { number: 7, title: "Dependent", state: "OPEN", url: "https://github.com/o/r/issues/7" },
         ],
       }),

--- a/lib/providers/provider-issue-dependencies.test.ts
+++ b/lib/providers/provider-issue-dependencies.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for provider dependency retrieval normalization.
+ *
+ * Run with: npx tsx --test lib/providers/provider-issue-dependencies.test.ts
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import type { RunCommand } from "../context.js";
+import { GitHubProvider } from "./github.js";
+import { GitLabProvider } from "./gitlab.js";
+
+function createGitHubRunCommand(opts: {
+  trackedInIssues?: Array<{ number: number; title: string; state: string; url: string }>;
+  trackedIssues?: Array<{ number: number; title: string; state: string; url: string }>;
+  failGraphql?: boolean;
+}): RunCommand {
+  const trackedInIssues = opts.trackedInIssues ?? [];
+  const trackedIssues = opts.trackedIssues ?? [];
+
+  return (async (command: string[]) => {
+    const rendered = command.join(" ");
+
+    if (rendered.includes("gh repo view --json owner,name")) {
+      return {
+        stdout: JSON.stringify({ owner: { login: "rayjolt" }, name: "devclaw" }),
+        stderr: "",
+        exitCode: 0,
+        code: 0,
+        signal: null,
+        killed: false,
+        termination: "exit",
+      } as any;
+    }
+
+    if (rendered.includes("gh api graphql")) {
+      if (opts.failGraphql) throw new Error("GraphQL is down");
+      return {
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              issue: {
+                trackedInIssues: { nodes: trackedInIssues },
+                trackedIssues: { nodes: trackedIssues },
+              },
+            },
+          },
+        }),
+        stderr: "",
+        exitCode: 0,
+        code: 0,
+        signal: null,
+        killed: false,
+        termination: "exit",
+      } as any;
+    }
+
+    throw new Error(`Unexpected command: ${rendered}`);
+  }) as RunCommand;
+}
+
+describe("GitHubProvider.getIssueDependencies", () => {
+  it("returns empty blockers/dependents when no dependencies exist", async () => {
+    const provider = new GitHubProvider({
+      repoPath: "/fake",
+      runCommand: createGitHubRunCommand({}),
+    });
+
+    const deps = await provider.getIssueDependencies(42);
+
+    assert.strictEqual(deps.issueId, 42);
+    assert.deepStrictEqual(deps.blockers, []);
+    assert.deepStrictEqual(deps.dependents, []);
+  });
+
+  it("normalizes a single blocker relation", async () => {
+    const provider = new GitHubProvider({
+      repoPath: "/fake",
+      runCommand: createGitHubRunCommand({
+        trackedInIssues: [
+          { number: 1, title: "Parent", state: "OPEN", url: "https://github.com/o/r/issues/1" },
+        ],
+      }),
+    });
+
+    const deps = await provider.getIssueDependencies(2);
+
+    assert.strictEqual(deps.blockers.length, 1);
+    assert.strictEqual(deps.blockers[0].iid, 1);
+    assert.strictEqual(deps.blockers[0].relation, "blocked_by");
+    assert.deepStrictEqual(deps.dependents, []);
+  });
+
+  it("normalizes multiple blockers and dependents", async () => {
+    const provider = new GitHubProvider({
+      repoPath: "/fake",
+      runCommand: createGitHubRunCommand({
+        trackedInIssues: [
+          { number: 1, title: "Blocker A", state: "OPEN", url: "https://github.com/o/r/issues/1" },
+          { number: 3, title: "Blocker B", state: "OPEN", url: "https://github.com/o/r/issues/3" },
+        ],
+        trackedIssues: [
+          { number: 7, title: "Dependent", state: "OPEN", url: "https://github.com/o/r/issues/7" },
+        ],
+      }),
+    });
+
+    const deps = await provider.getIssueDependencies(2);
+
+    assert.strictEqual(deps.blockers.length, 2);
+    assert.strictEqual(deps.blockers[1].iid, 3);
+    assert.strictEqual(deps.dependents.length, 1);
+    assert.strictEqual(deps.dependents[0].iid, 7);
+    assert.strictEqual(deps.dependents[0].relation, "blocks");
+  });
+
+  it("surfaces provider errors for upstream retry/fail-closed behavior", async () => {
+    const provider = new GitHubProvider({
+      repoPath: "/fake",
+      runCommand: createGitHubRunCommand({ failGraphql: true }),
+    });
+
+    await assert.rejects(() => provider.getIssueDependencies(2), /GraphQL is down/);
+  });
+});
+
+describe("GitLabProvider.getIssueDependencies", () => {
+  it("preserves backward compatibility with normalized empty graph", async () => {
+    const runCommand: RunCommand = (async () => {
+      throw new Error("should not be called");
+    }) as RunCommand;
+
+    const provider = new GitLabProvider({ repoPath: "/fake", runCommand });
+    const deps = await provider.getIssueDependencies(123);
+
+    assert.deepStrictEqual(deps, { issueId: 123, blockers: [], dependents: [] });
+  });
+});

--- a/lib/providers/provider.ts
+++ b/lib/providers/provider.ts
@@ -41,6 +41,8 @@ export type IssueDependency = {
   title: string;
   state: string;
   web_url: string;
+  /** Optional labels when provider can include them in dependency query payload. */
+  labels?: string[];
   relation: "blocks" | "blocked_by";
 };
 

--- a/lib/providers/provider.ts
+++ b/lib/providers/provider.ts
@@ -41,7 +41,7 @@ export type IssueDependency = {
   title: string;
   state: string;
   web_url: string;
-  /** Optional labels when provider can include them in dependency query payload. */
+  /** Optional labels when provider can include them in dependency payloads. */
   labels?: string[];
   relation: "blocks" | "blocked_by";
 };

--- a/lib/providers/provider.ts
+++ b/lib/providers/provider.ts
@@ -29,6 +29,30 @@ export type IssueComment = {
   created_at: string;
 };
 
+/**
+ * Provider-agnostic dependency edge for a single related issue.
+ *
+ * `relation` is from the perspective of the queried issue:
+ * - "blocks": this issue blocks the related issue (related is dependent)
+ * - "blocked_by": this issue is blocked by the related issue (related is blocker)
+ */
+export type IssueDependency = {
+  iid: number;
+  title: string;
+  state: string;
+  web_url: string;
+  relation: "blocks" | "blocked_by";
+};
+
+/**
+ * Normalized dependency graph slice for one issue.
+ */
+export type IssueDependencies = {
+  issueId: number;
+  blockers: IssueDependency[];
+  dependents: IssueDependency[];
+};
+
 /** Built-in PR states. */
 export const PrState = {
   OPEN: "open",
@@ -97,6 +121,11 @@ export interface IssueProvider {
   /** List issues with optional filters. Provider-agnostic — future Jira/Linear/Trello can map to native queries. */
   listIssues(opts?: { label?: string; state?: "open" | "closed" | "all" }): Promise<Issue[]>;
   getIssue(issueId: number): Promise<Issue>;
+  /**
+   * Get normalized dependency graph relations for an issue.
+   * Implementations should throw on provider/API failures so callers can retry/fail-closed.
+   */
+  getIssueDependencies(issueId: number): Promise<IssueDependencies>;
   listComments(issueId: number): Promise<IssueComment[]>;
   transitionLabel(issueId: number, from: StateLabel, to: StateLabel): Promise<void>;
   addLabel(issueId: number, label: string): Promise<void>;

--- a/lib/runtime/workspace-resolution.test.ts
+++ b/lib/runtime/workspace-resolution.test.ts
@@ -1,0 +1,99 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { resolveRuntimeWorkspace } from "./workspace-resolution.js";
+
+describe("runtime workspace resolution", () => {
+  it("prefers explicit plugin config runtimeWorkspace binding", async () => {
+    const ws = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-ws-binding-"));
+    try {
+      const res = resolveRuntimeWorkspace({
+        pluginConfig: {
+          runtimeWorkspace: { agentId: "devclaw", workspaceDir: ws },
+        },
+        config: {
+          agents: { list: [{ id: "devclaw", workspace: ws }] },
+        },
+        requireExists: true,
+      });
+
+      assert.equal(res.ok, true);
+      if (!res.ok) return;
+      assert.equal(res.source, "binding");
+      assert.equal(res.agentId, "devclaw");
+      assert.equal(res.workspaceDir, ws);
+    } finally {
+      await fs.rm(ws, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to legacy agents.list devclaw workspace (but never defaults)", async () => {
+    const legacyWs = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-ws-legacy-"));
+    const defaultWs = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-ws-default-"));
+    try {
+      const res = resolveRuntimeWorkspace({
+        pluginConfig: {},
+        config: {
+          agents: {
+            list: [{ id: "devclaw", workspace: legacyWs }],
+            defaults: { workspace: defaultWs },
+          },
+        },
+        requireExists: true,
+      });
+
+      assert.equal(res.ok, true);
+      if (!res.ok) return;
+      assert.equal(res.source, "legacy");
+      assert.equal(res.workspaceDir, legacyWs);
+    } finally {
+      await Promise.all([
+        fs.rm(legacyWs, { recursive: true, force: true }),
+        fs.rm(defaultWs, { recursive: true, force: true }),
+      ]);
+    }
+  });
+
+  it("fails closed when no binding is present (even if defaults workspace is set)", async () => {
+    const defaultWs = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-ws-default-only-"));
+    try {
+      const res = resolveRuntimeWorkspace({
+        pluginConfig: {},
+        config: {
+          agents: {
+            list: [],
+            defaults: { workspace: defaultWs },
+          },
+        },
+        requireExists: true,
+      });
+
+      assert.equal(res.ok, false);
+      if (res.ok) return;
+      assert.equal(res.source, "error");
+      assert.match(res.error, /could not be resolved/i);
+    } finally {
+      await fs.rm(defaultWs, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when binding workspaceDir does not exist", () => {
+    const missing = path.join(os.tmpdir(), `devclaw-missing-${Date.now()}`);
+    const res = resolveRuntimeWorkspace({
+      pluginConfig: {
+        runtimeWorkspace: { agentId: "devclaw", workspaceDir: missing },
+      },
+      config: {
+        agents: { list: [{ id: "devclaw", workspace: missing }] },
+      },
+      requireExists: true,
+    });
+
+    assert.equal(res.ok, false);
+    if (res.ok) return;
+    assert.match(res.error, /does not exist/i);
+  });
+});

--- a/lib/runtime/workspace-resolution.ts
+++ b/lib/runtime/workspace-resolution.ts
@@ -1,0 +1,142 @@
+/**
+ * runtime/workspace-resolution.ts — Canonical DevClaw runtime workspace resolver.
+ *
+ * Goal: prevent DevClaw runtime from "drifting" into other OpenClaw workspaces.
+ * Runtime must resolve a single authoritative workspace binding and fail closed
+ * if it cannot.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { homedir } from "node:os";
+
+export type WorkspaceResolutionSource = "binding" | "legacy" | "error";
+
+export type WorkspaceResolutionOk = {
+  ok: true;
+  agentId: string;
+  workspaceDir: string;
+  source: Exclude<WorkspaceResolutionSource, "error">;
+};
+
+export type WorkspaceResolutionErr = {
+  ok: false;
+  agentId: null;
+  workspaceDir: null;
+  source: "error";
+  error: string;
+};
+
+export type WorkspaceResolutionResult = WorkspaceResolutionOk | WorkspaceResolutionErr;
+
+export type OpenClawConfigLike = {
+  agents?: {
+    list?: Array<{ id: string; workspace?: string }>;
+    defaults?: { workspace?: string };
+  };
+};
+
+export type DevClawPluginConfigLike = {
+  /** Preferred: written by DevClaw setup into openclaw.json plugin config. */
+  runtimeWorkspace?: {
+    agentId?: string;
+    workspaceDir?: string;
+  };
+};
+
+function expandHome(p: string): string {
+  if (p === "~") return homedir();
+  if (p.startsWith("~/")) return path.join(homedir(), p.slice(2));
+  return p;
+}
+
+function normalizeWorkspaceDir(p: string): string {
+  // Expand ~ then resolve to an absolute path.
+  const expanded = expandHome(p.trim());
+  return path.resolve(expanded);
+}
+
+function isExistingDirectory(p: string): boolean {
+  try {
+    return fs.statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function err(message: string): WorkspaceResolutionErr {
+  return {
+    ok: false,
+    agentId: null,
+    workspaceDir: null,
+    source: "error",
+    error: message,
+  };
+}
+
+/**
+ * Resolve DevClaw runtime workspace binding.
+ *
+ * Resolution order:
+ *  1) Plugin config binding: pluginConfig.runtimeWorkspace { agentId, workspaceDir }
+ *  2) Legacy fallback: agents.list entry for id === "devclaw" (explicit agent workspace)
+ *
+ * Explicitly NOT allowed:
+ *  - agents.defaults.workspace
+ *  - hardcoded ~/.openclaw/workspace-devclaw fallbacks
+ */
+export function resolveRuntimeWorkspace(opts: {
+  pluginConfig?: Record<string, unknown> | undefined;
+  config?: OpenClawConfigLike | undefined;
+  /** If true (default), workspaceDir must exist as a directory. */
+  requireExists?: boolean;
+}): WorkspaceResolutionResult {
+  const requireExists = opts.requireExists ?? true;
+  const pluginCfg = (opts.pluginConfig ?? {}) as DevClawPluginConfigLike;
+  const fullCfg = (opts.config ?? {}) as OpenClawConfigLike;
+
+  // 1) Authoritative binding (preferred)
+  const binding = pluginCfg.runtimeWorkspace;
+  if (binding && (binding.agentId || binding.workspaceDir)) {
+    const agentId = String(binding.agentId ?? "").trim();
+    const rawWs = String(binding.workspaceDir ?? "").trim();
+    if (!agentId) return err("DevClaw runtime workspace binding is missing agentId (plugins.entries.devclaw.config.runtimeWorkspace.agentId)");
+    if (!rawWs) return err("DevClaw runtime workspace binding is missing workspaceDir (plugins.entries.devclaw.config.runtimeWorkspace.workspaceDir)");
+
+    const workspaceDir = normalizeWorkspaceDir(rawWs);
+
+    if (requireExists && !isExistingDirectory(workspaceDir)) {
+      return err(
+        `DevClaw runtime workspace directory does not exist: ${workspaceDir}. Re-run DevClaw setup for agent "${agentId}".`,
+      );
+    }
+
+    // Cross-check against agent list if present — prevents stale/mismatched binding.
+    const agentEntry = fullCfg.agents?.list?.find((a) => a.id === agentId);
+    if (agentEntry?.workspace) {
+      const agentWorkspace = normalizeWorkspaceDir(agentEntry.workspace);
+      if (agentWorkspace !== workspaceDir) {
+        return err(
+          `DevClaw runtime workspace binding mismatch for agent "${agentId}": pluginConfig=${workspaceDir} but agents.list=${agentWorkspace}`,
+        );
+      }
+    }
+
+    return { ok: true, agentId, workspaceDir, source: "binding" };
+  }
+
+  // 2) Legacy: explicit devclaw agent workspace in agents.list
+  const legacy = fullCfg.agents?.list?.find((a) => a.id === "devclaw");
+  if (legacy?.workspace) {
+    const workspaceDir = normalizeWorkspaceDir(legacy.workspace);
+    if (requireExists && !isExistingDirectory(workspaceDir)) {
+      return err(
+        `Legacy DevClaw agent workspace does not exist: ${workspaceDir}. Re-run DevClaw setup to write an explicit runtimeWorkspace binding.`,
+      );
+    }
+    return { ok: true, agentId: legacy.id, workspaceDir, source: "legacy" };
+  }
+
+  return err(
+    "DevClaw runtime workspace binding could not be resolved. Run the DevClaw setup tool to bind runtimeWorkspace (agentId + workspaceDir).",
+  );
+}

--- a/lib/services/bootstrap.e2e.test.ts
+++ b/lib/services/bootstrap.e2e.test.ts
@@ -102,8 +102,8 @@ describe("E2E bootstrap — extraSystemPrompt injection", () => {
     });
 
     const prompts = h.commands.extraSystemPrompts();
-    // No prompt files exist in this temp workspace — extraSystemPrompt should be absent
-    assert.strictEqual(prompts.length, 0, "No extraSystemPrompt when no prompt files exist");
+    assert.strictEqual(prompts.length, 1);
+    assert.ok(prompts[0].includes("# DEVELOPER Worker Instructions"));
   });
 
   it("should resolve tester instructions independently from developer", async () => {

--- a/lib/services/heartbeat/agent-discovery.test.ts
+++ b/lib/services/heartbeat/agent-discovery.test.ts
@@ -1,0 +1,60 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { discoverAgents } from "./agent-discovery.js";
+
+describe("heartbeat agent discovery", () => {
+  it("returns only the bound workspace (does not scan defaults workspace)", async () => {
+    const boundWs = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-bound-ws-"));
+    const defaultWs = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-default-ws-"));
+
+    try {
+      const { agents, resolution } = discoverAgents(
+        {
+          agents: {
+            list: [{ id: "devclaw", workspace: boundWs }],
+            defaults: { workspace: defaultWs },
+          },
+        } as any,
+        {
+          runtimeWorkspace: { agentId: "devclaw", workspaceDir: boundWs },
+        },
+      );
+
+      assert.equal(resolution.ok, true);
+      assert.equal(agents.length, 1);
+      assert.equal(agents[0].workspace, boundWs);
+    } finally {
+      await Promise.all([
+        fs.rm(boundWs, { recursive: true, force: true }),
+        fs.rm(defaultWs, { recursive: true, force: true }),
+      ]);
+    }
+  });
+
+  it("fails closed when no binding is resolvable (even if defaults is set)", async () => {
+    const defaultWs = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-default-ws-only-"));
+
+    try {
+      const { agents, resolution } = discoverAgents(
+        {
+          agents: {
+            list: [],
+            defaults: { workspace: defaultWs },
+          },
+        } as any,
+        {},
+      );
+
+      assert.equal(agents.length, 0);
+      assert.equal(resolution.ok, false);
+      if (resolution.ok) return;
+      assert.match(resolution.error, /could not be resolved/i);
+    } finally {
+      await fs.rm(defaultWs, { recursive: true, force: true });
+    }
+  });
+});

--- a/lib/services/heartbeat/agent-discovery.ts
+++ b/lib/services/heartbeat/agent-discovery.ts
@@ -1,70 +1,37 @@
 /**
- * Agent discovery — scan workspaces to find active DevClaw agents.
+ * Agent discovery — resolve the single authoritative DevClaw runtime workspace.
+ *
+ * DevClaw runtime must NOT scan arbitrary workspaces, must NOT fall back to
+ * agents.defaults.workspace, and must NOT infer a workspace from "devclaw markers".
  */
-import fs from "node:fs";
-import path from "node:path";
-import { DATA_DIR } from "../../setup/migrate-layout.js";
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
+import { resolveRuntimeWorkspace, type WorkspaceResolutionResult } from "../../runtime/workspace-resolution.js";
 
 export type Agent = {
   agentId: string;
   workspace: string;
 };
 
-// ---------------------------------------------------------------------------
-// Discovery
-// ---------------------------------------------------------------------------
-
 /**
- * Discover DevClaw agents by scanning which agent workspaces have projects.
- * Self-discovering: any agent whose workspace contains projects.json is processed.
- * Also checks the default workspace (agents.defaults.workspace) for projects.
+ * Discover DevClaw runtime agent(s).
+ *
+ * Returns at most one agent: the bound DevClaw runtime workspace.
  */
-export function discoverAgents(config: {
-  agents?: {
-    list?: Array<{ id: string; workspace?: string }>;
-    defaults?: { workspace?: string };
+export function discoverAgents(
+  config: any,
+  pluginConfig?: Record<string, unknown>,
+): { agents: Agent[]; resolution: WorkspaceResolutionResult } {
+  const resolution = resolveRuntimeWorkspace({
+    config: config as any,
+    pluginConfig,
+    requireExists: true,
+  });
+
+  if (!resolution.ok) {
+    return { agents: [], resolution };
+  }
+
+  return {
+    agents: [{ agentId: resolution.agentId, workspace: resolution.workspaceDir }],
+    resolution,
   };
-}): Agent[] {
-  const seen = new Set<string>();
-  const agents: Agent[] = [];
-
-  // Check explicit agent list
-  for (const a of config.agents?.list || []) {
-    if (!a.workspace) continue;
-    try {
-      if (hasProjects(a.workspace)) {
-        agents.push({ agentId: a.id, workspace: a.workspace });
-        seen.add(a.workspace);
-      }
-    } catch {
-      /* skip */
-    }
-  }
-
-  // Check default workspace (used when no explicit agents are registered)
-  const defaultWorkspace = config.agents?.defaults?.workspace;
-  if (defaultWorkspace && !seen.has(defaultWorkspace)) {
-    try {
-      if (hasProjects(defaultWorkspace)) {
-        agents.push({ agentId: "main", workspace: defaultWorkspace });
-      }
-    } catch {
-      /* skip */
-    }
-  }
-
-  return agents;
-}
-
-/** Check if a workspace has a projects.json (new or old locations). */
-export function hasProjects(workspace: string): boolean {
-  return (
-    fs.existsSync(path.join(workspace, DATA_DIR, "projects.json")) ||
-    fs.existsSync(path.join(workspace, "projects.json")) ||
-    fs.existsSync(path.join(workspace, "projects", "projects.json"))
-  );
 }

--- a/lib/services/heartbeat/index.test.ts
+++ b/lib/services/heartbeat/index.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { discoverAgents } from "./agent-discovery.js";
+import {
+  refreshWorkspaceScaffolding,
+  resetRefreshedWorkspacesForTests,
+} from "./index.js";
+
+afterEach(() => {
+  resetRefreshedWorkspacesForTests();
+});
+
+describe("heartbeat workspace refresh cadence", () => {
+  it("refreshes each workspace at most once across multiple ticks", async () => {
+    const calls: string[] = [];
+    const logger = {
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+    };
+
+    const agents = [
+      { agentId: "devclaw", workspace: "/tmp/ws-a" },
+      { agentId: "devclaw-2", workspace: "/tmp/ws-a" },
+    ];
+
+    await refreshWorkspaceScaffolding(agents, logger, async (workspaceDir) => {
+      calls.push(workspaceDir);
+    });
+    await refreshWorkspaceScaffolding(agents, logger, async (workspaceDir) => {
+      calls.push(workspaceDir);
+    });
+
+    assert.deepEqual(calls, ["/tmp/ws-a"]);
+  });
+
+  it("does not refresh agents.defaults.workspace when runtime binding resolves elsewhere", async () => {
+    const boundWs = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-bound-refresh-"));
+    const defaultWs = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-default-refresh-"));
+
+    // Marker path that previously caused confusion when defaults workspace was scanned.
+    await fs.mkdir(path.join(defaultWs, "devclaw"), { recursive: true });
+    await fs.writeFile(
+      path.join(defaultWs, "devclaw", "projects.json"),
+      JSON.stringify({ marker: true }),
+      "utf-8",
+    );
+
+    const logger = {
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+    };
+
+    try {
+      const { agents, resolution } = discoverAgents(
+        {
+          agents: {
+            list: [{ id: "devclaw", workspace: boundWs }],
+            defaults: { workspace: defaultWs },
+          },
+        } as any,
+        {
+          runtimeWorkspace: { agentId: "devclaw", workspaceDir: boundWs },
+        },
+      );
+
+      assert.equal(resolution.ok, true);
+
+      const calls: string[] = [];
+      await refreshWorkspaceScaffolding(agents, logger, async (workspaceDir) => {
+        calls.push(workspaceDir);
+      });
+
+      assert.deepEqual(calls, [boundWs]);
+      assert.equal(calls.includes(defaultWs), false);
+    } finally {
+      await Promise.all([
+        fs.rm(boundWs, { recursive: true, force: true }),
+        fs.rm(defaultWs, { recursive: true, force: true }),
+      ]);
+    }
+  });
+});

--- a/lib/services/heartbeat/index.ts
+++ b/lib/services/heartbeat/index.ts
@@ -114,7 +114,7 @@ async function runHeartbeatTick(
     }
 
     if (resolution.ok && resolution.source === "legacy") {
-      logger.warn("work_heartbeat: using legacy DevClaw workspace resolution (agents.list devclaw). Run setup to write plugins.entries.devclaw.config.runtimeWorkspace.");
+      logger.warn("work_heartbeat: using legacy DevClaw workspace resolution (agents.list devclaw). Re-run `devclaw setup` to write plugins.entries.devclaw.config.runtimeWorkspace.");
     }
 
     const result = await processAllAgents(agents, config, ctx.pluginConfig, logger, ctx.runCommand, ctx.runtime, resolution);

--- a/lib/services/heartbeat/index.ts
+++ b/lib/services/heartbeat/index.ts
@@ -18,6 +18,8 @@ import {
 } from "./health.js";
 import type { Agent } from "./agent-discovery.js";
 import { discoverAgents } from "./agent-discovery.js";
+import { logGlobal as auditLogGlobal } from "../../audit.js";
+import type { WorkspaceResolutionResult } from "../../runtime/workspace-resolution.js";
 import { HEARTBEAT_DEFAULTS, resolveHeartbeatConfig } from "./config.js";
 import type { HeartbeatConfig } from "./config.js";
 
@@ -100,10 +102,22 @@ async function runHeartbeatTick(
     const config = resolveHeartbeatConfig(ctx.pluginConfig);
     if (!config.enabled) return;
 
-    const agents = discoverAgents(ctx.config);
-    if (agents.length === 0) return;
+    const { agents, resolution } = discoverAgents(ctx.config, ctx.pluginConfig);
+    if (agents.length === 0) {
+      // Fail closed: do not scan defaults or infer workspaces.
+      logger.error(`work_heartbeat tick skipped: ${resolution.ok ? "no agents" : resolution.error}`);
+      await auditLogGlobal("heartbeat_tick_skipped", {
+        reason: resolution.ok ? "no agents resolved" : resolution.error,
+        resolutionSource: resolution.ok ? resolution.source : "error",
+      }).catch(() => {});
+      return;
+    }
 
-    const result = await processAllAgents(agents, config, ctx.pluginConfig, logger, ctx.runCommand, ctx.runtime);
+    if (resolution.ok && resolution.source === "legacy") {
+      logger.warn("work_heartbeat: using legacy DevClaw workspace resolution (agents.list devclaw). Run setup to write plugins.entries.devclaw.config.runtimeWorkspace.");
+    }
+
+    const result = await processAllAgents(agents, config, ctx.pluginConfig, logger, ctx.runCommand, ctx.runtime, resolution);
     logTickResult(result, logger);
   } catch (err) {
     logger.error(`work_heartbeat tick failed: ${err}`);
@@ -121,7 +135,8 @@ async function processAllAgents(
   pluginConfig: Record<string, unknown> | undefined,
   logger: ServiceContext["logger"],
   runCommand: import("../../context.js").RunCommand,
-  runtime?: PluginRuntime,
+  runtime: PluginRuntime | undefined,
+  resolution: WorkspaceResolutionResult,
 ): Promise<TickResult> {
   const result: TickResult = {
     totalPickups: 0,
@@ -151,6 +166,9 @@ async function processAllAgents(
     const agentResult = await tick({
       workspaceDir: workspace,
       agentId,
+      resolvedWorkspaceDir: workspace,
+      resolvedAgentId: agentId,
+      resolutionSource: resolution.ok ? resolution.source : "error",
       config,
       pluginConfig,
       sessions,

--- a/lib/services/heartbeat/index.ts
+++ b/lib/services/heartbeat/index.ts
@@ -91,6 +91,7 @@ export function registerHeartbeatService(api: OpenClawPluginApi, pluginCtx: Plug
  * (setInterval + async means the next tick can fire while the previous awaits).
  */
 let _tickRunning = false;
+const refreshedWorkspaces = new Set<string>();
 
 async function runHeartbeatTick(
   ctx: PluginContext,
@@ -147,17 +148,8 @@ async function processAllAgents(
     totalTestSkipTransitions: 0,
   };
 
-  // Ensure defaults are fresh on every startup (prompts, workflow, etc.)
-  const refreshedWorkspaces = new Set<string>();
-  for (const { workspace } of agents) {
-    if (refreshedWorkspaces.has(workspace)) continue;
-    refreshedWorkspaces.add(workspace);
-    try {
-      await ensureDefaultFiles(workspace);
-    } catch (err) {
-      logger.warn(`Workspace refresh failed for ${workspace}: ${(err as Error).message}`);
-    }
-  }
+  // Refresh scaffold files once per process/workspace (not once per tick).
+  await refreshWorkspaceScaffolding(agents, logger);
 
   // Fetch gateway sessions once for all agents/projects
   const sessions = await fetchGatewaySessions(undefined, runCommand);
@@ -186,6 +178,26 @@ async function processAllAgents(
   }
 
   return result;
+}
+
+export async function refreshWorkspaceScaffolding(
+  agents: Agent[],
+  logger: ServiceContext["logger"],
+  ensureDefaultFilesImpl: (workspaceDir: string) => Promise<void> = ensureDefaultFiles,
+): Promise<void> {
+  for (const { workspace } of agents) {
+    if (refreshedWorkspaces.has(workspace)) continue;
+    refreshedWorkspaces.add(workspace);
+    try {
+      await ensureDefaultFilesImpl(workspace);
+    } catch (err) {
+      logger.warn(`Workspace refresh failed for ${workspace}: ${(err as Error).message}`);
+    }
+  }
+}
+
+export function resetRefreshedWorkspacesForTests(): void {
+  refreshedWorkspaces.clear();
 }
 
 /**

--- a/lib/services/heartbeat/review-skip.ts
+++ b/lib/services/heartbeat/review-skip.ts
@@ -21,6 +21,7 @@ import { detectStepRouting } from "../queue-scan.js";
 import type { RunCommand } from "../../context.js";
 import { log as auditLog } from "../../audit.js";
 import { ciDiagnostics, getCiStatusWithRetry } from "../ci-gate.js";
+import { guardTerminalCompletion } from "../terminal-guard.js";
 
 /**
  * Scan review queue states and auto-merge + transition issues with review:skip.
@@ -62,6 +63,47 @@ export async function reviewSkipPass(opts: {
       // Only process issues managed by DevClaw (marked with 👀 on issue body).
       const isManaged = await provider.issueHasReaction(issue.iid, "eyes");
       if (!isManaged) continue;
+
+      // Pre-terminal guard (covers edge-case workflows where review:skip could lead to Done/closeIssue).
+      const guard = await guardTerminalCompletion({
+        workflow,
+        provider,
+        issueId: issue.iid,
+        fromLabel: state.label,
+        toState: targetState,
+        actions,
+      });
+
+      if (!guard.allow) {
+        const pr = guard.prStatus;
+        const prUrl = pr?.url ?? null;
+        try {
+          await provider.addComment(issue.iid, `⚠️ DevClaw blocked terminal completion: ${guard.reason} (${prUrl ?? "no PR url"}).`);
+        } catch { /* best-effort */ }
+        await auditLog(workspaceDir, "terminal_completion_blocked", {
+          project: projectName,
+          issueId: issue.iid,
+          from: state.label,
+          intendedTo: targetState.label,
+          reason: guard.reason,
+          prUrl,
+          prState: pr?.state,
+          mergeable: pr?.mergeable,
+        });
+        if (guard.toLabel) {
+          await provider.transitionLabel(issue.iid, state.label, guard.toLabel);
+          await auditLog(workspaceDir, "terminal_guard_transition", {
+            project: projectName,
+            issueId: issue.iid,
+            from: state.label,
+            to: guard.toLabel,
+            reason: guard.reason,
+            prUrl,
+          });
+          transitions++;
+        }
+        continue;
+      }
 
       // Execute SKIP transition actions
       let aborted = false;

--- a/lib/services/heartbeat/review.guard.test.ts
+++ b/lib/services/heartbeat/review.guard.test.ts
@@ -13,6 +13,7 @@ describe("heartbeat/review — terminal completion guard (human review path)", (
     // Custom workflow: approval would normally close immediately (terminal path), and we intentionally
     // omit the explicit MERGE_CONFLICT transition to ensure the shared terminal guard is doing the work.
     const workflow = structuredClone(DEFAULT_WORKFLOW);
+    workflow.states.toReview.on ??= {};
     workflow.states.toReview.on[WorkflowEvent.APPROVED] = { target: "done", actions: [Action.CLOSE_ISSUE] };
     delete (workflow.states.toReview.on as any)[WorkflowEvent.MERGE_CONFLICT];
 
@@ -45,6 +46,7 @@ describe("heartbeat/review — terminal completion guard (human review path)", (
 
     // Custom workflow: approval would close immediately, but it has no mergePr action.
     const workflow = structuredClone(DEFAULT_WORKFLOW);
+    workflow.states.toReview.on ??= {};
     workflow.states.toReview.on[WorkflowEvent.APPROVED] = { target: "done", actions: [Action.CLOSE_ISSUE] };
 
     provider.seedIssue({ iid: 21, title: "Approved but not merged", labels: ["To Review", "review:human"] });

--- a/lib/services/heartbeat/review.guard.test.ts
+++ b/lib/services/heartbeat/review.guard.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { reviewPass } from "./review.js";
+import { TestProvider } from "../../testing/test-provider.js";
+import { DEFAULT_WORKFLOW, Action, WorkflowEvent } from "../../workflow/index.js";
+import { PrState } from "../../providers/provider.js";
+
+describe("heartbeat/review — terminal completion guard (human review path)", () => {
+  it("blocks terminal completion and routes to To Improve when PR is conflicting (mergeable=false)", async () => {
+    const provider = new TestProvider();
+
+    // Custom workflow: approval would normally close immediately (terminal path), and we intentionally
+    // omit the explicit MERGE_CONFLICT transition to ensure the shared terminal guard is doing the work.
+    const workflow = structuredClone(DEFAULT_WORKFLOW);
+    workflow.states.toReview.on[WorkflowEvent.APPROVED] = { target: "done", actions: [Action.CLOSE_ISSUE] };
+    delete (workflow.states.toReview.on as any)[WorkflowEvent.MERGE_CONFLICT];
+
+    provider.seedIssue({ iid: 20, title: "Conflicting PR", labels: ["To Review", "review:human"] });
+    provider.setPrStatus(20, {
+      state: PrState.APPROVED,
+      url: "https://example/pr/20",
+      mergeable: false,
+    });
+
+    const n = await reviewPass({
+      workspaceDir: "/tmp",
+      projectName: "devclaw",
+      workflow,
+      provider,
+      repoPath: "/tmp/repo",
+      runCommand: (async () => ({ stdout: "", stderr: "", exitCode: 0, code: 0, signal: null, killed: false, termination: "exit" })) as any,
+    });
+
+    assert.equal(n, 1, "should transition away from terminal completion");
+
+    const issue = await provider.getIssue(20);
+    assert.ok(issue.labels.includes("To Improve"), `labels=${issue.labels.join(",")}`);
+    assert.equal(issue.state, "opened");
+    assert.equal(provider.callsTo("closeIssue").length, 0);
+  });
+
+  it("blocks terminal completion when auto-merge is off and PR is not merged yet (mergeable unknown)", async () => {
+    const provider = new TestProvider();
+
+    // Custom workflow: approval would close immediately, but it has no mergePr action.
+    const workflow = structuredClone(DEFAULT_WORKFLOW);
+    workflow.states.toReview.on[WorkflowEvent.APPROVED] = { target: "done", actions: [Action.CLOSE_ISSUE] };
+
+    provider.seedIssue({ iid: 21, title: "Approved but not merged", labels: ["To Review", "review:human"] });
+    provider.setPrStatus(21, {
+      state: PrState.APPROVED,
+      url: "https://example/pr/21",
+      // mergeable omitted/unknown — should not be treated as conflict, but auto-merge-off + unmerged must still block.
+    });
+
+    const n = await reviewPass({
+      workspaceDir: "/tmp",
+      projectName: "devclaw",
+      workflow,
+      provider,
+      repoPath: "/tmp/repo",
+      runCommand: (async () => ({ stdout: "", stderr: "", exitCode: 0, code: 0, signal: null, killed: false, termination: "exit" })) as any,
+    });
+
+    assert.equal(n, 0, "should not transition");
+
+    const issue = await provider.getIssue(21);
+    assert.ok(issue.labels.includes("To Review"), `labels=${issue.labels.join(",")}`);
+    assert.ok(!issue.labels.includes("Done"));
+    assert.equal(issue.state, "opened");
+
+    assert.equal(provider.callsTo("closeIssue").length, 0);
+    assert.equal(provider.callsTo("transitionLabel").length, 0);
+  });
+});

--- a/lib/services/heartbeat/review.ts
+++ b/lib/services/heartbeat/review.ts
@@ -18,6 +18,7 @@ import { detectStepRouting } from "../queue-scan.js";
 import type { RunCommand } from "../../context.js";
 import { log as auditLog } from "../../audit.js";
 import { ciDiagnostics, getCiStatusWithRetry } from "../ci-gate.js";
+import { guardTerminalCompletion } from "../terminal-guard.js";
 
 /**
  * Scan review-type states and transition issues whose PR check condition is met.
@@ -228,6 +229,59 @@ export async function reviewPass(opts: {
       const actions = typeof transition === "object" ? transition.actions : undefined;
       const targetState = workflow.states[targetKey];
       if (!targetState) continue;
+
+      // Pre-terminal guard: do not allow Done/closeIssue when PR is conflicting,
+      // or when auto-merge is off and PR is not actually merged yet.
+      const guard = await guardTerminalCompletion({
+        workflow,
+        provider,
+        issueId: issue.iid,
+        fromLabel: state.label,
+        toState: targetState,
+        actions,
+      });
+
+      if (!guard.allow) {
+        const pr = guard.prStatus;
+        const prUrl = pr?.url ?? status.url ?? null;
+        try {
+          if (guard.reason === "merge_conflict") {
+            await provider.addComment(issue.iid, `⚠️ DevClaw blocked terminal completion: PR has merge conflicts (${prUrl ?? "no PR url"}).`);
+          } else if (guard.reason === "pr_not_merged_auto_merge_off") {
+            await provider.addComment(issue.iid, `⏸️ DevClaw blocked terminal completion: auto-merge is off and PR is not merged yet (${prUrl ?? "no PR url"}). Merge the PR, then the heartbeat will close this issue.`);
+          } else if (guard.reason === "pr_closed_unmerged") {
+            await provider.addComment(issue.iid, `⚠️ DevClaw blocked terminal completion: PR was closed without merging (${prUrl ?? "no PR url"}).`);
+          } else {
+            await provider.addComment(issue.iid, "⚠️ DevClaw blocked terminal completion: unable to verify PR mergeability/merge state.");
+          }
+        } catch { /* best-effort */ }
+
+        await auditLog(workspaceDir, "terminal_completion_blocked", {
+          project: projectName,
+          issueId: issue.iid,
+          from: state.label,
+          intendedTo: targetState.label,
+          reason: guard.reason,
+          prUrl,
+          prState: pr?.state ?? status.state,
+          mergeable: pr?.mergeable ?? status.mergeable,
+        });
+
+        if (guard.toLabel) {
+          await provider.transitionLabel(issue.iid, state.label, guard.toLabel);
+          await auditLog(workspaceDir, "terminal_guard_transition", {
+            project: projectName,
+            issueId: issue.iid,
+            from: state.label,
+            to: guard.toLabel,
+            reason: guard.reason,
+            prUrl,
+          });
+          transitions++;
+        }
+
+        continue;
+      }
 
       // Execute transition actions — mergePr is critical (aborts on failure)
       let aborted = false;

--- a/lib/services/heartbeat/test-skip.guard.test.ts
+++ b/lib/services/heartbeat/test-skip.guard.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { createTestHarness } from "../../testing/harness.js";
+import { testSkipPass } from "./test-skip.js";
+
+describe("heartbeat/test-skip — terminal completion guard", () => {
+  it("routes to To Improve and does not close when PR is conflicting (mergeable=false)", async () => {
+    const h = await createTestHarness();
+    try {
+      h.provider.seedIssue({ iid: 1, title: "Conflict", labels: ["To Test", "test:skip"] });
+      h.provider.setPrStatus(1, { state: "open", url: "https://example.com/pr/1", mergeable: false });
+
+      const n = await testSkipPass({
+        workspaceDir: h.workspaceDir,
+        projectName: h.project.name,
+        workflow: h.workflow,
+        provider: h.provider,
+      });
+
+      assert.equal(n, 1, "should transition once (to feedback state)");
+
+      const issue = await h.provider.getIssue(1);
+      assert.ok(issue.labels.includes("To Improve"), `labels=${issue.labels.join(",")}`);
+      assert.equal(issue.state, "opened", "should not close issue on conflict");
+
+      assert.equal(h.provider.callsTo("closeIssue").length, 0);
+    } finally {
+      await h.cleanup();
+    }
+  });
+
+  it("does not transition to Done (and does not close) when auto-merge is off and PR is not merged", async () => {
+    const h = await createTestHarness();
+    try {
+      h.provider.seedIssue({ iid: 2, title: "Unmerged", labels: ["To Test", "test:skip"] });
+      h.provider.setPrStatus(2, { state: "approved", url: "https://example.com/pr/2", mergeable: true });
+
+      const n = await testSkipPass({
+        workspaceDir: h.workspaceDir,
+        projectName: h.project.name,
+        workflow: h.workflow,
+        provider: h.provider,
+      });
+
+      assert.equal(n, 0, "should not transition");
+
+      const issue = await h.provider.getIssue(2);
+      assert.ok(issue.labels.includes("To Test"), `labels=${issue.labels.join(",")}`);
+      assert.ok(!issue.labels.includes("Done"));
+      assert.equal(issue.state, "opened");
+
+      assert.equal(h.provider.callsTo("closeIssue").length, 0);
+      assert.equal(h.provider.callsTo("transitionLabel").length, 0);
+    } finally {
+      await h.cleanup();
+    }
+  });
+
+  it("allows transition to Done + close after PR is merged", async () => {
+    const h = await createTestHarness();
+    try {
+      h.provider.seedIssue({ iid: 3, title: "Merged", labels: ["To Test", "test:skip"] });
+      h.provider.setPrStatus(3, { state: "merged", url: "https://example.com/pr/3", mergeable: true });
+
+      const n = await testSkipPass({
+        workspaceDir: h.workspaceDir,
+        projectName: h.project.name,
+        workflow: h.workflow,
+        provider: h.provider,
+      });
+
+      assert.equal(n, 1);
+
+      const issue = await h.provider.getIssue(3);
+      assert.ok(issue.labels.includes("Done"), `labels=${issue.labels.join(",")}`);
+      assert.equal(issue.state, "closed", "should close issue when completing");
+
+      assert.equal(h.provider.callsTo("closeIssue").length, 1);
+    } finally {
+      await h.cleanup();
+    }
+  });
+});

--- a/lib/services/heartbeat/test-skip.guard.test.ts
+++ b/lib/services/heartbeat/test-skip.guard.test.ts
@@ -81,4 +81,30 @@ describe("heartbeat/test-skip — terminal completion guard", () => {
       await h.cleanup();
     }
   });
+
+  it("treats mergeable=unknown as non-conflicting (still allows close when PR is merged)", async () => {
+    const h = await createTestHarness();
+    try {
+      h.provider.seedIssue({ iid: 4, title: "Merged (unknown mergeable)", labels: ["To Test", "test:skip"] });
+      // mergeable omitted/unknown — should not be treated as conflicting.
+      h.provider.setPrStatus(4, { state: "merged", url: "https://example.com/pr/4" });
+
+      const n = await testSkipPass({
+        workspaceDir: h.workspaceDir,
+        projectName: h.project.name,
+        workflow: h.workflow,
+        provider: h.provider,
+      });
+
+      assert.equal(n, 1);
+
+      const issue = await h.provider.getIssue(4);
+      assert.ok(issue.labels.includes("Done"), `labels=${issue.labels.join(",")}`);
+      assert.equal(issue.state, "closed");
+
+      assert.equal(h.provider.callsTo("closeIssue").length, 1);
+    } finally {
+      await h.cleanup();
+    }
+  });
 });

--- a/lib/services/heartbeat/test-skip.ts
+++ b/lib/services/heartbeat/test-skip.ts
@@ -17,6 +17,7 @@ import {
 } from "../../workflow/index.js";
 import { detectStepRouting } from "../queue-scan.js";
 import { log as auditLog } from "../../audit.js";
+import { guardTerminalCompletion } from "../terminal-guard.js";
 
 /**
  * Scan test queue states and auto-transition issues with test:skip.
@@ -48,6 +49,60 @@ export async function testSkipPass(opts: {
     for (const issue of issues) {
       const routing = detectStepRouting(issue.labels, "test");
       if (routing !== "skip") continue;
+
+      // Pre-terminal guard: never allow Done/closeIssue if PR is conflicting or not merged (auto-merge off).
+      const guard = await guardTerminalCompletion({
+        workflow,
+        provider,
+        issueId: issue.iid,
+        fromLabel: state.label,
+        toState: targetState,
+        actions,
+      });
+
+      if (!guard.allow) {
+        const pr = guard.prStatus;
+        const prUrl = pr?.url ?? null;
+
+        // Best-effort: leave a clear breadcrumb.
+        try {
+          if (guard.reason === "merge_conflict") {
+            await provider.addComment(issue.iid, `⚠️ DevClaw blocked terminal completion: PR has merge conflicts (${prUrl ?? "no PR url"}).`);
+          } else if (guard.reason === "pr_not_merged_auto_merge_off") {
+            await provider.addComment(issue.iid, `⏸️ DevClaw blocked terminal completion: auto-merge is off and PR is not merged yet (${prUrl ?? "no PR url"}). Merge the PR, then the heartbeat will close this issue.`);
+          } else if (guard.reason === "pr_closed_unmerged") {
+            await provider.addComment(issue.iid, `⚠️ DevClaw blocked terminal completion: PR was closed without merging (${prUrl ?? "no PR url"}).`);
+          } else {
+            await provider.addComment(issue.iid, "⚠️ DevClaw blocked terminal completion: unable to verify PR mergeability/merge state.");
+          }
+        } catch { /* best-effort */ }
+
+        await auditLog(workspaceDir, "terminal_completion_blocked", {
+          project: projectName,
+          issueId: issue.iid,
+          from: state.label,
+          intendedTo: targetState.label,
+          reason: guard.reason,
+          prUrl,
+          prState: pr?.state,
+          mergeable: pr?.mergeable,
+        });
+
+        if (guard.toLabel) {
+          await provider.transitionLabel(issue.iid, state.label, guard.toLabel);
+          await auditLog(workspaceDir, "terminal_guard_transition", {
+            project: projectName,
+            issueId: issue.iid,
+            from: state.label,
+            to: guard.toLabel,
+            reason: guard.reason,
+            prUrl,
+          });
+          transitions++;
+        }
+
+        continue;
+      }
 
       // Execute SKIP transition actions
       if (actions) {

--- a/lib/services/heartbeat/tick-runner.audit.test.ts
+++ b/lib/services/heartbeat/tick-runner.audit.test.ts
@@ -1,0 +1,48 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { tick } from "./tick-runner.js";
+
+const noopRunCommand = (async () => ({
+  stdout: "{}",
+  stderr: "",
+  code: 0,
+  signal: null,
+  killed: false,
+})) as any;
+
+describe("heartbeat tick audit payload", () => {
+  it("includes resolved workspace fields in heartbeat_tick audit event", async () => {
+    const ws = await fs.mkdtemp(path.join(os.tmpdir(), "devclaw-tick-audit-"));
+    try {
+      await tick({
+        workspaceDir: ws,
+        agentId: "devclaw",
+        resolvedWorkspaceDir: ws,
+        resolvedAgentId: "devclaw",
+        resolutionSource: "binding",
+        config: { intervalSeconds: 60, enabled: true, maxPickupsPerTick: 1 } as any,
+        pluginConfig: {},
+        sessions: null,
+        logger: { info() {}, warn() {} },
+        runtime: undefined,
+        runCommand: noopRunCommand,
+      });
+
+      const auditPath = path.join(ws, "devclaw", "log", "audit.log");
+      const raw = await fs.readFile(auditPath, "utf-8");
+      const lines = raw.trim().split("\n");
+      const last = JSON.parse(lines[lines.length - 1]);
+
+      assert.equal(last.event, "heartbeat_tick");
+      assert.equal(last.resolvedWorkspaceDir, ws);
+      assert.equal(last.resolvedAgentId, "devclaw");
+      assert.equal(last.resolutionSource, "binding");
+    } finally {
+      await fs.rm(ws, { recursive: true, force: true });
+    }
+  });
+});

--- a/lib/services/heartbeat/tick-runner.ts
+++ b/lib/services/heartbeat/tick-runner.ts
@@ -178,7 +178,6 @@ export async function tick(opts: {
         maxPickups: remaining,
         runtime,
         instanceName,
-        runtime,
         runCommand,
       });
 

--- a/lib/services/heartbeat/tick-runner.ts
+++ b/lib/services/heartbeat/tick-runner.ts
@@ -45,6 +45,10 @@ export type TickResult = {
 export async function tick(opts: {
   workspaceDir: string;
   agentId?: string;
+  /** Explicit workspace resolution metadata for auditing. */
+  resolvedWorkspaceDir?: string;
+  resolvedAgentId?: string;
+  resolutionSource?: "binding" | "legacy" | "error";
   config: HeartbeatConfig;
   pluginConfig?: Record<string, unknown>;
   sessions: SessionLookup | null;
@@ -72,17 +76,6 @@ export async function tick(opts: {
   const data = await readProjects(workspaceDir);
   const slugs = Object.keys(data.projects);
 
-  if (slugs.length === 0) {
-    return {
-      totalPickups: 0,
-      totalHealthFixes: 0,
-      totalSkipped: 0,
-      totalReviewTransitions: 0,
-      totalReviewSkipTransitions: 0,
-      totalTestSkipTransitions: 0,
-    };
-  }
-
   const result: TickResult = {
     totalPickups: 0,
     totalHealthFixes: 0,
@@ -91,6 +84,24 @@ export async function tick(opts: {
     totalReviewSkipTransitions: 0,
     totalTestSkipTransitions: 0,
   };
+
+  // If there are no projects yet, still emit an audited tick for visibility.
+  if (slugs.length === 0) {
+    await auditLog(workspaceDir, "heartbeat_tick", {
+      resolvedWorkspaceDir: opts.resolvedWorkspaceDir ?? workspaceDir,
+      resolvedAgentId: opts.resolvedAgentId ?? agentId ?? null,
+      resolutionSource: opts.resolutionSource ?? null,
+      projectsScanned: 0,
+      healthFixes: 0,
+      reviewTransitions: 0,
+      reviewSkipTransitions: 0,
+      testSkipTransitions: 0,
+      pickups: 0,
+      skipped: 0,
+    });
+
+    return result;
+  }
 
   const projectExecution =
     (pluginConfig?.projectExecution as string) ?? ExecutionMode.PARALLEL;
@@ -196,6 +207,9 @@ export async function tick(opts: {
   }
 
   await auditLog(workspaceDir, "heartbeat_tick", {
+    resolvedWorkspaceDir: opts.resolvedWorkspaceDir ?? workspaceDir,
+    resolvedAgentId: opts.resolvedAgentId ?? agentId ?? null,
+    resolutionSource: opts.resolutionSource ?? null,
     projectsScanned: slugs.length,
     healthFixes: result.totalHealthFixes,
     reviewTransitions: result.totalReviewTransitions,

--- a/lib/services/pipeline-terminal-guard.test.ts
+++ b/lib/services/pipeline-terminal-guard.test.ts
@@ -1,0 +1,94 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { executeCompletion } from "./pipeline.js";
+import { createTestHarness } from "../testing/index.js";
+
+// Regression: pipeline completion must never execute terminal side effects
+// (especially closeIssue) when the shared terminal guard blocks.
+
+describe("executeCompletion terminal guard (pipeline)", () => {
+  it("does not close issue when PR is conflicting (mergeable=false)", async () => {
+    const h = await createTestHarness({
+      workers: {
+        tester: { active: true, issueId: "34", level: "senior" },
+      },
+    });
+
+    h.provider.seedIssue({
+      iid: 34,
+      title: "Conflicting PR should block terminal completion",
+      labels: ["Testing"],
+    });
+
+    h.provider.setPrStatus(34, {
+      state: "open",
+      url: "https://example.com/pr/34",
+      mergeable: false,
+    });
+
+    const out = await executeCompletion({
+      workspaceDir: h.workspaceDir,
+      projectSlug: h.project.slug,
+      channels: h.project.channels,
+      role: "tester",
+      result: "pass",
+      issueId: 34,
+      summary: "pass",
+      provider: h.provider,
+      repoPath: "/tmp/test-repo",
+      projectName: "test-project",
+      runCommand: h.runCommand,
+    });
+
+    assert.strictEqual(out.labelTransition, "Testing → To Improve");
+    assert.strictEqual(h.provider.callsTo("closeIssue").length, 0);
+
+    const issue = await h.provider.getIssue(34);
+    assert.strictEqual(issue.state, "opened");
+    assert.ok(issue.labels.includes("To Improve"), `labels=${issue.labels.join(",")}`);
+  });
+
+  it("does not close issue when auto-merge is off and PR is not merged", async () => {
+    const h = await createTestHarness({
+      workers: {
+        tester: { active: true, issueId: "35", level: "senior" },
+      },
+    });
+
+    h.provider.seedIssue({
+      iid: 35,
+      title: "Unmerged PR should block terminal completion when auto-merge is off",
+      labels: ["Testing"],
+    });
+
+    // mergeable unknown/true should not matter; without mergePr in the action list,
+    // terminal completion must wait for provider to report PR merged.
+    h.provider.setPrStatus(35, {
+      state: "open",
+      url: "https://example.com/pr/35",
+      mergeable: true,
+    });
+
+    const out = await executeCompletion({
+      workspaceDir: h.workspaceDir,
+      projectSlug: h.project.slug,
+      channels: h.project.channels,
+      role: "tester",
+      result: "pass",
+      issueId: 35,
+      summary: "pass",
+      provider: h.provider,
+      repoPath: "/tmp/test-repo",
+      projectName: "test-project",
+      runCommand: h.runCommand,
+    });
+
+    // Guard blocks without suggesting a state change; pipeline stays put.
+    assert.strictEqual(out.labelTransition, "Testing → Testing");
+    assert.strictEqual(h.provider.callsTo("closeIssue").length, 0);
+
+    const issue = await h.provider.getIssue(35);
+    assert.strictEqual(issue.state, "opened");
+    assert.ok(issue.labels.includes("Testing"), `labels=${issue.labels.join(",")}`);
+  });
+});

--- a/lib/services/pipeline.ts
+++ b/lib/services/pipeline.ts
@@ -110,6 +110,69 @@ export async function executeCompletion(opts: {
   let terminalGuardOverrideToLabel: string | null = null;
   let terminalGuardReason: string | null = null;
 
+  // IMPORTANT: pre-terminal guard must run before any terminal side effects.
+  // Pipeline actions can include side effects (merge, close) — so we compute the
+  // guard upfront and then skip any terminal actions if the guard blocks.
+  const intendedTargetState = findStateByLabel(workflow, rule.to);
+  const terminalGuard = intendedTargetState
+    ? await guardTerminalCompletion({
+        workflow,
+        provider,
+        issueId,
+        fromLabel: rule.from,
+        toState: intendedTargetState,
+        actions: rule.actions,
+      })
+    : null;
+
+  const terminalBlocked = terminalGuard?.allow === false;
+  if (terminalGuard && terminalGuard.allow === false) {
+    const pr = terminalGuard.prStatus;
+    const guardPrUrl = pr?.url ?? null;
+    terminalGuardReason = terminalGuard.reason;
+    terminalGuardOverrideToLabel = terminalGuard.toLabel ?? rule.from;
+
+    // Best-effort: leave breadcrumbs for humans.
+    try {
+      if (terminalGuard.reason === "merge_conflict") {
+        await provider.addComment(
+          issueId,
+          `⚠️ DevClaw blocked terminal completion: PR has merge conflicts (${guardPrUrl ?? "no PR url"}).`,
+        );
+      } else if (terminalGuard.reason === "pr_not_merged_auto_merge_off") {
+        await provider.addComment(
+          issueId,
+          `⏸️ DevClaw blocked terminal completion: auto-merge is off and PR is not merged yet (${guardPrUrl ?? "no PR url"}). Merge the PR, then DevClaw will close this issue.`,
+        );
+      } else if (terminalGuard.reason === "pr_closed_unmerged") {
+        await provider.addComment(
+          issueId,
+          `⚠️ DevClaw blocked terminal completion: PR was closed without merging (${guardPrUrl ?? "no PR url"}).`,
+        );
+      } else {
+        await provider.addComment(
+          issueId,
+          "⚠️ DevClaw blocked terminal completion: unable to verify PR mergeability/merge state.",
+        );
+      }
+    } catch {
+      /* best-effort */
+    }
+
+    await auditLog(workspaceDir, "terminal_completion_blocked", {
+      project: projectName,
+      issueId,
+      from: rule.from,
+      intendedTo: rule.to,
+      reason: terminalGuard.reason,
+      prUrl: guardPrUrl,
+      prState: pr?.state,
+      mergeable: pr?.mergeable,
+      correlationId,
+      path: "pipeline",
+    }).catch(() => {});
+  }
+
   for (const action of rule.actions) {
     switch (action) {
       case Action.GIT_PULL:
@@ -150,6 +213,8 @@ export async function executeCompletion(opts: {
         }
         break;
       case Action.MERGE_PR:
+        // If the pre-terminal guard blocks, do not attempt terminal side effects.
+        if (terminalBlocked) break;
         try {
           if (!prTitle) {
             try {
@@ -229,55 +294,9 @@ export async function executeCompletion(opts: {
   let nextState = getNextStateDescription(workflow, role, result);
   const notifyConfig = getNotificationConfig(pluginConfig);
 
-  // Pre-terminal guard (covers pipeline-driven transitions too, not only heartbeat):
-  // never allow terminal completion if PR is conflicting, and when auto-merge is off
-  // do not close until provider reports PR merged.
-  const intendedTargetState = findStateByLabel(workflow, rule.to);
-  if (intendedTargetState) {
-    const guard = await guardTerminalCompletion({
-      workflow,
-      provider,
-      issueId,
-      fromLabel: rule.from,
-      toState: intendedTargetState,
-      actions: rule.actions,
-    });
 
-    if (!guard.allow) {
-      const pr = guard.prStatus;
-      const prUrl = pr?.url ?? null;
-      terminalGuardReason = guard.reason;
-      terminalGuardOverrideToLabel = guard.toLabel ?? rule.from;
-
-      try {
-        if (guard.reason === "merge_conflict") {
-          await provider.addComment(issueId, `⚠️ DevClaw blocked terminal completion: PR has merge conflicts (${prUrl ?? "no PR url"}).`);
-        } else if (guard.reason === "pr_not_merged_auto_merge_off") {
-          await provider.addComment(issueId, `⏸️ DevClaw blocked terminal completion: auto-merge is off and PR is not merged yet (${prUrl ?? "no PR url"}). Merge the PR, then DevClaw will close this issue.`);
-        } else if (guard.reason === "pr_closed_unmerged") {
-          await provider.addComment(issueId, `⚠️ DevClaw blocked terminal completion: PR was closed without merging (${prUrl ?? "no PR url"}).`);
-        } else {
-          await provider.addComment(issueId, "⚠️ DevClaw blocked terminal completion: unable to verify PR mergeability/merge state.");
-        }
-      } catch {
-        /* best-effort */
-      }
-
-      await auditLog(workspaceDir, "terminal_completion_blocked", {
-        project: projectName,
-        issueId,
-        from: rule.from,
-        intendedTo: rule.to,
-        reason: guard.reason,
-        prUrl,
-        prState: pr?.state,
-        mergeable: pr?.mergeable,
-        correlationId,
-        path: "pipeline",
-      }).catch(() => {});
-
-      nextState = `blocked: ${guard.reason}`;
-    }
+  if (terminalBlocked && terminalGuardReason) {
+    nextState = `blocked: ${terminalGuardReason}`;
   }
 
   let workerName: string | undefined;

--- a/lib/services/pipeline.ts
+++ b/lib/services/pipeline.ts
@@ -331,7 +331,9 @@ export async function executeCompletion(opts: {
     updatedIssue = transitionResult.issue;
   }
 
-  const runPostActions = transitioned && effectiveTo === rule.to;
+  // Post-actions are allowed only when we actually transition to the rule's
+  // intended state (rule.to) AND the terminal guard did not block.
+  const runPostActions = !terminalBlocked && transitioned && effectiveTo === rule.to;
   if (runPostActions) {
     for (const action of rule.actions) {
       switch (action) {

--- a/lib/services/pipeline.ts
+++ b/lib/services/pipeline.ts
@@ -21,6 +21,7 @@ import { log as auditLog } from "../audit.js";
 import { loadConfig } from "../config/index.js";
 import { detectStepRouting } from "./queue-scan.js";
 import { ciDiagnostics, getCiStatusWithRetry } from "./ci-gate.js";
+import { guardTerminalCompletion } from "./terminal-guard.js";
 import {
   Action,
   DEFAULT_WORKFLOW,
@@ -29,6 +30,7 @@ import {
   getStateLabels,
   getNextStateDescription,
   resolveNotifyChannel,
+  findStateByLabel,
   type CompletionRule,
   type WorkflowConfig,
 } from "../workflow/index.js";
@@ -105,6 +107,8 @@ export async function executeCompletion(opts: {
   let prTitle: string | undefined;
   let sourceBranch: string | undefined;
   let ciOverrideToLabel: string | null = null;
+  let terminalGuardOverrideToLabel: string | null = null;
+  let terminalGuardReason: string | null = null;
 
   for (const action of rule.actions) {
     switch (action) {
@@ -222,8 +226,59 @@ export async function executeCompletion(opts: {
 
   const issueBefore = await provider.getIssue(issueId);
   const notifyTarget = resolveNotifyChannel(issueBefore.labels, channels);
-  const nextState = getNextStateDescription(workflow, role, result);
+  let nextState = getNextStateDescription(workflow, role, result);
   const notifyConfig = getNotificationConfig(pluginConfig);
+
+  // Pre-terminal guard (covers pipeline-driven transitions too, not only heartbeat):
+  // never allow terminal completion if PR is conflicting, and when auto-merge is off
+  // do not close until provider reports PR merged.
+  const intendedTargetState = findStateByLabel(workflow, rule.to);
+  if (intendedTargetState) {
+    const guard = await guardTerminalCompletion({
+      workflow,
+      provider,
+      issueId,
+      fromLabel: rule.from,
+      toState: intendedTargetState,
+      actions: rule.actions,
+    });
+
+    if (!guard.allow) {
+      const pr = guard.prStatus;
+      const prUrl = pr?.url ?? null;
+      terminalGuardReason = guard.reason;
+      terminalGuardOverrideToLabel = guard.toLabel ?? rule.from;
+
+      try {
+        if (guard.reason === "merge_conflict") {
+          await provider.addComment(issueId, `⚠️ DevClaw blocked terminal completion: PR has merge conflicts (${prUrl ?? "no PR url"}).`);
+        } else if (guard.reason === "pr_not_merged_auto_merge_off") {
+          await provider.addComment(issueId, `⏸️ DevClaw blocked terminal completion: auto-merge is off and PR is not merged yet (${prUrl ?? "no PR url"}). Merge the PR, then DevClaw will close this issue.`);
+        } else if (guard.reason === "pr_closed_unmerged") {
+          await provider.addComment(issueId, `⚠️ DevClaw blocked terminal completion: PR was closed without merging (${prUrl ?? "no PR url"}).`);
+        } else {
+          await provider.addComment(issueId, "⚠️ DevClaw blocked terminal completion: unable to verify PR mergeability/merge state.");
+        }
+      } catch {
+        /* best-effort */
+      }
+
+      await auditLog(workspaceDir, "terminal_completion_blocked", {
+        project: projectName,
+        issueId,
+        from: rule.from,
+        intendedTo: rule.to,
+        reason: guard.reason,
+        prUrl,
+        prState: pr?.state,
+        mergeable: pr?.mergeable,
+        correlationId,
+        path: "pipeline",
+      }).catch(() => {});
+
+      nextState = `blocked: ${guard.reason}`;
+    }
+  }
 
   let workerName: string | undefined;
   try {
@@ -237,7 +292,7 @@ export async function executeCompletion(opts: {
     // best-effort
   }
 
-  const effectiveTo = ciOverrideToLabel ?? (rule.to as StateLabel);
+  const effectiveTo = (terminalGuardOverrideToLabel ?? ciOverrideToLabel ?? (rule.to as StateLabel)) as StateLabel;
   const transitioned = effectiveTo !== rule.from;
 
   let updatedIssue = issueBefore;
@@ -391,9 +446,11 @@ export async function executeCompletion(opts: {
     }
   }
   const effectiveNextState =
-    ciOverrideToLabel && ciOverrideToLabel !== rule.to
-      ? `CI gate applied (${rule.from} → ${ciOverrideToLabel})`
-      : nextState;
+    terminalGuardReason
+      ? `Terminal guard blocked completion (${terminalGuardReason})`
+      : (ciOverrideToLabel && ciOverrideToLabel !== rule.to
+        ? `CI gate applied (${rule.from} → ${ciOverrideToLabel})`
+        : nextState);
 
   announcement += `\n${effectiveNextState}.`;
 

--- a/lib/services/queue-scan-dependencies.test.ts
+++ b/lib/services/queue-scan-dependencies.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
-import { findNextIssueForRole } from "./queue-scan.js";
+import { findNextIssueForRole, getDependencyGateStatus } from "./queue-scan.js";
 import { DEFAULT_WORKFLOW } from "../workflow/index.js";
 import type { Issue, IssueDependencies, IssueProvider } from "../providers/provider.js";
 
@@ -118,5 +118,59 @@ describe("findNextIssueForRole dependency gating", () => {
     assert.ok(next);
     assert.strictEqual(next!.issue.iid, 12);
     assert.strictEqual(attempts, 3);
+  });
+
+  it("detects direct dependency cycle A↔B", async () => {
+    const provider: QueueProvider = {
+      async listIssuesByLabel() {
+        return [issue(1)];
+      },
+      async getIssueDependencies(issueId: number): Promise<IssueDependencies> {
+        if (issueId === 1) {
+          return {
+            issueId,
+            blockers: [{ iid: 2, title: "B", state: "OPEN", web_url: "u", relation: "blocked_by" }],
+            dependents: [],
+          };
+        }
+        return {
+          issueId,
+          blockers: [{ iid: 1, title: "A", state: "OPEN", web_url: "u", relation: "blocked_by" }],
+          dependents: [],
+        };
+      },
+    };
+
+    const gate = await getDependencyGateStatus(provider, { iid: 1 }, DEFAULT_WORKFLOW);
+    assert.strictEqual(gate.blocked, true);
+    assert.strictEqual(gate.kind, "cycle");
+    assert.deepStrictEqual(gate.cyclePath, [1, 2, 1]);
+  });
+
+  it("detects indirect dependency cycle A→B→C→A and invokes cycle callback", async () => {
+    const provider: QueueProvider = {
+      async listIssuesByLabel() {
+        return [issue(1)];
+      },
+      async getIssueDependencies(issueId: number): Promise<IssueDependencies> {
+        if (issueId === 1) {
+          return { issueId, blockers: [{ iid: 2, title: "B", state: "OPEN", web_url: "u", relation: "blocked_by" }], dependents: [] };
+        }
+        if (issueId === 2) {
+          return { issueId, blockers: [{ iid: 3, title: "C", state: "OPEN", web_url: "u", relation: "blocked_by" }], dependents: [] };
+        }
+        return { issueId, blockers: [{ iid: 1, title: "A", state: "OPEN", web_url: "u", relation: "blocked_by" }], dependents: [] };
+      },
+    };
+
+    let callbackPath: number[] | null = null;
+    const next = await findNextIssueForRole(provider, "developer", DEFAULT_WORKFLOW, undefined, {
+      onCycleDetected: async ({ cyclePath }) => {
+        callbackPath = cyclePath;
+      },
+    });
+
+    assert.strictEqual(next, null);
+    assert.deepStrictEqual(callbackPath, [1, 2, 3, 1]);
   });
 });

--- a/lib/services/queue-scan-dependencies.test.ts
+++ b/lib/services/queue-scan-dependencies.test.ts
@@ -1,0 +1,122 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { findNextIssueForRole } from "./queue-scan.js";
+import { DEFAULT_WORKFLOW } from "../workflow/index.js";
+import type { Issue, IssueDependencies, IssueProvider } from "../providers/provider.js";
+
+type QueueProvider = Pick<IssueProvider, "listIssuesByLabel" | "getIssueDependencies">;
+
+function issue(iid: number, labels: string[] = ["To Do"]): Issue {
+  return {
+    iid,
+    title: `Issue #${iid}`,
+    description: "",
+    labels,
+    state: "OPEN",
+    web_url: `https://example.test/issues/${iid}`,
+  };
+}
+
+describe("findNextIssueForRole dependency gating", () => {
+  it("skips blocked issues and dispatches the next unblocked issue", async () => {
+    const provider: QueueProvider = {
+      async listIssuesByLabel() {
+        return [issue(1), issue(2)];
+      },
+      async getIssueDependencies(issueId: number): Promise<IssueDependencies> {
+        if (issueId === 2) {
+          return {
+            issueId,
+            blockers: [{ iid: 10, title: "blocker", state: "OPEN", web_url: "u", relation: "blocked_by" }],
+            dependents: [],
+          };
+        }
+        return { issueId, blockers: [], dependents: [] };
+      },
+    };
+
+    const next = await findNextIssueForRole(provider, "developer", DEFAULT_WORKFLOW);
+    assert.ok(next);
+    assert.strictEqual(next!.issue.iid, 1);
+  });
+
+  it("treats rejected blockers as still blocking", async () => {
+    const provider: QueueProvider = {
+      async listIssuesByLabel() {
+        return [issue(1), issue(2)];
+      },
+      async getIssueDependencies(issueId: number): Promise<IssueDependencies> {
+        if (issueId === 2) {
+          return {
+            issueId,
+            blockers: [{ iid: 11, title: "rejected blocker", state: "CLOSED", web_url: "u", labels: ["Rejected"], relation: "blocked_by" }],
+            dependents: [],
+          };
+        }
+        return { issueId, blockers: [], dependents: [] };
+      },
+    };
+
+    const next = await findNextIssueForRole(provider, "developer", DEFAULT_WORKFLOW);
+    assert.ok(next);
+    assert.strictEqual(next!.issue.iid, 1);
+  });
+
+  it("allows dispatch when all blockers are terminal non-rejected", async () => {
+    const provider: QueueProvider = {
+      async listIssuesByLabel() {
+        return [issue(5)];
+      },
+      async getIssueDependencies(issueId: number): Promise<IssueDependencies> {
+        return {
+          issueId,
+          blockers: [
+            { iid: 20, title: "done blocker", state: "CLOSED", web_url: "u", labels: ["Done"], relation: "blocked_by" },
+            { iid: 21, title: "closed blocker", state: "CLOSED", web_url: "u", relation: "blocked_by" },
+          ],
+          dependents: [],
+        };
+      },
+    };
+
+    const next = await findNextIssueForRole(provider, "developer", DEFAULT_WORKFLOW);
+    assert.ok(next);
+    assert.strictEqual(next!.issue.iid, 5);
+  });
+
+  it("retries dependency reads and fails closed if still uncertain", async () => {
+    let attempts = 0;
+    const provider: QueueProvider = {
+      async listIssuesByLabel(label: string) {
+        return label === "To Do" ? [issue(9)] : [];
+      },
+      async getIssueDependencies() {
+        attempts++;
+        throw new Error("transient provider failure");
+      },
+    };
+
+    const next = await findNextIssueForRole(provider, "developer", DEFAULT_WORKFLOW);
+    assert.strictEqual(next, null);
+    assert.strictEqual(attempts, 3);
+  });
+
+  it("retries dependency reads and succeeds on a later attempt", async () => {
+    let attempts = 0;
+    const provider: QueueProvider = {
+      async listIssuesByLabel() {
+        return [issue(12)];
+      },
+      async getIssueDependencies(issueId: number) {
+        attempts++;
+        if (attempts < 3) throw new Error("temporary");
+        return { issueId, blockers: [], dependents: [] };
+      },
+    };
+
+    const next = await findNextIssueForRole(provider, "developer", DEFAULT_WORKFLOW);
+    assert.ok(next);
+    assert.strictEqual(next!.issue.iid, 12);
+    assert.strictEqual(attempts, 3);
+  });
+});

--- a/lib/services/queue-scan-dependencies.test.ts
+++ b/lib/services/queue-scan-dependencies.test.ts
@@ -208,4 +208,46 @@ describe("findNextIssueForRole dependency gating", () => {
     assert.strictEqual(next, null);
     assert.deepStrictEqual(transitions, [{ issueId: 1, from: "To Do", to: "Refining" }]);
   });
+
+  it("continues scanning when isEligible throws for one issue", async () => {
+    const provider: QueueProvider = {
+      async listIssuesByLabel() {
+        return [issue(1), issue(2)];
+      },
+      async getIssueDependencies(issueId: number): Promise<IssueDependencies> {
+        return { issueId, blockers: [], dependents: [] };
+      },
+    };
+
+    const next = await findNextIssueForRole(provider, "developer", DEFAULT_WORKFLOW, undefined, {
+      isEligible: ({ issue }) => {
+        if (issue.iid === 2) throw new Error("boom");
+        return true;
+      },
+    });
+
+    assert.ok(next);
+    assert.strictEqual(next!.issue.iid, 1);
+  });
+
+  it("continues scanning when onIneligible throws for one issue", async () => {
+    const provider: QueueProvider = {
+      async listIssuesByLabel() {
+        return [issue(1), issue(2)];
+      },
+      async getIssueDependencies(issueId: number): Promise<IssueDependencies> {
+        return { issueId, blockers: [], dependents: [] };
+      },
+    };
+
+    const next = await findNextIssueForRole(provider, "developer", DEFAULT_WORKFLOW, undefined, {
+      isEligible: ({ issue }) => ({ ok: issue.iid === 1, reason: "not-ready" }),
+      onIneligible: async () => {
+        throw new Error("callback failed");
+      },
+    });
+
+    assert.ok(next);
+    assert.strictEqual(next!.issue.iid, 1);
+  });
 });

--- a/lib/services/queue-scan-dependencies.test.ts
+++ b/lib/services/queue-scan-dependencies.test.ts
@@ -18,6 +18,21 @@ function issue(iid: number, labels: string[] = ["To Do"]): Issue {
 }
 
 describe("findNextIssueForRole dependency gating", () => {
+  it("dispatches issues with no dependencies", async () => {
+    const provider: QueueProvider = {
+      async listIssuesByLabel() {
+        return [issue(100)];
+      },
+      async getIssueDependencies(issueId: number): Promise<IssueDependencies> {
+        return { issueId, blockers: [], dependents: [] };
+      },
+    };
+
+    const next = await findNextIssueForRole(provider, "developer", DEFAULT_WORKFLOW);
+    assert.ok(next);
+    assert.strictEqual(next!.issue.iid, 100);
+  });
+
   it("skips blocked issues and dispatches the next unblocked issue", async () => {
     const provider: QueueProvider = {
       async listIssuesByLabel() {
@@ -127,17 +142,9 @@ describe("findNextIssueForRole dependency gating", () => {
       },
       async getIssueDependencies(issueId: number): Promise<IssueDependencies> {
         if (issueId === 1) {
-          return {
-            issueId,
-            blockers: [{ iid: 2, title: "B", state: "OPEN", web_url: "u", relation: "blocked_by" }],
-            dependents: [],
-          };
+          return { issueId, blockers: [{ iid: 2, title: "B", state: "OPEN", web_url: "u", relation: "blocked_by" }], dependents: [] };
         }
-        return {
-          issueId,
-          blockers: [{ iid: 1, title: "A", state: "OPEN", web_url: "u", relation: "blocked_by" }],
-          dependents: [],
-        };
+        return { issueId, blockers: [{ iid: 1, title: "A", state: "OPEN", web_url: "u", relation: "blocked_by" }], dependents: [] };
       },
     };
 
@@ -172,5 +179,33 @@ describe("findNextIssueForRole dependency gating", () => {
 
     assert.strictEqual(next, null);
     assert.deepStrictEqual(callbackPath, [1, 2, 3, 1]);
+  });
+
+  it("transitions cycle issues to Refining via onCycleDetected hook (integration wiring)", async () => {
+    const transitions: Array<{ issueId: number; from: string; to: string }> = [];
+
+    const provider: QueueProvider & Pick<IssueProvider, "transitionLabel"> = {
+      async listIssuesByLabel(label: string) {
+        return label === "To Do" ? [issue(1)] : [];
+      },
+      async getIssueDependencies(issueId: number): Promise<IssueDependencies> {
+        if (issueId === 1) {
+          return { issueId, blockers: [{ iid: 2, title: "B", state: "OPEN", web_url: "u", relation: "blocked_by" }], dependents: [] };
+        }
+        return { issueId, blockers: [{ iid: 1, title: "A", state: "OPEN", web_url: "u", relation: "blocked_by" }], dependents: [] };
+      },
+      async transitionLabel(issueId: number, from: string, to: string): Promise<void> {
+        transitions.push({ issueId, from, to });
+      },
+    };
+
+    const next = await findNextIssueForRole(provider, "developer", DEFAULT_WORKFLOW, undefined, {
+      onCycleDetected: async ({ issue, label }) => {
+        await provider.transitionLabel(issue.iid, label, "Refining");
+      },
+    });
+
+    assert.strictEqual(next, null);
+    assert.deepStrictEqual(transitions, [{ issueId: 1, from: "To Do", to: "Refining" }]);
   });
 });

--- a/lib/services/queue-scan.ts
+++ b/lib/services/queue-scan.ts
@@ -103,7 +103,8 @@ export type DependencyGateStatus = {
 // ---------------------------------------------------------------------------
 
 export async function findNextIssueForRole(
-  provider: Pick<IssueProvider, "listIssuesByLabel" | "getIssueDependencies">,
+  provider: Pick<IssueProvider, "listIssuesByLabel" | "getIssueDependencies"> &
+    Partial<Pick<IssueProvider, "transitionLabel" | "addComment">>,
   role: Role,
   workflow: WorkflowConfig,
   instanceName?: string,

--- a/lib/services/queue-scan.ts
+++ b/lib/services/queue-scan.ts
@@ -104,6 +104,12 @@ export type DependencyGateStatus = {
   kind?: "dependency" | "cycle" | "uncertain";
 };
 
+function toErrorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "string") return err;
+  return "unknown error";
+}
+
 // ---------------------------------------------------------------------------
 // Issue queue queries
 // ---------------------------------------------------------------------------
@@ -157,7 +163,10 @@ export async function findNextIssueForRole(
         ? issues.filter((i) => isOwnedByOrUnclaimed(i.labels, instanceName))
         : issues;
 
-      for (const issue of eligible.slice().reverse()) {
+      // Providers typically return queue issues newest-first; scan oldest-first
+      // to preserve FIFO semantics within each label queue.
+      const queueOrder = eligible.slice().reverse();
+      for (const issue of queueOrder) {
         const gate = await getDependencyGateStatus(provider, issue, workflow);
         if (gate.blocked) {
           if (
@@ -178,12 +187,26 @@ export async function findNextIssueForRole(
         }
 
         if (opts?.isEligible) {
-          const res = await opts.isEligible({ issue, label });
-          const ok = typeof res === "boolean" ? res : res.ok;
-          const reason = typeof res === "boolean" ? undefined : res.reason;
-          if (!ok) {
-            if (opts.onIneligible)
-              await opts.onIneligible({ issue, label, reason });
+          try {
+            const res = await opts.isEligible({ issue, label });
+            const ok = typeof res === "boolean" ? res : res.ok;
+            const reason = typeof res === "boolean" ? undefined : res.reason;
+            if (!ok) {
+              if (opts.onIneligible) {
+                try {
+                  await opts.onIneligible({ issue, label, reason });
+                } catch (err) {
+                  console.warn(
+                    `[queue-scan] onIneligible failed for #${issue.iid} (${label}): ${toErrorMessage(err)}`,
+                  );
+                }
+              }
+              continue;
+            }
+          } catch (err) {
+            console.warn(
+              `[queue-scan] isEligible failed for #${issue.iid} (${label}): ${toErrorMessage(err)}`,
+            );
             continue;
           }
         }

--- a/lib/services/queue-scan.ts
+++ b/lib/services/queue-scan.ts
@@ -4,7 +4,12 @@
  * Shared by: tick (projectTick), work-start (auto-pickup), and other consumers
  * that need to find queued issues or detect roles/levels from labels.
  */
-import type { Issue, IssueDependency, IssueDependencies, StateLabel } from "../providers/provider.js";
+import type {
+  Issue,
+  IssueDependency,
+  IssueDependencies,
+  StateLabel,
+} from "../providers/provider.js";
 import type { IssueProvider } from "../providers/provider.js";
 import { getLevelsForRole, getAllLevels } from "../roles/index.js";
 import {
@@ -74,7 +79,8 @@ export function detectRoleLevelFromLabels(
  * Returns the routing value for the given step, or null if no routing label exists.
  */
 export function detectStepRouting(
-  labels: string[], step: string,
+  labels: string[],
+  step: string,
 ): string | null {
   const prefix = `${step}:`;
   const match = labels.find((l) => l.toLowerCase().startsWith(prefix));
@@ -109,11 +115,37 @@ export async function findNextIssueForRole(
   workflow: WorkflowConfig,
   instanceName?: string,
   opts?: {
+    /**
+     * Called when a dependency cycle is detected and the caller wants to take
+     * action (e.g. move issue to Refining).
+     */
     onCycleDetected?: (args: {
       issue: Issue;
       label: StateLabel;
       cyclePath: number[];
       reason: string;
+    }) => Promise<void>;
+
+    /**
+     * Optional eligibility predicate for role-specific gates beyond dependency
+     * checks (e.g. review:human, test:skip).
+     *
+     * If it returns false, the scan continues to the next issue.
+     */
+    isEligible?: (args: {
+      issue: Issue;
+      label: StateLabel;
+    }) =>
+      | boolean
+      | Promise<boolean>
+      | { ok: boolean; reason?: string }
+      | Promise<{ ok: boolean; reason?: string }>;
+
+    /** Called when an issue is skipped due to isEligible returning false. */
+    onIneligible?: (args: {
+      issue: Issue;
+      label: StateLabel;
+      reason?: string;
     }) => Promise<void>;
   },
 ): Promise<{ issue: Issue; label: StateLabel } | null> {
@@ -127,18 +159,40 @@ export async function findNextIssueForRole(
 
       for (const issue of eligible.slice().reverse()) {
         const gate = await getDependencyGateStatus(provider, issue, workflow);
-        if (!gate.blocked) return { issue, label };
-
-        if (gate.kind === "cycle" && gate.cyclePath && opts?.onCycleDetected) {
-          await opts.onCycleDetected({
-            issue,
-            label,
-            cyclePath: gate.cyclePath,
-            reason: gate.reason ?? `Dependency cycle detected: ${gate.cyclePath.join(" → ")}`,
-          });
+        if (gate.blocked) {
+          if (
+            gate.kind === "cycle" &&
+            gate.cyclePath &&
+            opts?.onCycleDetected
+          ) {
+            await opts.onCycleDetected({
+              issue,
+              label,
+              cyclePath: gate.cyclePath,
+              reason:
+                gate.reason ??
+                `Dependency cycle detected: ${gate.cyclePath.join(" → ")}`,
+            });
+          }
+          continue;
         }
+
+        if (opts?.isEligible) {
+          const res = await opts.isEligible({ issue, label });
+          const ok = typeof res === "boolean" ? res : res.ok;
+          const reason = typeof res === "boolean" ? undefined : res.reason;
+          if (!ok) {
+            if (opts.onIneligible)
+              await opts.onIneligible({ issue, label, reason });
+            continue;
+          }
+        }
+
+        return { issue, label };
       }
-    } catch { /* continue */ }
+    } catch {
+      /* continue */
+    }
   }
   return null;
 }
@@ -159,10 +213,17 @@ export async function getDependencyGateStatus(
   }
   depCache.set(issue.iid, deps);
 
-  const unresolved = deps.blockers.filter((blocker) => !isResolvedBlocker(blocker, workflow));
+  const unresolved = deps.blockers.filter(
+    (blocker) => !isResolvedBlocker(blocker, workflow),
+  );
   if (unresolved.length === 0) return { blocked: false };
 
-  const cyclePath = await detectCyclePath(provider, issue.iid, workflow, depCache);
+  const cyclePath = await detectCyclePath(
+    provider,
+    issue.iid,
+    workflow,
+    depCache,
+  );
   if (cyclePath) {
     return {
       blocked: true,
@@ -180,7 +241,10 @@ export async function getDependencyGateStatus(
   };
 }
 
-function isResolvedBlocker(blocker: IssueDependency, workflow: WorkflowConfig): boolean {
+function isResolvedBlocker(
+  blocker: IssueDependency,
+  workflow: WorkflowConfig,
+): boolean {
   const labels = blocker.labels ?? [];
 
   // Explicit requirement: Rejected blockers remain blocking.
@@ -206,7 +270,10 @@ async function detectCyclePath(
 ): Promise<number[] | null> {
   const visited = new Set<number>([startIssueId]);
 
-  const dfs = async (nodeId: number, path: number[]): Promise<number[] | null> => {
+  const dfs = async (
+    nodeId: number,
+    path: number[],
+  ): Promise<number[] | null> => {
     let deps = cache.get(nodeId);
     if (deps === undefined) {
       deps = await getIssueDependenciesWithRetry(provider, nodeId, 3);
@@ -214,7 +281,9 @@ async function detectCyclePath(
     }
     if (!deps) return null;
 
-    for (const blocker of deps.blockers.filter((b) => !isResolvedBlocker(b, workflow))) {
+    for (const blocker of deps.blockers.filter(
+      (b) => !isResolvedBlocker(b, workflow),
+    )) {
       if (blocker.iid === startIssueId) return [...path, startIssueId];
       if (visited.has(blocker.iid)) continue;
       visited.add(blocker.iid);
@@ -262,8 +331,11 @@ export async function findNextIssue(
       const eligible = instanceName
         ? issues.filter((i) => isOwnedByOrUnclaimed(i.labels, instanceName))
         : issues;
-      if (eligible.length > 0) return { issue: eligible[eligible.length - 1]!, label };
-    } catch { /* continue */ }
+      if (eligible.length > 0)
+        return { issue: eligible[eligible.length - 1]!, label };
+    } catch {
+      /* continue */
+    }
   }
   return null;
 }

--- a/lib/services/queue-scan.ts
+++ b/lib/services/queue-scan.ts
@@ -4,7 +4,7 @@
  * Shared by: tick (projectTick), work-start (auto-pickup), and other consumers
  * that need to find queued issues or detect roles/levels from labels.
  */
-import type { Issue, IssueDependency, StateLabel } from "../providers/provider.js";
+import type { Issue, IssueDependency, IssueDependencies, StateLabel } from "../providers/provider.js";
 import type { IssueProvider } from "../providers/provider.js";
 import { getLevelsForRole, getAllLevels } from "../roles/index.js";
 import {
@@ -91,6 +91,13 @@ export function detectRoleFromLabel(
   return workflowDetectRole(workflow, label);
 }
 
+export type DependencyGateStatus = {
+  blocked: boolean;
+  reason?: string;
+  cyclePath?: number[];
+  kind?: "dependency" | "cycle" | "uncertain";
+};
+
 // ---------------------------------------------------------------------------
 // Issue queue queries
 // ---------------------------------------------------------------------------
@@ -100,6 +107,14 @@ export async function findNextIssueForRole(
   role: Role,
   workflow: WorkflowConfig,
   instanceName?: string,
+  opts?: {
+    onCycleDetected?: (args: {
+      issue: Issue;
+      label: StateLabel;
+      cyclePath: number[];
+      reason: string;
+    }) => Promise<void>;
+  },
 ): Promise<{ issue: Issue; label: StateLabel } | null> {
   const labels = getQueueLabels(workflow, role);
   for (const label of labels) {
@@ -110,22 +125,58 @@ export async function findNextIssueForRole(
         : issues;
 
       for (const issue of eligible.slice().reverse()) {
-        const blocked = await isIssueBlocked(provider, issue, workflow);
-        if (!blocked) return { issue, label };
+        const gate = await getDependencyGateStatus(provider, issue, workflow);
+        if (!gate.blocked) return { issue, label };
+
+        if (gate.kind === "cycle" && gate.cyclePath && opts?.onCycleDetected) {
+          await opts.onCycleDetected({
+            issue,
+            label,
+            cyclePath: gate.cyclePath,
+            reason: gate.reason ?? `Dependency cycle detected: ${gate.cyclePath.join(" → ")}`,
+          });
+        }
       }
     } catch { /* continue */ }
   }
   return null;
 }
 
-async function isIssueBlocked(
+export async function getDependencyGateStatus(
   provider: Pick<IssueProvider, "getIssueDependencies">,
-  issue: Issue,
+  issue: Pick<Issue, "iid">,
   workflow: WorkflowConfig,
-): Promise<boolean> {
+): Promise<DependencyGateStatus> {
+  const depCache = new Map<number, IssueDependencies | null>();
   const deps = await getIssueDependenciesWithRetry(provider, issue.iid, 3);
-  if (!deps) return true; // fail-closed when dependency status is uncertain
-  return deps.blockers.some((blocker) => !isResolvedBlocker(blocker, workflow));
+  if (!deps) {
+    return {
+      blocked: true,
+      kind: "uncertain",
+      reason: "Dependency status unavailable (provider read failed)",
+    };
+  }
+  depCache.set(issue.iid, deps);
+
+  const unresolved = deps.blockers.filter((blocker) => !isResolvedBlocker(blocker, workflow));
+  if (unresolved.length === 0) return { blocked: false };
+
+  const cyclePath = await detectCyclePath(provider, issue.iid, workflow, depCache);
+  if (cyclePath) {
+    return {
+      blocked: true,
+      kind: "cycle",
+      cyclePath,
+      reason: `Dependency cycle detected: ${cyclePath.join(" → ")}`,
+    };
+  }
+
+  const blockerIds = unresolved.map((b) => `#${b.iid}`).join(", ");
+  return {
+    blocked: true,
+    kind: "dependency",
+    reason: `Waiting on blockers: ${blockerIds}`,
+  };
 }
 
 function isResolvedBlocker(blocker: IssueDependency, workflow: WorkflowConfig): boolean {
@@ -144,6 +195,35 @@ function isResolvedBlocker(blocker: IssueDependency, workflow: WorkflowConfig): 
   // Fallback when labels are unavailable: use provider issue state.
   const state = blocker.state.toLowerCase();
   return state === "closed" || state === "done" || state === "merged";
+}
+
+async function detectCyclePath(
+  provider: Pick<IssueProvider, "getIssueDependencies">,
+  startIssueId: number,
+  workflow: WorkflowConfig,
+  cache: Map<number, IssueDependencies | null>,
+): Promise<number[] | null> {
+  const visited = new Set<number>([startIssueId]);
+
+  const dfs = async (nodeId: number, path: number[]): Promise<number[] | null> => {
+    let deps = cache.get(nodeId);
+    if (deps === undefined) {
+      deps = await getIssueDependenciesWithRetry(provider, nodeId, 3);
+      cache.set(nodeId, deps ?? null);
+    }
+    if (!deps) return null;
+
+    for (const blocker of deps.blockers.filter((b) => !isResolvedBlocker(b, workflow))) {
+      if (blocker.iid === startIssueId) return [...path, startIssueId];
+      if (visited.has(blocker.iid)) continue;
+      visited.add(blocker.iid);
+      const found = await dfs(blocker.iid, [...path, blocker.iid]);
+      if (found) return found;
+    }
+    return null;
+  };
+
+  return dfs(startIssueId, [startIssueId]);
 }
 
 async function getIssueDependenciesWithRetry(

--- a/lib/services/queue-scan.ts
+++ b/lib/services/queue-scan.ts
@@ -4,13 +4,14 @@
  * Shared by: tick (projectTick), work-start (auto-pickup), and other consumers
  * that need to find queued issues or detect roles/levels from labels.
  */
-import type { Issue, StateLabel } from "../providers/provider.js";
+import type { Issue, IssueDependency, StateLabel } from "../providers/provider.js";
 import type { IssueProvider } from "../providers/provider.js";
 import { getLevelsForRole, getAllLevels } from "../roles/index.js";
 import {
   getQueueLabels,
   getAllQueueLabels,
   detectRoleFromLabel as workflowDetectRole,
+  findStateByLabel,
   isOwnedByOrUnclaimed,
   type WorkflowConfig,
   type Role,
@@ -95,7 +96,7 @@ export function detectRoleFromLabel(
 // ---------------------------------------------------------------------------
 
 export async function findNextIssueForRole(
-  provider: Pick<IssueProvider, "listIssuesByLabel">,
+  provider: Pick<IssueProvider, "listIssuesByLabel" | "getIssueDependencies">,
   role: Role,
   workflow: WorkflowConfig,
   instanceName?: string,
@@ -107,8 +108,56 @@ export async function findNextIssueForRole(
       const eligible = instanceName
         ? issues.filter((i) => isOwnedByOrUnclaimed(i.labels, instanceName))
         : issues;
-      if (eligible.length > 0) return { issue: eligible[eligible.length - 1]!, label };
+
+      for (const issue of eligible.slice().reverse()) {
+        const blocked = await isIssueBlocked(provider, issue, workflow);
+        if (!blocked) return { issue, label };
+      }
     } catch { /* continue */ }
+  }
+  return null;
+}
+
+async function isIssueBlocked(
+  provider: Pick<IssueProvider, "getIssueDependencies">,
+  issue: Issue,
+  workflow: WorkflowConfig,
+): Promise<boolean> {
+  const deps = await getIssueDependenciesWithRetry(provider, issue.iid, 3);
+  if (!deps) return true; // fail-closed when dependency status is uncertain
+  return deps.blockers.some((blocker) => !isResolvedBlocker(blocker, workflow));
+}
+
+function isResolvedBlocker(blocker: IssueDependency, workflow: WorkflowConfig): boolean {
+  const labels = blocker.labels ?? [];
+
+  // Explicit requirement: Rejected blockers remain blocking.
+  if (labels.some((l) => l.toLowerCase() === "rejected")) return false;
+
+  // Any other terminal state label resolves the blocker.
+  const hasTerminalLabel = labels.some((l) => {
+    const state = findStateByLabel(workflow, l);
+    return state?.type === "terminal";
+  });
+  if (hasTerminalLabel) return true;
+
+  // Fallback when labels are unavailable: use provider issue state.
+  const state = blocker.state.toLowerCase();
+  return state === "closed" || state === "done" || state === "merged";
+}
+
+async function getIssueDependenciesWithRetry(
+  provider: Pick<IssueProvider, "getIssueDependencies">,
+  issueId: number,
+  attempts: number,
+): Promise<Awaited<ReturnType<IssueProvider["getIssueDependencies"]>> | null> {
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return await provider.getIssueDependencies(issueId);
+    } catch {
+      if (i === attempts - 1) return null;
+      await new Promise((resolve) => setTimeout(resolve, 150 * (i + 1)));
+    }
   }
   return null;
 }

--- a/lib/services/terminal-guard.ts
+++ b/lib/services/terminal-guard.ts
@@ -1,0 +1,115 @@
+/**
+ * terminal-guard.ts — Shared guard that prevents terminal completion when PR state makes it unsafe.
+ *
+ * Invariants:
+ * - Never allow terminal completion if PR is conflicting (mergeable === false).
+ * - When auto-merge is off for the completion path (no mergePr action), do not allow
+ *   terminal completion until provider reports PR is merged.
+ */
+
+import type { IssueProvider, PrStatus } from "../providers/provider.js";
+import { PrState } from "../providers/provider.js";
+import {
+  Action,
+  StateType,
+  type StateConfig,
+  type WorkflowConfig,
+} from "../workflow/index.js";
+import { findStateByLabel, getRevertLabel } from "../workflow/queries.js";
+
+export type TerminalGuardDecision =
+  | {
+      allow: true;
+      prStatus?: PrStatus;
+    }
+  | {
+      allow: false;
+      /** Suggested label to transition to (optional). If omitted, caller should stay put. */
+      toLabel?: string;
+      reason:
+        | "merge_conflict"
+        | "pr_not_merged_auto_merge_off"
+        | "pr_closed_unmerged"
+        | "pr_status_unavailable";
+      prStatus?: PrStatus;
+    };
+
+function getFeedbackLabel(workflow: WorkflowConfig): string {
+  // Prefer canonical label if present.
+  const toImprove = findStateByLabel(workflow, "To Improve");
+  if (toImprove) return toImprove.label;
+  // Fallback: developer revert queue.
+  try {
+    return getRevertLabel(workflow, "developer");
+  } catch {
+    return "To Improve";
+  }
+}
+
+function isTerminalPath(toState: StateConfig, actions: string[] | undefined): boolean {
+  if (toState.type === StateType.TERMINAL) return true;
+  if ((actions ?? []).includes(Action.CLOSE_ISSUE)) return true;
+  return false;
+}
+
+/**
+ * Decide whether a transition that would complete an issue is allowed.
+ */
+export async function guardTerminalCompletion(opts: {
+  workflow: WorkflowConfig;
+  provider: IssueProvider;
+  issueId: number;
+  fromLabel: string;
+  toState: StateConfig;
+  actions?: string[];
+}): Promise<TerminalGuardDecision> {
+  const { workflow, provider, issueId, toState, actions } = opts;
+
+  if (!isTerminalPath(toState, actions)) return { allow: true };
+
+  let prStatus: PrStatus;
+  try {
+    prStatus = await provider.getPrStatus(issueId);
+  } catch {
+    return {
+      allow: false,
+      reason: "pr_status_unavailable",
+    };
+  }
+
+  // No PR associated (or provider couldn't find one): allow completion.
+  if (!prStatus.url) return { allow: true, prStatus };
+
+  // Conflicts always block and route to feedback.
+  if (prStatus.mergeable === false) {
+    return {
+      allow: false,
+      toLabel: getFeedbackLabel(workflow),
+      reason: "merge_conflict",
+      prStatus,
+    };
+  }
+
+  // Closed but not merged: treat as unmerged and route to feedback.
+  if (prStatus.state === PrState.CLOSED) {
+    return {
+      allow: false,
+      toLabel: getFeedbackLabel(workflow),
+      reason: "pr_closed_unmerged",
+      prStatus,
+    };
+  }
+
+  // Auto-merge is considered "on" for this path only if mergePr is present.
+  const autoMergeEnabled = (actions ?? []).includes(Action.MERGE_PR);
+
+  if (!autoMergeEnabled && prStatus.state !== PrState.MERGED) {
+    return {
+      allow: false,
+      reason: "pr_not_merged_auto_merge_off",
+      prStatus,
+    };
+  }
+
+  return { allow: true, prStatus };
+}

--- a/lib/services/tick.reviewer-starvation.test.ts
+++ b/lib/services/tick.reviewer-starvation.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { projectTick } from "./tick.js";
+import { DEFAULT_WORKFLOW, ReviewPolicy } from "../workflow/index.js";
+import { createTestHarness } from "../testing/index.js";
+
+/**
+ * Regression test for Issue #50: reviewer head-of-line blocking.
+ *
+ * If the first scanned `To Review` issue is ineligible for reviewer dispatch
+ * (e.g. `review:human`), the scan must continue until it finds an eligible
+ * one (e.g. `review:agent`).
+ */
+describe("projectTick — reviewer queue starvation", () => {
+  it("skips ineligible items and continues scanning To Review", async () => {
+    const h = await createTestHarness();
+
+    // Seed in an order that reproduces head-of-line blocking:
+    // the scan iterates the provider list in reverse order.
+    h.provider.seedIssue({
+      iid: 410,
+      title: "Eligible agent review",
+      labels: ["To Review", "review:agent"],
+    });
+    h.provider.seedIssue({
+      iid: 411,
+      title: "Human review A",
+      labels: ["To Review", "review:human"],
+    });
+    h.provider.seedIssue({
+      iid: 412,
+      title: "Human review B",
+      labels: ["To Review", "review:human"],
+    });
+
+    const result = await projectTick({
+      workspaceDir: h.workspaceDir,
+      projectSlug: h.project.slug,
+      agentId: "test-agent",
+      targetRole: "reviewer",
+      workflow: { ...DEFAULT_WORKFLOW, reviewPolicy: ReviewPolicy.AGENT },
+      provider: h.provider,
+      runCommand: h.runCommand,
+    });
+
+    assert.equal(result.pickups.length, 1);
+    assert.equal(result.pickups[0].role, "reviewer");
+    assert.equal(result.pickups[0].issueId, 410);
+
+    const reviewerSkips = result.skipped
+      .filter((s) => s.role === "reviewer")
+      .map((s) => s.reason)
+      .join("\n");
+
+    assert.ok(
+      reviewerSkips.includes("review:human"),
+      `expected skip reasons to include review:human, got:\n${reviewerSkips}`,
+    );
+  });
+});

--- a/lib/services/tick.ts
+++ b/lib/services/tick.ts
@@ -9,7 +9,14 @@ import type { RunCommand } from "../context.js";
 import type { Issue, IssueProvider } from "../providers/provider.js";
 import { createProvider } from "../providers/index.js";
 import { selectLevel } from "../roles/model-selector.js";
-import { getRoleWorker, getProject, readProjects, findFreeSlot, countActiveSlots, reconcileSlots } from "../projects/index.js";
+import {
+  getRoleWorker,
+  getProject,
+  readProjects,
+  findFreeSlot,
+  countActiveSlots,
+  reconcileSlots,
+} from "../projects/index.js";
 import { dispatchTask } from "../dispatch/index.js";
 import { getLevelsForRole } from "../roles/index.js";
 import { loadConfig } from "../config/index.js";
@@ -22,7 +29,11 @@ import {
   type WorkflowConfig,
   type Role,
 } from "../workflow/index.js";
-import { detectRoleLevelFromLabels, detectStepRouting, findNextIssueForRole } from "./queue-scan.js";
+import {
+  detectRoleLevelFromLabels,
+  detectStepRouting,
+  findNextIssueForRole,
+} from "./queue-scan.js";
 
 // ---------------------------------------------------------------------------
 // projectTick
@@ -73,17 +84,38 @@ export async function projectTick(opts: {
   runCommand?: RunCommand;
 }): Promise<TickResult> {
   const {
-    workspaceDir, projectSlug, agentId, sessionKey, pluginConfig, dryRun,
-    maxPickups, targetRole, runtime, instanceName, runCommand,
+    workspaceDir,
+    projectSlug,
+    agentId,
+    sessionKey,
+    pluginConfig,
+    dryRun,
+    maxPickups,
+    targetRole,
+    runtime,
+    instanceName,
+    runCommand,
   } = opts;
 
   const project = getProject(await readProjects(workspaceDir), projectSlug);
-  if (!project) return { pickups: [], skipped: [{ reason: `Project not found: ${projectSlug}` }] };
+  if (!project)
+    return {
+      pickups: [],
+      skipped: [{ reason: `Project not found: ${projectSlug}` }],
+    };
 
   const resolvedConfig = await loadConfig(workspaceDir, project.name);
   const workflow = opts.workflow ?? resolvedConfig.workflow;
 
-  const provider = opts.provider ?? (await createProvider({ repo: project.repo, provider: project.provider, runCommand: runCommand! })).provider;
+  const provider =
+    opts.provider ??
+    (
+      await createProvider({
+        repo: project.repo,
+        provider: project.provider,
+        runCommand: runCommand!,
+      })
+    ).provider;
   const roleExecution = workflow.roleExecution ?? ExecutionMode.PARALLEL;
   const enabledRoles = Object.entries(resolvedConfig.roles)
     .filter(([, r]) => r.enabled)
@@ -110,7 +142,12 @@ export async function projectTick(opts: {
 
     // Check sequential role execution: any other role must be inactive
     const otherRoles = enabledRoles.filter((r: string) => r !== role);
-    if (roleExecution === ExecutionMode.SEQUENTIAL && otherRoles.some((r: string) => countActiveSlots(getRoleWorker(fresh, r)) > 0)) {
+    if (
+      roleExecution === ExecutionMode.SEQUENTIAL &&
+      otherRoles.some(
+        (r: string) => countActiveSlots(getRoleWorker(fresh, r)) > 0,
+      )
+    ) {
       skipped.push({ role, reason: "Sequential: other role active" });
       continue;
     }
@@ -119,11 +156,18 @@ export async function projectTick(opts: {
     if (role === "reviewer") {
       const policy = workflow.reviewPolicy ?? ReviewPolicy.HUMAN;
       if (policy === ReviewPolicy.HUMAN) {
-        skipped.push({ role, reason: "Review policy: human (heartbeat handles via PR polling)" });
+        skipped.push({
+          role,
+          reason: "Review policy: human (heartbeat handles via PR polling)",
+        });
         continue;
       }
       if (policy === ReviewPolicy.SKIP) {
-        skipped.push({ role, reason: "Review policy: skip (heartbeat handles via review-skip pass)" });
+        skipped.push({
+          role,
+          reason:
+            "Review policy: skip (heartbeat handles via review-skip pass)",
+        });
         continue;
       }
     }
@@ -132,48 +176,77 @@ export async function projectTick(opts: {
     if (role === "tester") {
       const policy = workflow.testPolicy ?? TestPolicy.SKIP;
       if (policy === TestPolicy.SKIP) {
-        skipped.push({ role, reason: "Test policy: skip (heartbeat handles via test-skip pass)" });
+        skipped.push({
+          role,
+          reason: "Test policy: skip (heartbeat handles via test-skip pass)",
+        });
         continue;
       }
     }
 
-    const refiningLabel = Object.values(workflow.states)
-      .find((s) => s.type === StateType.HOLD && s.label.toLowerCase() === "refining")?.label ?? "Refining";
+    const refiningLabel =
+      Object.values(workflow.states).find(
+        (s) =>
+          s.type === StateType.HOLD && s.label.toLowerCase() === "refining",
+      )?.label ?? "Refining";
 
-    const next = await findNextIssueForRole(provider, role, workflow, instanceName, {
-      onCycleDetected: async ({ issue, label: currentLabel, reason }) => {
-        try {
-          await provider.transitionLabel(issue.iid, currentLabel, refiningLabel);
-          await provider.addComment(
-            issue.iid,
-            `⚠️ ${reason}\n\nMoved to **${refiningLabel}** automatically. Break the dependency loop, then run \`task_start\` to queue it again.`,
-          );
-          skipped.push({ role, reason: `Issue #${issue.iid} moved to ${refiningLabel}: ${reason}` });
-        } catch (err) {
-          skipped.push({ role, reason: `Issue #${issue.iid} has dependency cycle but auto-move failed: ${(err as Error).message}` });
-        }
+    const next = await findNextIssueForRole(
+      provider,
+      role,
+      workflow,
+      instanceName,
+      {
+        // Step routing: check for review:human / review:skip / test:skip labels.
+        // IMPORTANT: this must be part of the queue scan (not post-selection),
+        // otherwise a single ineligible head-of-queue issue can starve eligible
+        // items behind it.
+        isEligible: ({ issue }) => {
+          if (role === "reviewer") {
+            const routing = detectStepRouting(issue.labels, "review");
+            if (routing === "human" || routing === "skip")
+              return { ok: false, reason: `review:${routing} label` };
+          }
+          if (role === "tester") {
+            const routing = detectStepRouting(issue.labels, "test");
+            if (routing === "skip")
+              return { ok: false, reason: "test:skip label" };
+          }
+          return { ok: true };
+        },
+        onIneligible: async ({ issue, reason }) => {
+          skipped.push({
+            role,
+            reason: `Issue #${issue.iid}: ${reason ?? "ineligible"}`,
+          });
+        },
+        onCycleDetected: async ({ issue, label: currentLabel, reason }) => {
+          try {
+            await provider.transitionLabel(
+              issue.iid,
+              currentLabel,
+              refiningLabel,
+            );
+            await provider.addComment(
+              issue.iid,
+              `⚠️ ${reason}\n\nMoved to **${refiningLabel}** automatically. Break the dependency loop, then run \`task_start\` to queue it again.`,
+            );
+            skipped.push({
+              role,
+              reason: `Issue #${issue.iid} moved to ${refiningLabel}: ${reason}`,
+            });
+          } catch (err) {
+            skipped.push({
+              role,
+              reason: `Issue #${issue.iid} has dependency cycle but auto-move failed: ${(err as Error).message}`,
+            });
+          }
+        },
       },
-    });
+    );
     if (!next) continue;
 
     const { issue, label: currentLabel } = next;
     const targetLabel = getActiveLabel(workflow, role);
-
-    // Step routing: check for review:human / review:skip / test:skip labels
-    if (role === "reviewer") {
-      const routing = detectStepRouting(issue.labels, "review");
-      if (routing === "human" || routing === "skip") {
-        skipped.push({ role, reason: `review:${routing} label` });
-        continue;
-      }
-    }
-    if (role === "tester") {
-      const routing = detectStepRouting(issue.labels, "test");
-      if (routing === "skip") {
-        skipped.push({ role, reason: "test:skip label" });
-        continue;
-      }
-    }
 
     // Level selection: label → heuristic (must happen before free slot check)
     const selectedLevel = resolveLevelForIssue(issue, role);
@@ -186,19 +259,33 @@ export async function projectTick(opts: {
     }
 
     if (dryRun) {
-      const existingSession = roleWorker.levels[selectedLevel]?.[freeSlot]?.sessionKey;
+      const existingSession =
+        roleWorker.levels[selectedLevel]?.[freeSlot]?.sessionKey;
       pickups.push({
-        project: project.name, projectSlug, issueId: issue.iid, issueTitle: issue.title, issueUrl: issue.web_url,
-        role, level: selectedLevel,
+        project: project.name,
+        projectSlug,
+        issueId: issue.iid,
+        issueTitle: issue.title,
+        issueUrl: issue.web_url,
+        role,
+        level: selectedLevel,
         sessionAction: existingSession ? "send" : "spawn",
         announcement: `[DRY RUN] Would pick up #${issue.iid}`,
       });
     } else {
       try {
         const dr = await dispatchTask({
-          workspaceDir, agentId, project: fresh, issueId: issue.iid,
-          issueTitle: issue.title, issueDescription: issue.description ?? "", issueUrl: issue.web_url,
-          role, level: selectedLevel, fromLabel: currentLabel, toLabel: targetLabel,
+          workspaceDir,
+          agentId,
+          project: fresh,
+          issueId: issue.iid,
+          issueTitle: issue.title,
+          issueDescription: issue.description ?? "",
+          issueUrl: issue.web_url,
+          role,
+          level: selectedLevel,
+          fromLabel: currentLabel,
+          toLabel: targetLabel,
           provider,
           pluginConfig,
           sessionKey,
@@ -208,11 +295,21 @@ export async function projectTick(opts: {
           runCommand: runCommand!,
         });
         pickups.push({
-          project: project.name, projectSlug, issueId: issue.iid, issueTitle: issue.title, issueUrl: issue.web_url,
-          role, level: dr.level, sessionAction: dr.sessionAction, announcement: dr.announcement,
+          project: project.name,
+          projectSlug,
+          issueId: issue.iid,
+          issueTitle: issue.title,
+          issueUrl: issue.web_url,
+          role,
+          level: dr.level,
+          sessionAction: dr.sessionAction,
+          announcement: dr.announcement,
         });
       } catch (err) {
-        skipped.push({ role, reason: `Dispatch failed: ${(err as Error).message}` });
+        skipped.push({
+          role,
+          reason: `Dispatch failed: ${(err as Error).message}`,
+        });
         continue;
       }
     }

--- a/lib/services/tick.ts
+++ b/lib/services/tick.ts
@@ -17,6 +17,7 @@ import {
   ExecutionMode,
   ReviewPolicy,
   TestPolicy,
+  StateType,
   getActiveLabel,
   type WorkflowConfig,
   type Role,
@@ -136,7 +137,23 @@ export async function projectTick(opts: {
       }
     }
 
-    const next = await findNextIssueForRole(provider, role, workflow, instanceName);
+    const refiningLabel = Object.values(workflow.states)
+      .find((s) => s.type === StateType.HOLD && s.label.toLowerCase() === "refining")?.label ?? "Refining";
+
+    const next = await findNextIssueForRole(provider, role, workflow, instanceName, {
+      onCycleDetected: async ({ issue, label: currentLabel, reason }) => {
+        try {
+          await provider.transitionLabel(issue.iid, currentLabel, refiningLabel);
+          await provider.addComment(
+            issue.iid,
+            `⚠️ ${reason}\n\nMoved to **${refiningLabel}** automatically. Break the dependency loop, then run \`task_start\` to queue it again.`,
+          );
+          skipped.push({ role, reason: `Issue #${issue.iid} moved to ${refiningLabel}: ${reason}` });
+        } catch (err) {
+          skipped.push({ role, reason: `Issue #${issue.iid} has dependency cycle but auto-move failed: ${(err as Error).message}` });
+        }
+      },
+    });
     if (!next) continue;
 
     const { issue, label: currentLabel } = next;

--- a/lib/setup/config.ts
+++ b/lib/setup/config.ts
@@ -23,6 +23,7 @@ export async function writePluginConfig(
   runtime: PluginRuntime,
   agentId?: string,
   projectExecution?: ExecutionMode,
+  workspaceDir?: string,
 ): Promise<void> {
   const config = runtime.config.loadConfig() as Record<string, unknown>;
 
@@ -30,6 +31,14 @@ export async function writePluginConfig(
 
   if (projectExecution) {
     (config as any).plugins.entries.devclaw.config.projectExecution = projectExecution;
+  }
+
+  // Authoritative runtime workspace binding (used by heartbeat + hooks)
+  if (agentId && workspaceDir) {
+    (config as any).plugins.entries.devclaw.config.runtimeWorkspace = {
+      agentId,
+      workspaceDir,
+    };
   }
 
   // Clean up legacy models from openclaw.json (moved to workflow.yaml)

--- a/lib/setup/index.ts
+++ b/lib/setup/index.ts
@@ -67,7 +67,7 @@ export async function runSetup(opts: SetupOpts): Promise<SetupResult> {
   const { agentId, workspacePath, agentCreated, bindingMigrated } =
     await resolveOrCreateAgent(opts, warnings);
 
-  await writePluginConfig(opts.runtime, agentId, opts.projectExecution);
+  await writePluginConfig(opts.runtime, agentId, opts.projectExecution, workspacePath);
 
   const defaultWorkspacePath = getDefaultWorkspacePath(opts.runtime);
   const filesWritten = await scaffoldWorkspace(workspacePath, defaultWorkspacePath);

--- a/lib/setup/templates.ts
+++ b/lib/setup/templates.ts
@@ -14,15 +14,23 @@ import path from "node:path";
 
 // esbuild bundles everything into dist/index.js, so import.meta.url points to
 // dist/index.js → one level up reaches the repo root where defaults/ lives.
-const DEFAULTS_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "defaults");
+const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+const DEFAULTS_DIR_CANDIDATES = [
+  path.join(moduleDir, "..", "defaults"),
+  path.join(moduleDir, "..", "..", "defaults"),
+];
 
 function loadDefault(filename: string): string {
-  const filePath = path.join(DEFAULTS_DIR, filename);
-  try {
-    return fs.readFileSync(filePath, "utf-8");
-  } catch (err) {
-    throw new Error(`Failed to load default file: ${filePath} (${(err as Error).message})`);
+  for (const defaultsDir of DEFAULTS_DIR_CANDIDATES) {
+    const filePath = path.join(defaultsDir, filename);
+    if (fs.existsSync(filePath)) {
+      return fs.readFileSync(filePath, "utf-8");
+    }
   }
+
+  throw new Error(
+    `Failed to load default file: ${filename} (searched: ${DEFAULTS_DIR_CANDIDATES.join(", ")})`,
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/testing/harness.ts
+++ b/lib/testing/harness.ts
@@ -93,6 +93,7 @@ function createCommandInterceptor(): {
         : optsOrTimeout;
 
     const captured: CapturedCommand = { argv, opts };
+    let mockStdout = "{}";
 
     // Parse gateway agent calls to extract task message
     if (argv[0] === "openclaw" && argv[1] === "gateway" && argv[2] === "call") {
@@ -112,6 +113,10 @@ function createCommandInterceptor(): {
             if (params.idempotencyKey) {
               captured.idempotencyKey = params.idempotencyKey;
             }
+            mockStdout = JSON.stringify({
+              status: "accepted",
+              runId: `run-${Date.now()}`,
+            });
           }
           if (rpcMethod === "sessions.patch") {
             captured.sessionPatch = {
@@ -129,7 +134,7 @@ function createCommandInterceptor(): {
     commands.push(captured);
 
     return {
-      stdout: "{}",
+      stdout: mockStdout,
       stderr: "",
       code: 0,
       signal: null as null,

--- a/lib/testing/test-provider.ts
+++ b/lib/testing/test-provider.ts
@@ -9,6 +9,7 @@ import type {
   Issue,
   StateLabel,
   IssueComment,
+  IssueDependencies,
   PrStatus,
   CiStatus,
 } from "../providers/provider.js";
@@ -35,6 +36,7 @@ export type ProviderCall =
   | { method: "listIssuesByLabel"; args: { label: StateLabel } }
   | { method: "listIssues"; args: { label?: string; state?: string } }
   | { method: "getIssue"; args: { issueId: number } }
+  | { method: "getIssueDependencies"; args: { issueId: number } }
   | { method: "listComments"; args: { issueId: number } }
   | {
       method: "transitionLabel";
@@ -195,6 +197,11 @@ export class TestProvider implements IssueProvider {
     const issue = this.issues.get(issueId);
     if (!issue) throw new Error(`Issue #${issueId} not found in TestProvider`);
     return issue;
+  }
+
+  async getIssueDependencies(issueId: number): Promise<IssueDependencies> {
+    this.calls.push({ method: "getIssueDependencies", args: { issueId } });
+    return { issueId, blockers: [], dependents: [] };
   }
 
   async listComments(issueId: number): Promise<IssueComment[]> {

--- a/lib/tools/tasks/tasks-status-dependencies.test.ts
+++ b/lib/tools/tasks/tasks-status-dependencies.test.ts
@@ -1,11 +1,11 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
 import { DEFAULT_WORKFLOW } from "../../workflow/index.js";
-import { getBlockedMeta, isBlockingDependency } from "./tasks-status.js";
+import { getDependencyGateStatus } from "../../services/queue-scan.js";
 import type { IssueDependency } from "../../providers/provider.js";
 
-describe("tasks_status dependency visibility", () => {
-  it("marks open blockers as blocking and includes blocker IDs", async () => {
+describe("dependency gating", () => {
+  it("marks open blockers as blocked (kind=dependency) and includes blocker IDs in reason", async () => {
     const provider = {
       async getIssueDependencies(issueId: number) {
         return {
@@ -18,13 +18,13 @@ describe("tasks_status dependency visibility", () => {
       },
     };
 
-    const meta = await getBlockedMeta(provider as any, 2, DEFAULT_WORKFLOW);
-    assert.strictEqual(meta.blocked, true);
-    assert.deepStrictEqual(meta.blockerIds, [10]);
-    assert.match(meta.blockedReason, /#10/);
+    const gate = await getDependencyGateStatus(provider as any, { iid: 2 }, DEFAULT_WORKFLOW);
+    assert.strictEqual(gate.blocked, true);
+    assert.strictEqual(gate.kind, "dependency");
+    assert.match(gate.reason ?? "", /#10/);
   });
 
-  it("treats Rejected blockers as still blocking", () => {
+  it("treats Rejected blockers as still blocking", async () => {
     const blocker: IssueDependency = {
       iid: 11,
       title: "Rejected blocker",
@@ -33,10 +33,18 @@ describe("tasks_status dependency visibility", () => {
       web_url: "u",
       relation: "blocked_by",
     };
-    assert.strictEqual(isBlockingDependency(blocker, DEFAULT_WORKFLOW), true);
+
+    const provider = {
+      async getIssueDependencies(issueId: number) {
+        return { issueId, blockers: [blocker], dependents: [] };
+      },
+    };
+
+    const gate = await getDependencyGateStatus(provider as any, { iid: 2 }, DEFAULT_WORKFLOW);
+    assert.strictEqual(gate.blocked, true);
   });
 
-  it("treats Done blockers as resolved", () => {
+  it("treats Done blockers as resolved", async () => {
     const blocker: IssueDependency = {
       iid: 12,
       title: "Done blocker",
@@ -45,19 +53,27 @@ describe("tasks_status dependency visibility", () => {
       web_url: "u",
       relation: "blocked_by",
     };
-    assert.strictEqual(isBlockingDependency(blocker, DEFAULT_WORKFLOW), false);
+
+    const provider = {
+      async getIssueDependencies(issueId: number) {
+        return { issueId, blockers: [blocker], dependents: [] };
+      },
+    };
+
+    const gate = await getDependencyGateStatus(provider as any, { iid: 2 }, DEFAULT_WORKFLOW);
+    assert.deepStrictEqual(gate, { blocked: false });
   });
 
-  it("surfaces dependency lookup failure as fail-closed blocked reason", async () => {
+  it("surfaces dependency lookup failure as fail-closed blocked (kind=uncertain)", async () => {
     const provider = {
       async getIssueDependencies() {
         throw new Error("provider timeout");
       },
     };
 
-    const meta = await getBlockedMeta(provider as any, 2, DEFAULT_WORKFLOW);
-    assert.strictEqual(meta.blocked, true);
-    assert.strictEqual(meta.dependencyLookupFailed, true);
-    assert.match(meta.blockedReason, /fail-closed/i);
+    const gate = await getDependencyGateStatus(provider as any, { iid: 2 }, DEFAULT_WORKFLOW);
+    assert.strictEqual(gate.blocked, true);
+    assert.strictEqual(gate.kind, "uncertain");
+    assert.match(gate.reason ?? "", /unavailable|failed/i);
   });
 });

--- a/lib/tools/tasks/tasks-status-dependencies.test.ts
+++ b/lib/tools/tasks/tasks-status-dependencies.test.ts
@@ -1,0 +1,63 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { DEFAULT_WORKFLOW } from "../../workflow/index.js";
+import { getBlockedMeta, isBlockingDependency } from "./tasks-status.js";
+import type { IssueDependency } from "../../providers/provider.js";
+
+describe("tasks_status dependency visibility", () => {
+  it("marks open blockers as blocking and includes blocker IDs", async () => {
+    const provider = {
+      async getIssueDependencies(issueId: number) {
+        return {
+          issueId,
+          blockers: [
+            { iid: 10, title: "A", state: "OPEN", web_url: "u", relation: "blocked_by" as const },
+          ],
+          dependents: [],
+        };
+      },
+    };
+
+    const meta = await getBlockedMeta(provider as any, 2, DEFAULT_WORKFLOW);
+    assert.strictEqual(meta.blocked, true);
+    assert.deepStrictEqual(meta.blockerIds, [10]);
+    assert.match(meta.blockedReason, /#10/);
+  });
+
+  it("treats Rejected blockers as still blocking", () => {
+    const blocker: IssueDependency = {
+      iid: 11,
+      title: "Rejected blocker",
+      state: "CLOSED",
+      labels: ["Rejected"],
+      web_url: "u",
+      relation: "blocked_by",
+    };
+    assert.strictEqual(isBlockingDependency(blocker, DEFAULT_WORKFLOW), true);
+  });
+
+  it("treats Done blockers as resolved", () => {
+    const blocker: IssueDependency = {
+      iid: 12,
+      title: "Done blocker",
+      state: "CLOSED",
+      labels: ["Done"],
+      web_url: "u",
+      relation: "blocked_by",
+    };
+    assert.strictEqual(isBlockingDependency(blocker, DEFAULT_WORKFLOW), false);
+  });
+
+  it("surfaces dependency lookup failure as fail-closed blocked reason", async () => {
+    const provider = {
+      async getIssueDependencies() {
+        throw new Error("provider timeout");
+      },
+    };
+
+    const meta = await getBlockedMeta(provider as any, 2, DEFAULT_WORKFLOW);
+    assert.strictEqual(meta.blocked, true);
+    assert.strictEqual(meta.dependencyLookupFailed, true);
+    assert.match(meta.blockedReason, /fail-closed/i);
+  });
+});

--- a/lib/tools/tasks/tasks-status.ts
+++ b/lib/tools/tasks/tasks-status.ts
@@ -12,8 +12,8 @@ import { getStateLabelsByType } from "../../services/queue.js";
 import { requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider } from "../helpers.js";
 import { loadConfig } from "../../config/index.js";
 import { ciDiagnostics, getCiStatusWithRetry } from "../../services/ci-gate.js";
-import { CiState, type IssueDependency, type IssueProvider } from "../../providers/provider.js";
-import { findStateByLabel } from "../../workflow/index.js";
+import { CiState, type IssueProvider } from "../../providers/provider.js";
+import { getDependencyGateStatus } from "../../services/queue-scan.js";
 
 type IssueSummary = {
   id: number;
@@ -23,17 +23,10 @@ type IssueSummary = {
   ciReason?: string;
   ciFailedChecks?: string[];
   ciPendingChecks?: string[];
-  blocked?: boolean;
-  blockerIds?: number[];
-  blockedReason?: string;
-  dependencyLookupFailed?: boolean;
-};
-
-type BlockedMeta = {
-  blocked: boolean;
-  blockerIds: number[];
-  blockedReason: string;
-  dependencyLookupFailed?: boolean;
+  dependencyBlocked?: boolean;
+  dependencyBlockKind?: "dependency" | "cycle" | "uncertain";
+  dependencyReason?: string;
+  dependencyCyclePath?: number[];
 };
 
 async function withCiSummary(provider: IssueProvider, issue: { iid: number; title: string; web_url: string }, enabled: boolean): Promise<IssueSummary> {
@@ -50,48 +43,6 @@ async function withCiSummary(provider: IssueProvider, issue: { iid: number; titl
     ciFailedChecks: ci.failedChecks,
     ciPendingChecks: ci.pendingChecks,
   };
-}
-
-export function isBlockingDependency(blocker: IssueDependency, workflow: Awaited<ReturnType<typeof loadConfig>>["workflow"]): boolean {
-  const labels = blocker.labels ?? [];
-  if (labels.some((l) => l.toLowerCase() === "rejected")) return true;
-
-  const hasTerminalLabel = labels.some((l) => {
-    const state = findStateByLabel(workflow, l);
-    return state?.type === "terminal";
-  });
-  if (hasTerminalLabel) return false;
-
-  const state = blocker.state.toLowerCase();
-  const closedLike = state === "closed" || state === "done" || state === "merged";
-  return !closedLike;
-}
-
-export async function getBlockedMeta(
-  provider: Pick<IssueProvider, "getIssueDependencies">,
-  issueId: number,
-  workflow: Awaited<ReturnType<typeof loadConfig>>["workflow"],
-): Promise<BlockedMeta> {
-  try {
-    const deps = await provider.getIssueDependencies(issueId);
-    const unresolved = deps.blockers.filter((b) => isBlockingDependency(b, workflow));
-    const blockerIds = unresolved.map((b) => b.iid);
-    if (blockerIds.length === 0) {
-      return { blocked: false, blockerIds: [], blockedReason: "No unresolved blockers" };
-    }
-    return {
-      blocked: true,
-      blockerIds,
-      blockedReason: `Blocked by issue(s): ${blockerIds.map((id) => `#${id}`).join(", ")}`,
-    };
-  } catch {
-    return {
-      blocked: true,
-      blockerIds: [],
-      blockedReason: "Blocked (fail-closed): dependency lookup failed",
-      dependencyLookupFailed: true,
-    };
-  }
 }
 
 export function createTasksStatusTool(ctx: PluginContext) {
@@ -150,14 +101,14 @@ export function createTasksStatusTool(ctx: PluginContext) {
         const issues = await provider.listIssues({ label, state: "open" }).catch(() => []);
         const summaries: IssueSummary[] = [];
         for (const i of issues) {
-          const base = await withCiSummary(provider, i, !!workflow.ciGating);
-          const blockedMeta = await getBlockedMeta(provider, i.iid, workflow);
+          const summary = await withCiSummary(provider, i, !!workflow.ciGating);
+          const dep = await getDependencyGateStatus(provider, { iid: i.iid }, workflow);
           summaries.push({
-            ...base,
-            blocked: blockedMeta.blocked,
-            blockerIds: blockedMeta.blockerIds,
-            blockedReason: blockedMeta.blockedReason,
-            dependencyLookupFailed: blockedMeta.dependencyLookupFailed,
+            ...summary,
+            dependencyBlocked: dep.blocked,
+            dependencyBlockKind: dep.kind,
+            dependencyReason: dep.reason,
+            dependencyCyclePath: dep.cyclePath,
           });
         }
         queue[label] = {

--- a/lib/tools/tasks/tasks-status.ts
+++ b/lib/tools/tasks/tasks-status.ts
@@ -12,7 +12,8 @@ import { getStateLabelsByType } from "../../services/queue.js";
 import { requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider } from "../helpers.js";
 import { loadConfig } from "../../config/index.js";
 import { ciDiagnostics, getCiStatusWithRetry } from "../../services/ci-gate.js";
-import { CiState, type IssueProvider } from "../../providers/provider.js";
+import { CiState, type IssueDependency, type IssueProvider } from "../../providers/provider.js";
+import { findStateByLabel } from "../../workflow/index.js";
 
 type IssueSummary = {
   id: number;
@@ -22,6 +23,17 @@ type IssueSummary = {
   ciReason?: string;
   ciFailedChecks?: string[];
   ciPendingChecks?: string[];
+  blocked?: boolean;
+  blockerIds?: number[];
+  blockedReason?: string;
+  dependencyLookupFailed?: boolean;
+};
+
+type BlockedMeta = {
+  blocked: boolean;
+  blockerIds: number[];
+  blockedReason: string;
+  dependencyLookupFailed?: boolean;
 };
 
 async function withCiSummary(provider: IssueProvider, issue: { iid: number; title: string; web_url: string }, enabled: boolean): Promise<IssueSummary> {
@@ -38,6 +50,48 @@ async function withCiSummary(provider: IssueProvider, issue: { iid: number; titl
     ciFailedChecks: ci.failedChecks,
     ciPendingChecks: ci.pendingChecks,
   };
+}
+
+export function isBlockingDependency(blocker: IssueDependency, workflow: Awaited<ReturnType<typeof loadConfig>>["workflow"]): boolean {
+  const labels = blocker.labels ?? [];
+  if (labels.some((l) => l.toLowerCase() === "rejected")) return true;
+
+  const hasTerminalLabel = labels.some((l) => {
+    const state = findStateByLabel(workflow, l);
+    return state?.type === "terminal";
+  });
+  if (hasTerminalLabel) return false;
+
+  const state = blocker.state.toLowerCase();
+  const closedLike = state === "closed" || state === "done" || state === "merged";
+  return !closedLike;
+}
+
+export async function getBlockedMeta(
+  provider: Pick<IssueProvider, "getIssueDependencies">,
+  issueId: number,
+  workflow: Awaited<ReturnType<typeof loadConfig>>["workflow"],
+): Promise<BlockedMeta> {
+  try {
+    const deps = await provider.getIssueDependencies(issueId);
+    const unresolved = deps.blockers.filter((b) => isBlockingDependency(b, workflow));
+    const blockerIds = unresolved.map((b) => b.iid);
+    if (blockerIds.length === 0) {
+      return { blocked: false, blockerIds: [], blockedReason: "No unresolved blockers" };
+    }
+    return {
+      blocked: true,
+      blockerIds,
+      blockedReason: `Blocked by issue(s): ${blockerIds.map((id) => `#${id}`).join(", ")}`,
+    };
+  } catch {
+    return {
+      blocked: true,
+      blockerIds: [],
+      blockedReason: "Blocked (fail-closed): dependency lookup failed",
+      dependencyLookupFailed: true,
+    };
+  }
 }
 
 export function createTasksStatusTool(ctx: PluginContext) {
@@ -95,7 +149,17 @@ export function createTasksStatusTool(ctx: PluginContext) {
       for (const { label } of statesByType.queue) {
         const issues = await provider.listIssues({ label, state: "open" }).catch(() => []);
         const summaries: IssueSummary[] = [];
-        for (const i of issues) summaries.push(await withCiSummary(provider, i, !!workflow.ciGating));
+        for (const i of issues) {
+          const base = await withCiSummary(provider, i, !!workflow.ciGating);
+          const blockedMeta = await getBlockedMeta(provider, i.iid, workflow);
+          summaries.push({
+            ...base,
+            blocked: blockedMeta.blocked,
+            blockerIds: blockedMeta.blockerIds,
+            blockedReason: blockedMeta.blockedReason,
+            dependencyLookupFailed: blockedMeta.dependencyLookupFailed,
+          });
+        }
         queue[label] = {
           count: issues.length,
           issues: summaries,

--- a/lib/tools/worker/work-finish.test.ts
+++ b/lib/tools/worker/work-finish.test.ts
@@ -11,23 +11,21 @@
  */
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert";
-import { mkdtemp, writeFile, readFile } from "node:fs/promises";
+import { mkdtemp, mkdir, writeFile, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { rmdir } from "node:fs/promises";
+import { rm } from "node:fs/promises";
 
 // Helper to create a mock audit log with a merge_conflict transition
-async function createMockAuditLog(workspaceDir: string, issueId: number, hasMergeConflict: boolean): Promise<void> {
+async function createMockAuditLog(
+  workspaceDir: string,
+  issueId: number,
+  hasMergeConflict: boolean,
+): Promise<void> {
   const logDir = join(workspaceDir, "devclaw", "log");
-  
-  // Ensure directory exists
-  try {
-    await writeFile(join(workspaceDir, "devclaw", "placeholder"), "");
-  } catch {
-    // ignore
-  }
-  
-  const auditPath = join(workspaceDir, "devclaw", "log", "audit.log");
+  await mkdir(logDir, { recursive: true });
+
+  const auditPath = join(logDir, "audit.log");
   const entries = [];
   
   // Add some dummy entries
@@ -74,7 +72,7 @@ describe("work_finish: PR validation and conflict resolution", () => {
   after(async () => {
     // Clean up
     try {
-      await rmdir(tempDir, { recursive: true });
+      await rm(tempDir, { recursive: true, force: true });
     } catch {
       // ignore
     }
@@ -243,12 +241,12 @@ describe("work_finish: PR validation and conflict resolution", () => {
 
     it("should handle non-Error exceptions gracefully", () => {
       // Test that non-Error objects don't cause issues
-      const notAnError = "some string";
-      
-      const shouldRethrow = 
-        notAnError instanceof Error && 
-        ((notAnError as any).message?.startsWith("Cannot mark work_finish(done)") || 
-         (notAnError as any).message?.startsWith("Cannot complete work_finish(done)"));
+      const notAnError: unknown = "some string";
+
+      const shouldRethrow =
+        notAnError instanceof Error &&
+        (notAnError.message.startsWith("Cannot mark work_finish(done)") ||
+          notAnError.message.startsWith("Cannot complete work_finish(done)"));
       
       assert.ok(!shouldRethrow, "Should not re-throw non-Error objects");
     });


### PR DESCRIPTION
## Summary
- add explicit `--timeout 30000` to `openclaw gateway call agent` in `sendToAgent`
- keep wrapper `runCommand` timeout safely above gateway timeout using `Math.max(dispatchTimeoutMs, 35000)`
- extend dispatch idempotency test to assert `--timeout 30000` is present and wrapper timeout is > 30000

## Scope
Timeout-only change for dispatch path (no retry/backoff changes).

Closes #75
