### PR TITLE
test: intentionally fail CI to validate To Improve routing (#86)

### DIFF
--- a/lib/ci-fail-routing.test.ts
+++ b/lib/ci-fail-routing.test.ts
@@ -1,0 +1,12 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+describe("CI fail routing E2E marker", () => {
+  it("intentionally fails to validate To Improve routing when CI is red", () => {
+    assert.strictEqual(
+      true,
+      false,
+      "Intentional CI failure for issue #86 E2E gating scenario",
+    );
+  });
+});


### PR DESCRIPTION
## Summary\n- add a deterministic failing core test for CI-gating E2E scenario\n- keep change isolated to a single marker test file\n- purposefully leave failure in place to validate fail-path routing\n\n## Notes\n- This PR is intentionally red for workflow validation.\n- Addresses issue #86.