### PR TITLE
fix: dedupe blocked terminal heartbeat comments

### DIFF
--- a/lib/dispatch/session.ts
+++ b/lib/dispatch/session.ts
@@ -88,7 +88,6 @@ export function sendToAgent(
 ): void {
   const rc = opts.runCommand;
   const gatewayParams = JSON.stringify({
-    idempotencyKey: `devclaw-${opts.projectName}-${opts.issueId}-${opts.role}-${opts.level ?? "unknown"}-${opts.slotIndex ?? 0}-${sessionKey}`,
     agentId: opts.agentId ?? "devclaw",
     sessionKey,
     message: taskMessage,

--- a/lib/providers/github.list-comments.test.ts
+++ b/lib/providers/github.list-comments.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import type { RunCommand } from "../context.js";
+import { GitHubProvider } from "./github.js";
+
+describe("GitHubProvider.listComments", () => {
+  it("uses gh api pagination and returns stably sorted comments", async () => {
+    const calls: string[][] = [];
+    const runCommand: RunCommand = async (args) => {
+      calls.push(args);
+      return {
+        stdout: [
+          JSON.stringify({
+            id: 202,
+            author: "zoe",
+            body: "second page marker",
+            created_at: "2026-03-01T10:00:00Z",
+          }),
+          JSON.stringify({
+            id: 101,
+            author: "alice",
+            body: "first page",
+            created_at: "2026-03-01T09:00:00Z",
+          }),
+        ].join("\n"),
+        stderr: "",
+        exitCode: 0,
+        code: 0,
+        signal: null,
+        killed: false,
+        termination: "exit",
+      } as any;
+    };
+
+    const provider = new GitHubProvider({ repoPath: "/fake", runCommand });
+    const comments = await provider.listComments(42);
+
+    const ghCall = calls.find((c) => c[0] === "gh" && c[1] === "api");
+    assert.ok(ghCall, "expected gh api call");
+    assert.ok(
+      ghCall?.includes("--paginate"),
+      "expected --paginate for full comment retrieval",
+    );
+
+    assert.equal(comments.length, 2);
+    assert.equal(
+      comments[0]?.id,
+      101,
+      "expected stable chronological ordering",
+    );
+    assert.equal(comments[1]?.id, 202);
+  });
+});

--- a/lib/providers/github.ts
+++ b/lib/providers/github.ts
@@ -276,9 +276,14 @@ export class GitHubProvider implements IssueProvider {
 
   async listComments(issueId: number): Promise<IssueComment[]> {
     try {
-      const raw = await this.gh(["api", `repos/:owner/:repo/issues/${issueId}/comments`, "--jq", ".[] | {id: .id, author: .user.login, body: .body, created_at: .created_at}"]);
+      const raw = await this.gh(["api", `repos/:owner/:repo/issues/${issueId}/comments`, "--paginate", "--jq", ".[] | {id: .id, author: .user.login, body: .body, created_at: .created_at}"]);
       if (!raw) return [];
-      return raw.split("\n").filter(Boolean).map((line) => JSON.parse(line));
+      const comments = raw.split("\n").filter(Boolean).map((line) => JSON.parse(line) as IssueComment);
+      comments.sort((a, b) => {
+        const timeDiff = new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
+        return timeDiff !== 0 ? timeDiff : a.id - b.id;
+      });
+      return comments;
     } catch { return []; }
   }
 

--- a/lib/services/heartbeat/review-skip.guard.test.ts
+++ b/lib/services/heartbeat/review-skip.guard.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { reviewSkipPass } from "./review-skip.js";
+import { TestProvider } from "../../testing/test-provider.js";
+import {
+  DEFAULT_WORKFLOW,
+  Action,
+  WorkflowEvent,
+} from "../../workflow/index.js";
+import { PrState } from "../../providers/provider.js";
+
+describe("heartbeat/review-skip — terminal completion guard comment dedupe", () => {
+  it("posts at most one comment for unchanged blocked signature and one more when signature changes", async () => {
+    const provider = new TestProvider();
+
+    const workflow = structuredClone(DEFAULT_WORKFLOW);
+    workflow.states.toReview.on ??= {};
+    workflow.states.toReview.on[WorkflowEvent.SKIP] = {
+      target: "done",
+      actions: [Action.CLOSE_ISSUE],
+    };
+
+    provider.seedIssue({
+      iid: 40,
+      title: "Review skip blocked",
+      labels: ["To Review", "review:skip"],
+    });
+    provider.setPrStatus(40, {
+      state: PrState.APPROVED,
+      url: "https://example/pr/40",
+      mergeable: true,
+    });
+
+    const common = {
+      workspaceDir: "/tmp",
+      projectName: "devclaw",
+      workflow,
+      provider,
+      repoPath: "/tmp/repo",
+      runCommand: (async () => ({
+        stdout: "",
+        stderr: "",
+        exitCode: 0,
+        code: 0,
+        signal: null,
+        killed: false,
+        termination: "exit",
+      })) as any,
+    };
+
+    const n1 = await reviewSkipPass(common);
+    const n2 = await reviewSkipPass(common);
+
+    provider.setPrStatus(40, {
+      state: PrState.APPROVED,
+      url: "https://example/pr/40-v2",
+      mergeable: true,
+    });
+    const n3 = await reviewSkipPass(common);
+
+    assert.equal(n1, 0);
+    assert.equal(n2, 0);
+    assert.equal(n3, 0);
+
+    const commentCalls = provider.callsTo("addComment");
+    assert.equal(commentCalls.length, 2);
+    assert.notEqual(commentCalls[0]?.args.body, commentCalls[1]?.args.body);
+  });
+});

--- a/lib/services/heartbeat/review-skip.ts
+++ b/lib/services/heartbeat/review-skip.ts
@@ -22,6 +22,7 @@ import type { RunCommand } from "../../context.js";
 import { log as auditLog } from "../../audit.js";
 import { ciDiagnostics, getCiStatusWithRetry } from "../ci-gate.js";
 import { guardTerminalCompletion } from "../terminal-guard.js";
+import { postTerminalBlockedCommentOnce } from "./terminal-blocked-comment.js";
 
 /**
  * Scan review queue states and auto-merge + transition issues with review:skip.
@@ -35,23 +36,41 @@ export async function reviewSkipPass(opts: {
   repoPath: string;
   gitPullTimeoutMs?: number;
   /** Called after a successful PR merge (for notifications). */
-  onMerge?: (issueId: number, prUrl: string | null, prTitle?: string, sourceBranch?: string) => void;
+  onMerge?: (
+    issueId: number,
+    prUrl: string | null,
+    prTitle?: string,
+    sourceBranch?: string,
+  ) => void;
   runCommand: RunCommand;
 }): Promise<number> {
   const rc = opts.runCommand;
-  const { workspaceDir, projectName, workflow, provider, repoPath, gitPullTimeoutMs = 30_000, onMerge } = opts;
+  const {
+    workspaceDir,
+    projectName,
+    workflow,
+    provider,
+    repoPath,
+    gitPullTimeoutMs = 30_000,
+    onMerge,
+  } = opts;
   let transitions = 0;
 
   // Find review queue states (role=reviewer, type=queue) that have a SKIP event
-  const reviewQueueStates = Object.entries(workflow.states)
-    .filter(([, s]) => s.role === "reviewer" && s.type === StateType.QUEUE) as [string, StateConfig][];
+  const reviewQueueStates = Object.entries(workflow.states).filter(
+    ([, s]) => s.role === "reviewer" && s.type === StateType.QUEUE,
+  ) as [string, StateConfig][];
 
   for (const [_stateKey, state] of reviewQueueStates) {
     const skipTransition = state.on?.[WorkflowEvent.SKIP];
     if (!skipTransition) continue;
 
-    const targetKey = typeof skipTransition === "string" ? skipTransition : skipTransition.target;
-    const actions = typeof skipTransition === "object" ? skipTransition.actions : undefined;
+    const targetKey =
+      typeof skipTransition === "string"
+        ? skipTransition
+        : skipTransition.target;
+    const actions =
+      typeof skipTransition === "object" ? skipTransition.actions : undefined;
     const targetState = workflow.states[targetKey];
     if (!targetState) continue;
 
@@ -78,8 +97,15 @@ export async function reviewSkipPass(opts: {
         const pr = guard.prStatus;
         const prUrl = pr?.url ?? null;
         try {
-          await provider.addComment(issue.iid, `⚠️ DevClaw blocked terminal completion: ${guard.reason} (${prUrl ?? "no PR url"}).`);
-        } catch { /* best-effort */ }
+          await postTerminalBlockedCommentOnce({
+            provider,
+            issueId: issue.iid,
+            reason: guard.reason,
+            prUrl,
+          });
+        } catch {
+          /* best-effort */
+        }
         await auditLog(workspaceDir, "terminal_completion_blocked", {
           project: projectName,
           issueId: issue.iid,
@@ -114,14 +140,23 @@ export async function reviewSkipPass(opts: {
               const status = await provider.getPrStatus(issue.iid);
               // Already merged externally — skip the merge call but continue.
               if (status.state === PrState.MERGED) {
-                onMerge?.(issue.iid, status.url, status.title, status.sourceBranch);
+                onMerge?.(
+                  issue.iid,
+                  status.url,
+                  status.title,
+                  status.sourceBranch,
+                );
                 break;
               }
               // No PR exists — skip merge (work may have been committed directly).
               if (!status.url) break;
 
               if (workflow.ciGating) {
-                const { status: ci } = await getCiStatusWithRetry(provider, issue.iid, 3);
+                const { status: ci } = await getCiStatusWithRetry(
+                  provider,
+                  issue.iid,
+                  3,
+                );
                 if (ci.state === CiState.PENDING) {
                   await auditLog(workspaceDir, "review_skip_ci_pending", {
                     project: projectName,
@@ -133,13 +168,29 @@ export async function reviewSkipPass(opts: {
                   break;
                 }
                 if (ci.state === CiState.FAIL || ci.state === CiState.UNKNOWN) {
-                  const failedTransition = state.on?.[WorkflowEvent.CHANGES_REQUESTED] ?? state.on?.[WorkflowEvent.MERGE_FAILED];
+                  const failedTransition =
+                    state.on?.[WorkflowEvent.CHANGES_REQUESTED] ??
+                    state.on?.[WorkflowEvent.MERGE_FAILED];
                   if (failedTransition) {
-                    const failedKey = typeof failedTransition === "string" ? failedTransition : failedTransition.target;
+                    const failedKey =
+                      typeof failedTransition === "string"
+                        ? failedTransition
+                        : failedTransition.target;
                     const failedState = workflow.states[failedKey];
                     if (failedState) {
-                      await provider.transitionLabel(issue.iid, state.label, failedState.label);
-                      try { await provider.addComment(issue.iid, `⚠️ CI gate blocked auto-merge: ${ciDiagnostics(ci)}`); } catch { /* best effort */ }
+                      await provider.transitionLabel(
+                        issue.iid,
+                        state.label,
+                        failedState.label,
+                      );
+                      try {
+                        await provider.addComment(
+                          issue.iid,
+                          `⚠️ CI gate blocked auto-merge: ${ciDiagnostics(ci)}`,
+                        );
+                      } catch {
+                        /* best effort */
+                      }
                       transitions++;
                     }
                   }
@@ -150,7 +201,12 @@ export async function reviewSkipPass(opts: {
 
               try {
                 await provider.mergePr(issue.iid);
-                onMerge?.(issue.iid, status.url, status.title, status.sourceBranch);
+                onMerge?.(
+                  issue.iid,
+                  status.url,
+                  status.title,
+                  status.sourceBranch,
+                );
               } catch (err) {
                 // Merge failed → fire MERGE_FAILED transition if configured
                 await auditLog(workspaceDir, "review_skip_merge_failed", {
@@ -161,10 +217,17 @@ export async function reviewSkipPass(opts: {
                 });
                 const failedTransition = state.on?.[WorkflowEvent.MERGE_FAILED];
                 if (failedTransition) {
-                  const failedKey = typeof failedTransition === "string" ? failedTransition : failedTransition.target;
+                  const failedKey =
+                    typeof failedTransition === "string"
+                      ? failedTransition
+                      : failedTransition.target;
                   const failedState = workflow.states[failedKey];
                   if (failedState) {
-                    await provider.transitionLabel(issue.iid, state.label, failedState.label);
+                    await provider.transitionLabel(
+                      issue.iid,
+                      state.label,
+                      failedState.label,
+                    );
                     transitions++;
                   }
                 }
@@ -173,13 +236,28 @@ export async function reviewSkipPass(opts: {
               break;
             }
             case Action.GIT_PULL:
-              try { await rc(["git", "pull"], { timeoutMs: gitPullTimeoutMs, cwd: repoPath }); } catch { /* best-effort */ }
+              try {
+                await rc(["git", "pull"], {
+                  timeoutMs: gitPullTimeoutMs,
+                  cwd: repoPath,
+                });
+              } catch {
+                /* best-effort */
+              }
               break;
             case Action.CLOSE_ISSUE:
-              try { await provider.closeIssue(issue.iid); } catch { /* best-effort */ }
+              try {
+                await provider.closeIssue(issue.iid);
+              } catch {
+                /* best-effort */
+              }
               break;
             case Action.REOPEN_ISSUE:
-              try { await provider.reopenIssue(issue.iid); } catch { /* best-effort */ }
+              try {
+                await provider.reopenIssue(issue.iid);
+              } catch {
+                /* best-effort */
+              }
               break;
           }
           if (aborted) break;

--- a/lib/services/heartbeat/review.guard.test.ts
+++ b/lib/services/heartbeat/review.guard.test.ts
@@ -3,7 +3,11 @@ import { describe, it } from "node:test";
 
 import { reviewPass } from "./review.js";
 import { TestProvider } from "../../testing/test-provider.js";
-import { DEFAULT_WORKFLOW, Action, WorkflowEvent } from "../../workflow/index.js";
+import {
+  DEFAULT_WORKFLOW,
+  Action,
+  WorkflowEvent,
+} from "../../workflow/index.js";
 import { PrState } from "../../providers/provider.js";
 
 describe("heartbeat/review — terminal completion guard (human review path)", () => {
@@ -14,10 +18,17 @@ describe("heartbeat/review — terminal completion guard (human review path)", (
     // omit the explicit MERGE_CONFLICT transition to ensure the shared terminal guard is doing the work.
     const workflow = structuredClone(DEFAULT_WORKFLOW);
     workflow.states.toReview.on ??= {};
-    workflow.states.toReview.on[WorkflowEvent.APPROVED] = { target: "done", actions: [Action.CLOSE_ISSUE] };
+    workflow.states.toReview.on[WorkflowEvent.APPROVED] = {
+      target: "done",
+      actions: [Action.CLOSE_ISSUE],
+    };
     delete (workflow.states.toReview.on as any)[WorkflowEvent.MERGE_CONFLICT];
 
-    provider.seedIssue({ iid: 20, title: "Conflicting PR", labels: ["To Review", "review:human"] });
+    provider.seedIssue({
+      iid: 20,
+      title: "Conflicting PR",
+      labels: ["To Review", "review:human"],
+    });
     provider.setPrStatus(20, {
       state: PrState.APPROVED,
       url: "https://example/pr/20",
@@ -30,15 +41,88 @@ describe("heartbeat/review — terminal completion guard (human review path)", (
       workflow,
       provider,
       repoPath: "/tmp/repo",
-      runCommand: (async () => ({ stdout: "", stderr: "", exitCode: 0, code: 0, signal: null, killed: false, termination: "exit" })) as any,
+      runCommand: (async () => ({
+        stdout: "",
+        stderr: "",
+        exitCode: 0,
+        code: 0,
+        signal: null,
+        killed: false,
+        termination: "exit",
+      })) as any,
     });
 
     assert.equal(n, 1, "should transition away from terminal completion");
 
     const issue = await provider.getIssue(20);
-    assert.ok(issue.labels.includes("To Improve"), `labels=${issue.labels.join(",")}`);
+    assert.ok(
+      issue.labels.includes("To Improve"),
+      `labels=${issue.labels.join(",")}`,
+    );
     assert.equal(issue.state, "opened");
     assert.equal(provider.callsTo("closeIssue").length, 0);
+  });
+
+  it("dedupes blocked terminal comments across ticks and posts one new comment when signature changes", async () => {
+    const provider = new TestProvider();
+
+    const workflow = structuredClone(DEFAULT_WORKFLOW);
+    workflow.states.toReview.on ??= {};
+    workflow.states.toReview.on[WorkflowEvent.APPROVED] = {
+      target: "done",
+      actions: [Action.CLOSE_ISSUE],
+    };
+    delete (workflow.states.toReview.on as any)[WorkflowEvent.MERGE_CONFLICT];
+
+    provider.seedIssue({
+      iid: 30,
+      title: "Blocked comments",
+      labels: ["To Review", "review:human"],
+    });
+    provider.setPrStatus(30, {
+      state: PrState.APPROVED,
+      url: "https://example/pr/30",
+      mergeable: true,
+    });
+
+    const common = {
+      workspaceDir: "/tmp",
+      projectName: "devclaw",
+      workflow,
+      provider,
+      repoPath: "/tmp/repo",
+      runCommand: (async () => ({
+        stdout: "",
+        stderr: "",
+        exitCode: 0,
+        code: 0,
+        signal: null,
+        killed: false,
+        termination: "exit",
+      })) as any,
+    };
+
+    const n1 = await reviewPass(common);
+    const n2 = await reviewPass(common);
+
+    provider.setPrStatus(30, {
+      state: PrState.APPROVED,
+      url: "https://example/pr/30-conflict",
+      mergeable: false,
+    });
+    const n3 = await reviewPass(common);
+
+    assert.equal(n1, 0);
+    assert.equal(n2, 0);
+    assert.equal(n3, 1);
+
+    const commentCalls = provider.callsTo("addComment");
+    assert.equal(
+      commentCalls.length,
+      2,
+      "expected one comment for unchanged block + one after signature change",
+    );
+    assert.notEqual(commentCalls[0]?.args.body, commentCalls[1]?.args.body);
   });
 
   it("blocks terminal completion when auto-merge is off and PR is not merged yet (mergeable unknown)", async () => {
@@ -47,9 +131,16 @@ describe("heartbeat/review — terminal completion guard (human review path)", (
     // Custom workflow: approval would close immediately, but it has no mergePr action.
     const workflow = structuredClone(DEFAULT_WORKFLOW);
     workflow.states.toReview.on ??= {};
-    workflow.states.toReview.on[WorkflowEvent.APPROVED] = { target: "done", actions: [Action.CLOSE_ISSUE] };
+    workflow.states.toReview.on[WorkflowEvent.APPROVED] = {
+      target: "done",
+      actions: [Action.CLOSE_ISSUE],
+    };
 
-    provider.seedIssue({ iid: 21, title: "Approved but not merged", labels: ["To Review", "review:human"] });
+    provider.seedIssue({
+      iid: 21,
+      title: "Approved but not merged",
+      labels: ["To Review", "review:human"],
+    });
     provider.setPrStatus(21, {
       state: PrState.APPROVED,
       url: "https://example/pr/21",
@@ -62,13 +153,24 @@ describe("heartbeat/review — terminal completion guard (human review path)", (
       workflow,
       provider,
       repoPath: "/tmp/repo",
-      runCommand: (async () => ({ stdout: "", stderr: "", exitCode: 0, code: 0, signal: null, killed: false, termination: "exit" })) as any,
+      runCommand: (async () => ({
+        stdout: "",
+        stderr: "",
+        exitCode: 0,
+        code: 0,
+        signal: null,
+        killed: false,
+        termination: "exit",
+      })) as any,
     });
 
     assert.equal(n, 0, "should not transition");
 
     const issue = await provider.getIssue(21);
-    assert.ok(issue.labels.includes("To Review"), `labels=${issue.labels.join(",")}`);
+    assert.ok(
+      issue.labels.includes("To Review"),
+      `labels=${issue.labels.join(",")}`,
+    );
     assert.ok(!issue.labels.includes("Done"));
     assert.equal(issue.state, "opened");
 

--- a/lib/services/heartbeat/review.ts
+++ b/lib/services/heartbeat/review.ts
@@ -19,6 +19,7 @@ import type { RunCommand } from "../../context.js";
 import { log as auditLog } from "../../audit.js";
 import { ciDiagnostics, getCiStatusWithRetry } from "../ci-gate.js";
 import { guardTerminalCompletion } from "../terminal-guard.js";
+import { postTerminalBlockedCommentOnce } from "./terminal-blocked-comment.js";
 
 /**
  * Scan review-type states and transition issues whose PR check condition is met.
@@ -34,20 +35,48 @@ export async function reviewPass(opts: {
   /** Base branch used for git history fallback check (e.g. "main"). */
   baseBranch?: string;
   /** Called after a successful PR merge (for notifications). */
-  onMerge?: (issueId: number, prUrl: string | null, prTitle?: string, sourceBranch?: string) => void;
+  onMerge?: (
+    issueId: number,
+    prUrl: string | null,
+    prTitle?: string,
+    sourceBranch?: string,
+  ) => void;
   /** Called when changes are requested or conflicts detected (for notifications). */
-  onFeedback?: (issueId: number, reason: "changes_requested" | "merge_conflict", prUrl: string | null, issueTitle: string, issueUrl: string) => void;
+  onFeedback?: (
+    issueId: number,
+    reason: "changes_requested" | "merge_conflict",
+    prUrl: string | null,
+    issueTitle: string,
+    issueUrl: string,
+  ) => void;
   /** Called when a PR is closed without merging (for notifications). */
-  onPrClosed?: (issueId: number, prUrl: string | null, issueTitle: string, issueUrl: string) => void;
+  onPrClosed?: (
+    issueId: number,
+    prUrl: string | null,
+    issueTitle: string,
+    issueUrl: string,
+  ) => void;
   runCommand: RunCommand;
 }): Promise<number> {
   const rc = opts.runCommand;
-  const { workspaceDir, projectName, workflow, provider, repoPath, gitPullTimeoutMs = 30_000, baseBranch, onMerge, onFeedback, onPrClosed } = opts;
+  const {
+    workspaceDir,
+    projectName,
+    workflow,
+    provider,
+    repoPath,
+    gitPullTimeoutMs = 30_000,
+    baseBranch,
+    onMerge,
+    onFeedback,
+    onPrClosed,
+  } = opts;
   let transitions = 0;
 
   // Find all states with a review check (e.g. toReview with check: prApproved)
-  const reviewStates = Object.entries(workflow.states)
-    .filter(([, s]) => s.check != null) as [string, StateConfig][];
+  const reviewStates = Object.entries(workflow.states).filter(
+    ([, s]) => s.check != null,
+  ) as [string, StateConfig][];
 
   for (const [stateKey, state] of reviewStates) {
     if (!state.on || !state.check) continue;
@@ -73,40 +102,70 @@ export async function reviewPass(opts: {
       // Check git history for commits mentioning this issue number.
       if (!status.url && status.state === PrState.CLOSED && baseBranch) {
         try {
-          const isOnBranch = await provider.isCommitOnBaseBranch(issue.iid, baseBranch);
+          const isOnBranch = await provider.isCommitOnBaseBranch(
+            issue.iid,
+            baseBranch,
+          );
           if (isOnBranch) {
             status.state = PrState.MERGED;
             await auditLog(workspaceDir, "review_git_fallback", {
-              project: projectName, issueId: issue.iid,
+              project: projectName,
+              issueId: issue.iid,
               reason: "commit_on_base_branch",
               baseBranch,
             });
           }
-        } catch { /* best-effort — don't block on git failure */ }
+        } catch {
+          /* best-effort — don't block on git failure */
+        }
       }
 
       // PR_APPROVED: Accept both explicit approval and manual merge (merge = implicit approval).
       // PR_MERGED: Only triggers on merge. This prevents self-merged PRs (no reviews) from
       // bypassing the review:human gate — a developer merging their own PR must not pass as approved.
       const conditionMet =
-        (state.check === ReviewCheck.PR_MERGED && status.state === PrState.MERGED) ||
-        (state.check === ReviewCheck.PR_APPROVED && (status.state === PrState.APPROVED || status.state === PrState.MERGED));
+        (state.check === ReviewCheck.PR_MERGED &&
+          status.state === PrState.MERGED) ||
+        (state.check === ReviewCheck.PR_APPROVED &&
+          (status.state === PrState.APPROVED ||
+            status.state === PrState.MERGED));
 
       // Changes requested or PR has comment feedback → transition to toImprove
-      if (status.state === PrState.CHANGES_REQUESTED || status.state === PrState.HAS_COMMENTS) {
+      if (
+        status.state === PrState.CHANGES_REQUESTED ||
+        status.state === PrState.HAS_COMMENTS
+      ) {
         const changesTransition = state.on[WorkflowEvent.CHANGES_REQUESTED];
         if (changesTransition) {
-          const targetKey = typeof changesTransition === "string" ? changesTransition : changesTransition.target;
+          const targetKey =
+            typeof changesTransition === "string"
+              ? changesTransition
+              : changesTransition.target;
           const targetState = workflow.states[targetKey];
           if (targetState) {
-            await provider.transitionLabel(issue.iid, state.label, targetState.label);
+            await provider.transitionLabel(
+              issue.iid,
+              state.label,
+              targetState.label,
+            );
             await auditLog(workspaceDir, "review_transition", {
-              project: projectName, issueId: issue.iid,
-              from: state.label, to: targetState.label,
-              reason: status.state === PrState.HAS_COMMENTS ? "pr_comments" : "changes_requested",
+              project: projectName,
+              issueId: issue.iid,
+              from: state.label,
+              to: targetState.label,
+              reason:
+                status.state === PrState.HAS_COMMENTS
+                  ? "pr_comments"
+                  : "changes_requested",
               prUrl: status.url,
             });
-            onFeedback?.(issue.iid, "changes_requested", status.url, issue.title, issue.web_url);
+            onFeedback?.(
+              issue.iid,
+              "changes_requested",
+              status.url,
+              issue.title,
+              issue.web_url,
+            );
             // React to each review comment with 🤖 to acknowledge processing (best-effort)
             reactToFeedbackComments(provider, issue.iid).catch(() => {});
             transitions++;
@@ -119,17 +178,32 @@ export async function reviewPass(opts: {
       if (status.mergeable === false) {
         const conflictTransition = state.on[WorkflowEvent.MERGE_CONFLICT];
         if (conflictTransition) {
-          const targetKey = typeof conflictTransition === "string" ? conflictTransition : conflictTransition.target;
+          const targetKey =
+            typeof conflictTransition === "string"
+              ? conflictTransition
+              : conflictTransition.target;
           const targetState = workflow.states[targetKey];
           if (targetState) {
-            await provider.transitionLabel(issue.iid, state.label, targetState.label);
+            await provider.transitionLabel(
+              issue.iid,
+              state.label,
+              targetState.label,
+            );
             await auditLog(workspaceDir, "review_transition", {
-              project: projectName, issueId: issue.iid,
-              from: state.label, to: targetState.label,
+              project: projectName,
+              issueId: issue.iid,
+              from: state.label,
+              to: targetState.label,
               reason: "merge_conflict",
               prUrl: status.url,
             });
-            onFeedback?.(issue.iid, "merge_conflict", status.url, issue.title, issue.web_url);
+            onFeedback?.(
+              issue.iid,
+              "merge_conflict",
+              status.url,
+              issue.title,
+              issue.web_url,
+            );
             transitions++;
             continue;
           }
@@ -141,26 +215,46 @@ export async function reviewPass(opts: {
       if (status.state === PrState.CLOSED && status.url !== null) {
         const closedTransition = state.on[WorkflowEvent.PR_CLOSED];
         if (closedTransition) {
-          const targetKey = typeof closedTransition === "string" ? closedTransition : closedTransition.target;
-          const closedActions = typeof closedTransition === "object" ? closedTransition.actions : undefined;
+          const targetKey =
+            typeof closedTransition === "string"
+              ? closedTransition
+              : closedTransition.target;
+          const closedActions =
+            typeof closedTransition === "object"
+              ? closedTransition.actions
+              : undefined;
           const targetState = workflow.states[targetKey];
           if (targetState) {
-            await provider.transitionLabel(issue.iid, state.label, targetState.label);
+            await provider.transitionLabel(
+              issue.iid,
+              state.label,
+              targetState.label,
+            );
             if (closedActions) {
               for (const action of closedActions) {
                 switch (action) {
                   case Action.CLOSE_ISSUE:
-                    try { await provider.closeIssue(issue.iid); } catch { /* best-effort */ }
+                    try {
+                      await provider.closeIssue(issue.iid);
+                    } catch {
+                      /* best-effort */
+                    }
                     break;
                   case Action.REOPEN_ISSUE:
-                    try { await provider.reopenIssue(issue.iid); } catch { /* best-effort */ }
+                    try {
+                      await provider.reopenIssue(issue.iid);
+                    } catch {
+                      /* best-effort */
+                    }
                     break;
                 }
               }
             }
             await auditLog(workspaceDir, "review_transition", {
-              project: projectName, issueId: issue.iid,
-              from: state.label, to: targetState.label,
+              project: projectName,
+              issueId: issue.iid,
+              from: state.label,
+              to: targetState.label,
               reason: "pr_closed",
               prUrl: status.url,
               actions: closedActions,
@@ -176,7 +270,11 @@ export async function reviewPass(opts: {
 
       // Optional CI gate (opt-in): do not finalize/merge until CI is green.
       if (workflow.ciGating) {
-        const { status: ci, attempts } = await getCiStatusWithRetry(provider, issue.iid, 3);
+        const { status: ci, attempts } = await getCiStatusWithRetry(
+          provider,
+          issue.iid,
+          3,
+        );
         const ciReason = ciDiagnostics(ci);
 
         if (ci.state === CiState.PENDING) {
@@ -192,13 +290,29 @@ export async function reviewPass(opts: {
         }
 
         if (ci.state === CiState.FAIL || ci.state === CiState.UNKNOWN) {
-          const failTransition = state.on[WorkflowEvent.CHANGES_REQUESTED] ?? state.on[WorkflowEvent.MERGE_FAILED];
+          const failTransition =
+            state.on[WorkflowEvent.CHANGES_REQUESTED] ??
+            state.on[WorkflowEvent.MERGE_FAILED];
           if (failTransition) {
-            const targetKey = typeof failTransition === "string" ? failTransition : failTransition.target;
+            const targetKey =
+              typeof failTransition === "string"
+                ? failTransition
+                : failTransition.target;
             const targetState = workflow.states[targetKey];
             if (targetState) {
-              await provider.transitionLabel(issue.iid, state.label, targetState.label);
-              try { await provider.addComment(issue.iid, `⚠️ CI gate blocked auto-merge: ${ciReason}`); } catch { /* best effort */ }
+              await provider.transitionLabel(
+                issue.iid,
+                state.label,
+                targetState.label,
+              );
+              try {
+                await provider.addComment(
+                  issue.iid,
+                  `⚠️ CI gate blocked auto-merge: ${ciReason}`,
+                );
+              } catch {
+                /* best effort */
+              }
               await auditLog(workspaceDir, "review_transition", {
                 project: projectName,
                 issueId: issue.iid,
@@ -225,8 +339,10 @@ export async function reviewPass(opts: {
       if (!successEvent) continue;
 
       const transition = state.on[successEvent];
-      const targetKey = typeof transition === "string" ? transition : transition.target;
-      const actions = typeof transition === "object" ? transition.actions : undefined;
+      const targetKey =
+        typeof transition === "string" ? transition : transition.target;
+      const actions =
+        typeof transition === "object" ? transition.actions : undefined;
       const targetState = workflow.states[targetKey];
       if (!targetState) continue;
 
@@ -245,16 +361,15 @@ export async function reviewPass(opts: {
         const pr = guard.prStatus;
         const prUrl = pr?.url ?? status.url ?? null;
         try {
-          if (guard.reason === "merge_conflict") {
-            await provider.addComment(issue.iid, `⚠️ DevClaw blocked terminal completion: PR has merge conflicts (${prUrl ?? "no PR url"}).`);
-          } else if (guard.reason === "pr_not_merged_auto_merge_off") {
-            await provider.addComment(issue.iid, `⏸️ DevClaw blocked terminal completion: auto-merge is off and PR is not merged yet (${prUrl ?? "no PR url"}). Merge the PR, then the heartbeat will close this issue.`);
-          } else if (guard.reason === "pr_closed_unmerged") {
-            await provider.addComment(issue.iid, `⚠️ DevClaw blocked terminal completion: PR was closed without merging (${prUrl ?? "no PR url"}).`);
-          } else {
-            await provider.addComment(issue.iid, "⚠️ DevClaw blocked terminal completion: unable to verify PR mergeability/merge state.");
-          }
-        } catch { /* best-effort */ }
+          await postTerminalBlockedCommentOnce({
+            provider,
+            issueId: issue.iid,
+            reason: guard.reason,
+            prUrl,
+          });
+        } catch {
+          /* best-effort */
+        }
 
         await auditLog(workspaceDir, "terminal_completion_blocked", {
           project: projectName,
@@ -291,12 +406,22 @@ export async function reviewPass(opts: {
             case Action.MERGE_PR:
               // If the PR is already merged externally, skip the merge call but continue the transition.
               if (status.state === PrState.MERGED) {
-                onMerge?.(issue.iid, status.url, status.title, status.sourceBranch);
+                onMerge?.(
+                  issue.iid,
+                  status.url,
+                  status.title,
+                  status.sourceBranch,
+                );
                 break;
               }
               try {
                 await provider.mergePr(issue.iid);
-                onMerge?.(issue.iid, status.url, status.title, status.sourceBranch);
+                onMerge?.(
+                  issue.iid,
+                  status.url,
+                  status.title,
+                  status.sourceBranch,
+                );
               } catch (err) {
                 // Merge failed → fire MERGE_FAILED transition (developer fixes conflicts)
                 await auditLog(workspaceDir, "review_merge_failed", {
@@ -307,10 +432,17 @@ export async function reviewPass(opts: {
                 });
                 const failedTransition = state.on[WorkflowEvent.MERGE_FAILED];
                 if (failedTransition) {
-                  const failedKey = typeof failedTransition === "string" ? failedTransition : failedTransition.target;
+                  const failedKey =
+                    typeof failedTransition === "string"
+                      ? failedTransition
+                      : failedTransition.target;
                   const failedState = workflow.states[failedKey];
                   if (failedState) {
-                    await provider.transitionLabel(issue.iid, state.label, failedState.label);
+                    await provider.transitionLabel(
+                      issue.iid,
+                      state.label,
+                      failedState.label,
+                    );
                     await auditLog(workspaceDir, "review_transition", {
                       project: projectName,
                       issueId: issue.iid,
@@ -325,7 +457,14 @@ export async function reviewPass(opts: {
               }
               break;
             case Action.GIT_PULL:
-              try { await rc(["git", "pull"], { timeoutMs: gitPullTimeoutMs, cwd: repoPath }); } catch { /* best-effort */ }
+              try {
+                await rc(["git", "pull"], {
+                  timeoutMs: gitPullTimeoutMs,
+                  cwd: repoPath,
+                });
+              } catch {
+                /* best-effort */
+              }
               break;
             case Action.CLOSE_ISSUE:
               await provider.closeIssue(issue.iid);
@@ -379,10 +518,22 @@ async function reactToFeedbackComments(
   for (const comment of comments) {
     // Reviews (APPROVED, CHANGES_REQUESTED, COMMENTED) use a different reaction API
     // than issue/inline comments. Route accordingly.
-    if (comment.state === "APPROVED" || comment.state === "CHANGES_REQUESTED" || comment.state === "COMMENTED") {
-      await provider.reactToPrReview(issueId, comment.id, FEEDBACK_REACTION_EMOJI);
+    if (
+      comment.state === "APPROVED" ||
+      comment.state === "CHANGES_REQUESTED" ||
+      comment.state === "COMMENTED"
+    ) {
+      await provider.reactToPrReview(
+        issueId,
+        comment.id,
+        FEEDBACK_REACTION_EMOJI,
+      );
     } else {
-      await provider.reactToPrComment(issueId, comment.id, FEEDBACK_REACTION_EMOJI);
+      await provider.reactToPrComment(
+        issueId,
+        comment.id,
+        FEEDBACK_REACTION_EMOJI,
+      );
     }
   }
 }

--- a/lib/services/heartbeat/terminal-blocked-comment.test.ts
+++ b/lib/services/heartbeat/terminal-blocked-comment.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { postTerminalBlockedCommentOnce } from "./terminal-blocked-comment.js";
+
+describe("postTerminalBlockedCommentOnce", () => {
+  it("dedupes when signature marker exists outside the first page of comments", async () => {
+    const marker =
+      "<!-- devclaw:terminal-completion-blocked:30|merge_conflict|https://example/pr/30 -->";
+    const comments = Array.from({ length: 120 }, (_, i) => ({
+      id: i + 1,
+      author: "user",
+      body: i === 95 ? `existing note\n\n${marker}` : `noise comment ${i + 1}`,
+      created_at: new Date(2026, 0, 1, 0, i).toISOString(),
+    }));
+
+    let addCommentCalls = 0;
+    const provider = {
+      listComments: async () => comments,
+      addComment: async () => {
+        addCommentCalls += 1;
+        return 999;
+      },
+    } as any;
+
+    const posted = await postTerminalBlockedCommentOnce({
+      provider,
+      issueId: 30,
+      reason: "merge_conflict",
+      prUrl: "https://example/pr/30",
+    });
+
+    assert.equal(posted, false);
+    assert.equal(
+      addCommentCalls,
+      0,
+      "should not post duplicate marker comment",
+    );
+  });
+});

--- a/lib/services/heartbeat/terminal-blocked-comment.ts
+++ b/lib/services/heartbeat/terminal-blocked-comment.ts
@@ -1,0 +1,65 @@
+import type { IssueProvider } from "../../providers/provider.js";
+
+export type TerminalBlockedReason =
+  | "merge_conflict"
+  | "pr_not_merged_auto_merge_off"
+  | "pr_closed_unmerged"
+  | "pr_status_unavailable";
+
+function normalizePrUrl(prUrl: string | null): string {
+  return prUrl ?? "";
+}
+
+function signatureFor(
+  issueId: number,
+  reason: TerminalBlockedReason,
+  prUrl: string | null,
+): string {
+  return `${issueId}|${reason}|${normalizePrUrl(prUrl)}`;
+}
+
+function markerFor(signature: string): string {
+  return `<!-- devclaw:terminal-completion-blocked:${signature} -->`;
+}
+
+function messageFor(
+  reason: TerminalBlockedReason,
+  prUrl: string | null,
+): string {
+  if (reason === "merge_conflict") {
+    return `⚠️ DevClaw blocked terminal completion: PR has merge conflicts (${prUrl ?? "no PR url"}).`;
+  }
+  if (reason === "pr_not_merged_auto_merge_off") {
+    return `⏸️ DevClaw blocked terminal completion: auto-merge is off and PR is not merged yet (${prUrl ?? "no PR url"}). Merge the PR, then the heartbeat will close this issue.`;
+  }
+  if (reason === "pr_closed_unmerged") {
+    return `⚠️ DevClaw blocked terminal completion: PR was closed without merging (${prUrl ?? "no PR url"}).`;
+  }
+  return "⚠️ DevClaw blocked terminal completion: unable to verify PR mergeability/merge state.";
+}
+
+/**
+ * Post at most one blocked-terminal user comment per (issueId, reason, prUrl) signature.
+ * Uses recent comment lookup for restart-safe dedupe.
+ */
+export async function postTerminalBlockedCommentOnce(opts: {
+  provider: IssueProvider;
+  issueId: number;
+  reason: TerminalBlockedReason;
+  prUrl: string | null;
+}): Promise<boolean> {
+  const { provider, issueId, reason, prUrl } = opts;
+  const message = messageFor(reason, prUrl);
+  const signature = signatureFor(issueId, reason, prUrl);
+  const marker = markerFor(signature);
+
+  const comments = await provider.listComments(issueId);
+  const alreadyPosted = comments.some(
+    (comment) =>
+      comment.body.includes(marker) || comment.body.trim() === message,
+  );
+  if (alreadyPosted) return false;
+
+  await provider.addComment(issueId, `${message}\n\n${marker}`);
+  return true;
+}

--- a/lib/services/heartbeat/test-skip.guard.test.ts
+++ b/lib/services/heartbeat/test-skip.guard.test.ts
@@ -8,8 +8,16 @@ describe("heartbeat/test-skip — terminal completion guard", () => {
   it("routes to To Improve and does not close when PR is conflicting (mergeable=false)", async () => {
     const h = await createTestHarness();
     try {
-      h.provider.seedIssue({ iid: 1, title: "Conflict", labels: ["To Test", "test:skip"] });
-      h.provider.setPrStatus(1, { state: "open", url: "https://example.com/pr/1", mergeable: false });
+      h.provider.seedIssue({
+        iid: 1,
+        title: "Conflict",
+        labels: ["To Test", "test:skip"],
+      });
+      h.provider.setPrStatus(1, {
+        state: "open",
+        url: "https://example.com/pr/1",
+        mergeable: false,
+      });
 
       const n = await testSkipPass({
         workspaceDir: h.workspaceDir,
@@ -21,7 +29,10 @@ describe("heartbeat/test-skip — terminal completion guard", () => {
       assert.equal(n, 1, "should transition once (to feedback state)");
 
       const issue = await h.provider.getIssue(1);
-      assert.ok(issue.labels.includes("To Improve"), `labels=${issue.labels.join(",")}`);
+      assert.ok(
+        issue.labels.includes("To Improve"),
+        `labels=${issue.labels.join(",")}`,
+      );
       assert.equal(issue.state, "opened", "should not close issue on conflict");
 
       assert.equal(h.provider.callsTo("closeIssue").length, 0);
@@ -30,11 +41,75 @@ describe("heartbeat/test-skip — terminal completion guard", () => {
     }
   });
 
+  it("dedupes blocked terminal comments across ticks and posts one new comment when signature changes", async () => {
+    const h = await createTestHarness();
+    try {
+      h.provider.seedIssue({
+        iid: 2,
+        title: "Unmerged",
+        labels: ["To Test", "test:skip"],
+      });
+      h.provider.setPrStatus(2, {
+        state: "approved",
+        url: "https://example.com/pr/2",
+        mergeable: true,
+      });
+
+      const n1 = await testSkipPass({
+        workspaceDir: h.workspaceDir,
+        projectName: h.project.name,
+        workflow: h.workflow,
+        provider: h.provider,
+      });
+      const n2 = await testSkipPass({
+        workspaceDir: h.workspaceDir,
+        projectName: h.project.name,
+        workflow: h.workflow,
+        provider: h.provider,
+      });
+
+      // Change blocked signature (reason + URL) and verify one new comment is posted.
+      h.provider.setPrStatus(2, {
+        state: "approved",
+        url: "https://example.com/pr/2b",
+        mergeable: false,
+      });
+      const n3 = await testSkipPass({
+        workspaceDir: h.workspaceDir,
+        projectName: h.project.name,
+        workflow: h.workflow,
+        provider: h.provider,
+      });
+
+      assert.equal(n1, 0);
+      assert.equal(n2, 0);
+      assert.equal(n3, 1);
+
+      const commentCalls = h.provider.callsTo("addComment");
+      assert.equal(
+        commentCalls.length,
+        2,
+        "expected one comment for unchanged block + one after signature change",
+      );
+      assert.notEqual(commentCalls[0]?.args.body, commentCalls[1]?.args.body);
+    } finally {
+      await h.cleanup();
+    }
+  });
+
   it("does not transition to Done (and does not close) when auto-merge is off and PR is not merged", async () => {
     const h = await createTestHarness();
     try {
-      h.provider.seedIssue({ iid: 2, title: "Unmerged", labels: ["To Test", "test:skip"] });
-      h.provider.setPrStatus(2, { state: "approved", url: "https://example.com/pr/2", mergeable: true });
+      h.provider.seedIssue({
+        iid: 2,
+        title: "Unmerged",
+        labels: ["To Test", "test:skip"],
+      });
+      h.provider.setPrStatus(2, {
+        state: "approved",
+        url: "https://example.com/pr/2",
+        mergeable: true,
+      });
 
       const n = await testSkipPass({
         workspaceDir: h.workspaceDir,
@@ -46,7 +121,10 @@ describe("heartbeat/test-skip — terminal completion guard", () => {
       assert.equal(n, 0, "should not transition");
 
       const issue = await h.provider.getIssue(2);
-      assert.ok(issue.labels.includes("To Test"), `labels=${issue.labels.join(",")}`);
+      assert.ok(
+        issue.labels.includes("To Test"),
+        `labels=${issue.labels.join(",")}`,
+      );
       assert.ok(!issue.labels.includes("Done"));
       assert.equal(issue.state, "opened");
 
@@ -60,8 +138,16 @@ describe("heartbeat/test-skip — terminal completion guard", () => {
   it("allows transition to Done + close after PR is merged", async () => {
     const h = await createTestHarness();
     try {
-      h.provider.seedIssue({ iid: 3, title: "Merged", labels: ["To Test", "test:skip"] });
-      h.provider.setPrStatus(3, { state: "merged", url: "https://example.com/pr/3", mergeable: true });
+      h.provider.seedIssue({
+        iid: 3,
+        title: "Merged",
+        labels: ["To Test", "test:skip"],
+      });
+      h.provider.setPrStatus(3, {
+        state: "merged",
+        url: "https://example.com/pr/3",
+        mergeable: true,
+      });
 
       const n = await testSkipPass({
         workspaceDir: h.workspaceDir,
@@ -73,7 +159,10 @@ describe("heartbeat/test-skip — terminal completion guard", () => {
       assert.equal(n, 1);
 
       const issue = await h.provider.getIssue(3);
-      assert.ok(issue.labels.includes("Done"), `labels=${issue.labels.join(",")}`);
+      assert.ok(
+        issue.labels.includes("Done"),
+        `labels=${issue.labels.join(",")}`,
+      );
       assert.equal(issue.state, "closed", "should close issue when completing");
 
       assert.equal(h.provider.callsTo("closeIssue").length, 1);
@@ -85,9 +174,16 @@ describe("heartbeat/test-skip — terminal completion guard", () => {
   it("treats mergeable=unknown as non-conflicting (still allows close when PR is merged)", async () => {
     const h = await createTestHarness();
     try {
-      h.provider.seedIssue({ iid: 4, title: "Merged (unknown mergeable)", labels: ["To Test", "test:skip"] });
+      h.provider.seedIssue({
+        iid: 4,
+        title: "Merged (unknown mergeable)",
+        labels: ["To Test", "test:skip"],
+      });
       // mergeable omitted/unknown — should not be treated as conflicting.
-      h.provider.setPrStatus(4, { state: "merged", url: "https://example.com/pr/4" });
+      h.provider.setPrStatus(4, {
+        state: "merged",
+        url: "https://example.com/pr/4",
+      });
 
       const n = await testSkipPass({
         workspaceDir: h.workspaceDir,
@@ -99,7 +195,10 @@ describe("heartbeat/test-skip — terminal completion guard", () => {
       assert.equal(n, 1);
 
       const issue = await h.provider.getIssue(4);
-      assert.ok(issue.labels.includes("Done"), `labels=${issue.labels.join(",")}`);
+      assert.ok(
+        issue.labels.includes("Done"),
+        `labels=${issue.labels.join(",")}`,
+      );
       assert.equal(issue.state, "closed");
 
       assert.equal(h.provider.callsTo("closeIssue").length, 1);

--- a/lib/services/heartbeat/test-skip.ts
+++ b/lib/services/heartbeat/test-skip.ts
@@ -18,6 +18,7 @@ import {
 import { detectStepRouting } from "../queue-scan.js";
 import { log as auditLog } from "../../audit.js";
 import { guardTerminalCompletion } from "../terminal-guard.js";
+import { postTerminalBlockedCommentOnce } from "./terminal-blocked-comment.js";
 
 /**
  * Scan test queue states and auto-transition issues with test:skip.
@@ -33,15 +34,20 @@ export async function testSkipPass(opts: {
   let transitions = 0;
 
   // Find test queue states (role=tester, type=queue) that have a SKIP event
-  const testQueueStates = Object.entries(workflow.states)
-    .filter(([, s]) => s.role === "tester" && s.type === StateType.QUEUE) as [string, StateConfig][];
+  const testQueueStates = Object.entries(workflow.states).filter(
+    ([, s]) => s.role === "tester" && s.type === StateType.QUEUE,
+  ) as [string, StateConfig][];
 
   for (const [_stateKey, state] of testQueueStates) {
     const skipTransition = state.on?.[WorkflowEvent.SKIP];
     if (!skipTransition) continue;
 
-    const targetKey = typeof skipTransition === "string" ? skipTransition : skipTransition.target;
-    const actions = typeof skipTransition === "object" ? skipTransition.actions : undefined;
+    const targetKey =
+      typeof skipTransition === "string"
+        ? skipTransition
+        : skipTransition.target;
+    const actions =
+      typeof skipTransition === "object" ? skipTransition.actions : undefined;
     const targetState = workflow.states[targetKey];
     if (!targetState) continue;
 
@@ -64,18 +70,17 @@ export async function testSkipPass(opts: {
         const pr = guard.prStatus;
         const prUrl = pr?.url ?? null;
 
-        // Best-effort: leave a clear breadcrumb.
+        // Best-effort: leave a clear breadcrumb (deduped by issueId/reason/prUrl).
         try {
-          if (guard.reason === "merge_conflict") {
-            await provider.addComment(issue.iid, `⚠️ DevClaw blocked terminal completion: PR has merge conflicts (${prUrl ?? "no PR url"}).`);
-          } else if (guard.reason === "pr_not_merged_auto_merge_off") {
-            await provider.addComment(issue.iid, `⏸️ DevClaw blocked terminal completion: auto-merge is off and PR is not merged yet (${prUrl ?? "no PR url"}). Merge the PR, then the heartbeat will close this issue.`);
-          } else if (guard.reason === "pr_closed_unmerged") {
-            await provider.addComment(issue.iid, `⚠️ DevClaw blocked terminal completion: PR was closed without merging (${prUrl ?? "no PR url"}).`);
-          } else {
-            await provider.addComment(issue.iid, "⚠️ DevClaw blocked terminal completion: unable to verify PR mergeability/merge state.");
-          }
-        } catch { /* best-effort */ }
+          await postTerminalBlockedCommentOnce({
+            provider,
+            issueId: issue.iid,
+            reason: guard.reason,
+            prUrl,
+          });
+        } catch {
+          /* best-effort */
+        }
 
         await auditLog(workspaceDir, "terminal_completion_blocked", {
           project: projectName,
@@ -109,10 +114,18 @@ export async function testSkipPass(opts: {
         for (const action of actions) {
           switch (action) {
             case Action.CLOSE_ISSUE:
-              try { await provider.closeIssue(issue.iid); } catch { /* best-effort */ }
+              try {
+                await provider.closeIssue(issue.iid);
+              } catch {
+                /* best-effort */
+              }
               break;
             case Action.REOPEN_ISSUE:
-              try { await provider.reopenIssue(issue.iid); } catch { /* best-effort */ }
+              try {
+                await provider.reopenIssue(issue.iid);
+              } catch {
+                /* best-effort */
+              }
               break;
           }
         }


### PR DESCRIPTION
## Summary
- Add shared helper to dedupe blocked terminal completion comments by signature `(issueId, reason, prUrl)`.
- Use helper in:
  - `lib/services/heartbeat/test-skip.ts`
  - `lib/services/heartbeat/review.ts`
  - `lib/services/heartbeat/review-skip.ts`
- Keep `terminal_completion_blocked` audit events unchanged (still emitted each tick).
- Add/extend guard tests for all 3 paths, including signature-change behavior.

## Validation
- `npm run test:core` ✅
- `npm run check` ❌ (pre-existing TS1117 duplicate key in `lib/dispatch/session.ts:97`)
- `npm run build` not run because `npm run check` failed first.

Closes #79
