### PR TITLE
Fix To Do queue starvation when head issue is dependency-blocked

### DIFF
--- a/lib/services/queue-scan-dependencies.test.ts
+++ b/lib/services/queue-scan-dependencies.test.ts
@@ -2,9 +2,16 @@ import { describe, it } from "node:test";
 import assert from "node:assert";
 import { findNextIssueForRole, getDependencyGateStatus } from "./queue-scan.js";
 import { DEFAULT_WORKFLOW } from "../workflow/index.js";
-import type { Issue, IssueDependencies, IssueProvider } from "../providers/provider.js";
+import type {
+  Issue,
+  IssueDependencies,
+  IssueProvider,
+} from "../providers/provider.js";
 
-type QueueProvider = Pick<IssueProvider, "listIssuesByLabel" | "getIssueDependencies">;
+type QueueProvider = Pick<
+  IssueProvider,
+  "listIssuesByLabel" | "getIssueDependencies"
+>;
 
 function issue(iid: number, labels: string[] = ["To Do"]): Issue {
   return {
@@ -28,7 +35,11 @@ describe("findNextIssueForRole dependency gating", () => {
       },
     };
 
-    const next = await findNextIssueForRole(provider, "developer", DEFAULT_WORKFLOW);
+    const next = await findNextIssueForRole(
+      provider,
+      "developer",
+      DEFAULT_WORKFLOW,
+    );
     assert.ok(next);
     assert.strictEqual(next!.issue.iid, 100);
   });
@@ -42,7 +53,15 @@ describe("findNextIssueForRole dependency gating", () => {
         if (issueId === 2) {
           return {
             issueId,
-            blockers: [{ iid: 10, title: "blocker", state: "OPEN", web_url: "u", relation: "blocked_by" }],
+            blockers: [
+              {
+                iid: 10,
+                title: "blocker",
+                state: "OPEN",
+                web_url: "u",
+                relation: "blocked_by",
+              },
+            ],
             dependents: [],
           };
         }
@@ -50,9 +69,61 @@ describe("findNextIssueForRole dependency gating", () => {
       },
     };
 
-    const next = await findNextIssueForRole(provider, "developer", DEFAULT_WORKFLOW);
+    const next = await findNextIssueForRole(
+      provider,
+      "developer",
+      DEFAULT_WORKFLOW,
+    );
     assert.ok(next);
     assert.strictEqual(next!.issue.iid, 1);
+  });
+
+  it("continues scanning after a dependency-blocked head-of-queue issue (no head-of-line blocking)", async () => {
+    // Simulate provider returning newest-first, so reverse() yields FIFO scan.
+    // We want the scan order to be: 66 (blocked) → 65 (eligible).
+    const provider: QueueProvider = {
+      async listIssuesByLabel() {
+        return [issue(65), issue(66)];
+      },
+      async getIssueDependencies(issueId: number): Promise<IssueDependencies> {
+        if (issueId === 66) {
+          return {
+            issueId,
+            blockers: [
+              {
+                iid: 65,
+                title: "blocker",
+                state: "OPEN",
+                web_url: "u",
+                relation: "blocked_by",
+              },
+            ],
+            dependents: [],
+          };
+        }
+        return { issueId, blockers: [], dependents: [] };
+      },
+    };
+
+    const blocked: Array<{ iid: number; reason?: string }> = [];
+    const next = await findNextIssueForRole(
+      provider,
+      "developer",
+      DEFAULT_WORKFLOW,
+      undefined,
+      {
+        onDependencyBlocked: async ({ issue, gate }) => {
+          blocked.push({ iid: issue.iid, reason: gate.reason });
+        },
+      },
+    );
+
+    assert.ok(next);
+    assert.strictEqual(next!.issue.iid, 65);
+    assert.deepStrictEqual(
+      blocked.map((b) => b.iid),
+      [66],
+    );
   });
 
   it("treats rejected blockers as still blocking", async () => {
@@ -64,7 +135,16 @@ describe("findNextIssueForRole dependency gating", () => {
         if (issueId === 2) {
           return {
             issueId,
-            blockers: [{ iid: 11, title: "rejected blocker", state: "CLOSED", web_url: "u", labels: ["Rejected"], relation: "blocked_by" }],
+            blockers: [
+              {
+                iid: 11,
+                title: "rejected blocker",
+                state: "CLOSED",
+                web_url: "u",
+                labels: ["Rejected"],
+                relation: "blocked_by",
+              },
+            ],
             dependents: [],
           };
         }
@@ -72,7 +152,11 @@ describe("findNextIssueForRole dependency gating", () => {
       },
     };
 
-    const next = await findNextIssueForRole(provider, "developer", DEFAULT_WORKFLOW);
+    const next = await findNextIssueForRole(
+      provider,
+      "developer",
+      DEFAULT_WORKFLOW,
+    );
     assert.ok(next);
     assert.strictEqual(next!.issue.iid, 1);
   });
@@ -86,15 +170,32 @@ describe("findNextIssueForRole dependency gating", () => {
         return {
           issueId,
           blockers: [
-            { iid: 20, title: "done blocker", state: "CLOSED", web_url: "u", labels: ["Done"], relation: "blocked_by" },
-            { iid: 21, title: "closed blocker", state: "CLOSED", web_url: "u", relation: "blocked_by" },
+            {
+              iid: 20,
+              title: "done blocker",
+              state: "CLOSED",
+              web_url: "u",
+              labels: ["Done"],
+              relation: "blocked_by",
+            },
+            {
+              iid: 21,
+              title: "closed blocker",
+              state: "CLOSED",
+              web_url: "u",
+              relation: "blocked_by",
+            },
           ],
           dependents: [],
         };
       },
     };
 
-    const next = await findNextIssueForRole(provider, "developer", DEFAULT_WORKFLOW);
+    const next = await findNextIssueForRole(
+      provider,
+      "developer",
+      DEFAULT_WORKFLOW,
+    );
     assert.ok(next);
     assert.strictEqual(next!.issue.iid, 5);
   });
@@ -111,7 +212,11 @@ describe("findNextIssueForRole dependency gating", () => {
       },
     };
 
-    const next = await findNextIssueForRole(provider, "developer", DEFAULT_WORKFLOW);
+    const next = await findNextIssueForRole(
+      provider,
+      "developer",
+      DEFAULT_WORKFLOW,
+    );
     assert.strictEqual(next, null);
     assert.strictEqual(attempts, 3);
   });
@@ -129,7 +234,11 @@ describe("findNextIssueForRole dependency gating", () => {
       },
     };
 
-    const next = await findNextIssueForRole(provider, "developer", DEFAULT_WORKFLOW);
+    const next = await findNextIssueForRole(
+      provider,
+      "developer",
+      DEFAULT_WORKFLOW,
+    );
     assert.ok(next);
     assert.strictEqual(next!.issue.iid, 12);
     assert.strictEqual(attempts, 3);
@@ -142,13 +251,41 @@ describe("findNextIssueForRole dependency gating", () => {
       },
       async getIssueDependencies(issueId: number): Promise<IssueDependencies> {
         if (issueId === 1) {
-          return { issueId, blockers: [{ iid: 2, title: "B", state: "OPEN", web_url: "u", relation: "blocked_by" }], dependents: [] };
+          return {
+            issueId,
+            blockers: [
+              {
+                iid: 2,
+                title: "B",
+                state: "OPEN",
+                web_url: "u",
+                relation: "blocked_by",
+              },
+            ],
+            dependents: [],
+          };
         }
-        return { issueId, blockers: [{ iid: 1, title: "A", state: "OPEN", web_url: "u", relation: "blocked_by" }], dependents: [] };
+        return {
+          issueId,
+          blockers: [
+            {
+              iid: 1,
+              title: "A",
+              state: "OPEN",
+              web_url: "u",
+              relation: "blocked_by",
+            },
+          ],
+          dependents: [],
+        };
       },
     };
 
-    const gate = await getDependencyGateStatus(provider, { iid: 1 }, DEFAULT_WORKFLOW);
+    const gate = await getDependencyGateStatus(
+      provider,
+      { iid: 1 },
+      DEFAULT_WORKFLOW,
+    );
     assert.strictEqual(gate.blocked, true);
     assert.strictEqual(gate.kind, "cycle");
     assert.deepStrictEqual(gate.cyclePath, [1, 2, 1]);
@@ -161,28 +298,71 @@ describe("findNextIssueForRole dependency gating", () => {
       },
       async getIssueDependencies(issueId: number): Promise<IssueDependencies> {
         if (issueId === 1) {
-          return { issueId, blockers: [{ iid: 2, title: "B", state: "OPEN", web_url: "u", relation: "blocked_by" }], dependents: [] };
+          return {
+            issueId,
+            blockers: [
+              {
+                iid: 2,
+                title: "B",
+                state: "OPEN",
+                web_url: "u",
+                relation: "blocked_by",
+              },
+            ],
+            dependents: [],
+          };
         }
         if (issueId === 2) {
-          return { issueId, blockers: [{ iid: 3, title: "C", state: "OPEN", web_url: "u", relation: "blocked_by" }], dependents: [] };
+          return {
+            issueId,
+            blockers: [
+              {
+                iid: 3,
+                title: "C",
+                state: "OPEN",
+                web_url: "u",
+                relation: "blocked_by",
+              },
+            ],
+            dependents: [],
+          };
         }
-        return { issueId, blockers: [{ iid: 1, title: "A", state: "OPEN", web_url: "u", relation: "blocked_by" }], dependents: [] };
+        return {
+          issueId,
+          blockers: [
+            {
+              iid: 1,
+              title: "A",
+              state: "OPEN",
+              web_url: "u",
+              relation: "blocked_by",
+            },
+          ],
+          dependents: [],
+        };
       },
     };
 
     let callbackPath: number[] | null = null;
-    const next = await findNextIssueForRole(provider, "developer", DEFAULT_WORKFLOW, undefined, {
-      onCycleDetected: async ({ cyclePath }) => {
-        callbackPath = cyclePath;
+    const next = await findNextIssueForRole(
+      provider,
+      "developer",
+      DEFAULT_WORKFLOW,
+      undefined,
+      {
+        onCycleDetected: async ({ cyclePath }) => {
+          callbackPath = cyclePath;
+        },
       },
-    });
+    );
 
     assert.strictEqual(next, null);
     assert.deepStrictEqual(callbackPath, [1, 2, 3, 1]);
   });
 
   it("transitions cycle issues to Refining via onCycleDetected hook (integration wiring)", async () => {
-    const transitions: Array<{ issueId: number; from: string; to: string }> = [];
+    const transitions: Array<{ issueId: number; from: string; to: string }> =
+      [];
 
     const provider: QueueProvider & Pick<IssueProvider, "transitionLabel"> = {
       async listIssuesByLabel(label: string) {
@@ -190,23 +370,59 @@ describe("findNextIssueForRole dependency gating", () => {
       },
       async getIssueDependencies(issueId: number): Promise<IssueDependencies> {
         if (issueId === 1) {
-          return { issueId, blockers: [{ iid: 2, title: "B", state: "OPEN", web_url: "u", relation: "blocked_by" }], dependents: [] };
+          return {
+            issueId,
+            blockers: [
+              {
+                iid: 2,
+                title: "B",
+                state: "OPEN",
+                web_url: "u",
+                relation: "blocked_by",
+              },
+            ],
+            dependents: [],
+          };
         }
-        return { issueId, blockers: [{ iid: 1, title: "A", state: "OPEN", web_url: "u", relation: "blocked_by" }], dependents: [] };
+        return {
+          issueId,
+          blockers: [
+            {
+              iid: 1,
+              title: "A",
+              state: "OPEN",
+              web_url: "u",
+              relation: "blocked_by",
+            },
+          ],
+          dependents: [],
+        };
       },
-      async transitionLabel(issueId: number, from: string, to: string): Promise<void> {
+      async transitionLabel(
+        issueId: number,
+        from: string,
+        to: string,
+      ): Promise<void> {
         transitions.push({ issueId, from, to });
       },
     };
 
-    const next = await findNextIssueForRole(provider, "developer", DEFAULT_WORKFLOW, undefined, {
-      onCycleDetected: async ({ issue, label }) => {
-        await provider.transitionLabel(issue.iid, label, "Refining");
+    const next = await findNextIssueForRole(
+      provider,
+      "developer",
+      DEFAULT_WORKFLOW,
+      undefined,
+      {
+        onCycleDetected: async ({ issue, label }) => {
+          await provider.transitionLabel(issue.iid, label, "Refining");
+        },
       },
-    });
+    );
 
     assert.strictEqual(next, null);
-    assert.deepStrictEqual(transitions, [{ issueId: 1, from: "To Do", to: "Refining" }]);
+    assert.deepStrictEqual(transitions, [
+      { issueId: 1, from: "To Do", to: "Refining" },
+    ]);
   });
 
   it("continues scanning when isEligible throws for one issue", async () => {
@@ -219,12 +435,18 @@ describe("findNextIssueForRole dependency gating", () => {
       },
     };
 
-    const next = await findNextIssueForRole(provider, "developer", DEFAULT_WORKFLOW, undefined, {
-      isEligible: ({ issue }) => {
-        if (issue.iid === 2) throw new Error("boom");
-        return true;
+    const next = await findNextIssueForRole(
+      provider,
+      "developer",
+      DEFAULT_WORKFLOW,
+      undefined,
+      {
+        isEligible: ({ issue }) => {
+          if (issue.iid === 2) throw new Error("boom");
+          return true;
+        },
       },
-    });
+    );
 
     assert.ok(next);
     assert.strictEqual(next!.issue.iid, 1);
@@ -240,12 +462,21 @@ describe("findNextIssueForRole dependency gating", () => {
       },
     };
 
-    const next = await findNextIssueForRole(provider, "developer", DEFAULT_WORKFLOW, undefined, {
-      isEligible: ({ issue }) => ({ ok: issue.iid === 1, reason: "not-ready" }),
-      onIneligible: async () => {
-        throw new Error("callback failed");
+    const next = await findNextIssueForRole(
+      provider,
+      "developer",
+      DEFAULT_WORKFLOW,
+      undefined,
+      {
+        isEligible: ({ issue }) => ({
+          ok: issue.iid === 1,
+          reason: "not-ready",
+        }),
+        onIneligible: async () => {
+          throw new Error("callback failed");
+        },
       },
-    });
+    );
 
     assert.ok(next);
     assert.strictEqual(next!.issue.iid, 1);

--- a/lib/services/queue-scan.ts
+++ b/lib/services/queue-scan.ts
@@ -153,6 +153,13 @@ export async function findNextIssueForRole(
       label: StateLabel;
       reason?: string;
     }) => Promise<void>;
+
+    /** Called when an issue is blocked by the dependency gate (or dependency status is uncertain). */
+    onDependencyBlocked?: (args: {
+      issue: Issue;
+      label: StateLabel;
+      gate: DependencyGateStatus;
+    }) => Promise<void>;
   },
 ): Promise<{ issue: Issue; label: StateLabel } | null> {
   const labels = getQueueLabels(workflow, role);
@@ -183,6 +190,17 @@ export async function findNextIssueForRole(
                 `Dependency cycle detected: ${gate.cyclePath.join(" → ")}`,
             });
           }
+
+          if (opts?.onDependencyBlocked) {
+            try {
+              await opts.onDependencyBlocked({ issue, label, gate });
+            } catch (err) {
+              console.warn(
+                `[queue-scan] onDependencyBlocked failed for #${issue.iid} (${label}): ${toErrorMessage(err)}`,
+              );
+            }
+          }
+
           continue;
         }
 

--- a/lib/services/tick.ts
+++ b/lib/services/tick.ts
@@ -219,6 +219,12 @@ export async function projectTick(opts: {
             reason: `Issue #${issue.iid}: ${reason ?? "ineligible"}`,
           });
         },
+        onDependencyBlocked: async ({ issue, gate }) => {
+          skipped.push({
+            role,
+            reason: `Issue #${issue.iid}: ${gate.reason ?? "dependency-blocked"}`,
+          });
+        },
         onCycleDetected: async ({ issue, label: currentLabel, reason }) => {
           try {
             await provider.transitionLabel(


### PR DESCRIPTION
Addresses issue #67.

- Queue scan now reports dependency-blocked skips via a callback while continuing to scan for eligible issues.
- projectTick wires the callback so heartbeat skipped logs include dependency gate reason.
- Added regression test for head-of-line dependency-blocked scenario.