### PR TITLE
fix: harden CI gate diagnostics for transient missing PR head SHA

### DIFF
--- a/lib/providers/github.ts
+++ b/lib/providers/github.ts
@@ -408,9 +408,26 @@ export class GitHubProvider implements IssueProvider {
     }
 
     const pr = open[0];
-    const sha = pr.headRefOid;
+    const maxShaAttempts = 3;
+    let sha = pr.headRefOid;
+    let sawTransientMissingSha = false;
+
+    for (let attempt = 1; !sha && attempt <= maxShaAttempts; attempt++) {
+      sawTransientMissingSha = true;
+      if (attempt > 1) {
+        await new Promise((resolve) => setTimeout(resolve, 120 * (2 ** (attempt - 2))));
+      }
+      const refreshed = await this.findPrsForIssue<OpenPr>(issueId, "open", "title,body,number,url,headRefOid");
+      sha = refreshed[0]?.headRefOid ?? "";
+    }
+
     if (!sha) {
+      console.warn(`[github] CI status: persistent missing PR head SHA for issue #${issueId} after ${maxShaAttempts} retries`);
       return { state: CiState.UNKNOWN, failedChecks: [], pendingChecks: [], summary: "PR head SHA unavailable" };
+    }
+
+    if (sawTransientMissingSha) {
+      console.info(`[github] CI status: recovered transient missing PR head SHA for issue #${issueId}`);
     }
 
     const failedChecks: string[] = [];

--- a/lib/providers/github.ts
+++ b/lib/providers/github.ts
@@ -86,7 +86,7 @@ export class GitHubProvider implements IssueProvider {
   private async findPrsViaTimeline(
     issueId: number,
     state: "open" | "merged" | "all",
-  ): Promise<Array<{ number: number; title: string; body: string; headRefName: string; url: string; mergedAt: string | null; reviewDecision: string | null; state: string; mergeable: string | null }> | null> {
+  ): Promise<Array<{ number: number; title: string; body: string; headRefName: string; headRefOid: string; url: string; mergedAt: string | null; reviewDecision: string | null; state: string; mergeable: string | null }> | null> {
     const repo = await this.getRepoInfo();
     if (!repo) return null;
 
@@ -98,10 +98,10 @@ export class GitHubProvider implements IssueProvider {
               nodes {
                 __typename
                 ... on ConnectedEvent {
-                  subject { ... on PullRequest { number title body headRefName state url mergedAt reviewDecision mergeable } }
+                  subject { ... on PullRequest { number title body headRefName headRefOid state url mergedAt reviewDecision mergeable } }
                 }
                 ... on CrossReferencedEvent {
-                  source { ... on PullRequest { number title body headRefName state url mergedAt reviewDecision mergeable } }
+                  source { ... on PullRequest { number title body headRefName headRefOid state url mergedAt reviewDecision mergeable } }
                 }
               }
             }
@@ -115,7 +115,7 @@ export class GitHubProvider implements IssueProvider {
 
       // Extract PR data from both event types
       const seen = new Set<number>();
-      const prs: Array<{ number: number; title: string; body: string; headRefName: string; url: string; mergedAt: string | null; reviewDecision: string | null; state: string; mergeable: string | null }> = [];
+      const prs: Array<{ number: number; title: string; body: string; headRefName: string; headRefOid: string; url: string; mergedAt: string | null; reviewDecision: string | null; state: string; mergeable: string | null }> = [];
 
       for (const node of nodes) {
         const pr = node.subject ?? node.source;
@@ -127,6 +127,7 @@ export class GitHubProvider implements IssueProvider {
           title: pr.title ?? "",
           body: pr.body ?? "",
           headRefName: pr.headRefName ?? "",
+          headRefOid: pr.headRefOid ?? "",
           url: pr.url,
           mergedAt: pr.mergedAt ?? null,
           reviewDecision: pr.reviewDecision ?? null,
@@ -150,7 +151,7 @@ export class GitHubProvider implements IssueProvider {
    * Fallback: regex matching on branch name / title / body.
    *
    * TYPE CASTING NOTE: The timeline query returns a fixed set of fields
-   * (number, title, body, headRefName, state, url, mergedAt, reviewDecision, mergeable).
+   * (number, title, body, headRefName, headRefOid, state, url, mergedAt, reviewDecision, mergeable).
    * When callers request additional fields via the `fields` parameter (e.g., "mergeable"),
    * we cast the timeline results to T assuming they match. This works because:
    * 1. For common fields (mergeable, reviewDecision), the timeline API provides them.
@@ -166,7 +167,7 @@ export class GitHubProvider implements IssueProvider {
     const timelinePrs = await this.findPrsViaTimeline(issueId, state);
     if (timelinePrs && timelinePrs.length > 0) {
       // Map timeline results to the expected shape (T includes the requested fields)
-      // The timeline query now provides: number, title, body, headRefName, state, url, mergedAt, reviewDecision, mergeable
+      // The timeline query now provides: number, title, body, headRefName, headRefOid, state, url, mergedAt, reviewDecision, mergeable
       return timelinePrs as unknown as T[];
     }
 

--- a/lib/providers/provider-ci-status.test.ts
+++ b/lib/providers/provider-ci-status.test.ts
@@ -69,4 +69,27 @@ describe("GitHubProvider.getPrCiStatus", () => {
     assert.ok(ci.failedChecks.includes("quality"));
     assert.ok(calls >= 2);
   });
+
+  it("uses headRefOid from timeline PR metadata for CI lookup", async () => {
+    const p = new GitHubProvider({
+      repoPath: "/fake",
+      runCommand: rcFor({ checkRuns: { check_runs: [{ name: "quality", status: "completed", conclusion: "failure" }] } }),
+    });
+    (p as any).findPrsViaTimeline = async () => [{
+      number: 1,
+      title: "t",
+      body: "b",
+      headRefName: "feature/90-ci-gate-diagnostics",
+      headRefOid: "abc",
+      url: "u",
+      mergedAt: null,
+      reviewDecision: null,
+      state: "OPEN",
+      mergeable: "MERGEABLE",
+    }];
+
+    const ci = await p.getPrCiStatus(1);
+    assert.strictEqual(ci.state, CiState.FAIL);
+    assert.ok(ci.failedChecks.includes("quality"));
+  });
 });

--- a/lib/providers/provider-ci-status.test.ts
+++ b/lib/providers/provider-ci-status.test.ts
@@ -51,4 +51,22 @@ describe("GitHubProvider.getPrCiStatus", () => {
     const ci = await p.getPrCiStatus(1);
     assert.strictEqual(ci.state, CiState.UNKNOWN);
   });
+
+  it("retries transient missing PR head SHA and reports failing checks", async () => {
+    const p = new GitHubProvider({
+      repoPath: "/fake",
+      runCommand: rcFor({ checkRuns: { check_runs: [{ name: "quality", status: "completed", conclusion: "failure" }] } }),
+    });
+    let calls = 0;
+    (p as any).findPrsForIssue = async () => {
+      calls++;
+      if (calls === 1) return [{ title: "t", body: "b", number: 1, url: "u", headRefOid: "" }];
+      return [{ title: "t", body: "b", number: 1, url: "u", headRefOid: "abc" }];
+    };
+
+    const ci = await p.getPrCiStatus(1);
+    assert.strictEqual(ci.state, CiState.FAIL);
+    assert.ok(ci.failedChecks.includes("quality"));
+    assert.ok(calls >= 2);
+  });
 });

--- a/lib/services/ci-gate.test.ts
+++ b/lib/services/ci-gate.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert";
-import { getCiStatusWithRetry } from "./ci-gate.js";
+import { ciDiagnostics, getCiStatusWithRetry } from "./ci-gate.js";
 import { CiState } from "../providers/provider.js";
 
 describe("getCiStatusWithRetry", () => {
@@ -32,5 +32,22 @@ describe("getCiStatusWithRetry", () => {
     const result = await getCiStatusWithRetry(provider as any, 1, 3);
     assert.strictEqual(calls, 3);
     assert.strictEqual(result.status.state, CiState.PASS);
+  });
+
+  it("prefers concrete failure diagnostics over transient SHA-unavailable unknown", async () => {
+    let calls = 0;
+    const provider = {
+      async getPrCiStatus() {
+        calls++;
+        if (calls === 1) {
+          return { state: CiState.UNKNOWN, failedChecks: [], pendingChecks: [], summary: "PR head SHA unavailable" };
+        }
+        return { state: CiState.FAIL, failedChecks: ["quality"], pendingChecks: [] };
+      },
+    };
+
+    const result = await getCiStatusWithRetry(provider as any, 90, 3);
+    assert.strictEqual(result.status.state, CiState.FAIL);
+    assert.strictEqual(ciDiagnostics(result.status), "CI failed: quality");
   });
 });

--- a/lib/services/ci-gate.ts
+++ b/lib/services/ci-gate.ts
@@ -11,20 +11,27 @@ export async function getCiStatusWithRetry(
   attempts = 3,
 ): Promise<CiGateResult> {
   let last: CiStatus = { state: CiState.UNKNOWN, failedChecks: [], pendingChecks: [], summary: "CI status unavailable" };
+  let bestKnown: CiStatus | null = null;
 
   for (let i = 0; i < attempts; i++) {
     try {
       const status = await provider.getPrCiStatus(issueId);
       last = status;
+
+      if (status.state === CiState.FAIL || status.state === CiState.PENDING || status.state === CiState.PASS) {
+        bestKnown = status;
+      }
+
       if (status.state !== CiState.UNKNOWN) {
         return { status, attempts: i + 1 };
       }
+
       // UNKNOWN is retried per policy (fail-closed only after all retries).
       if (i < attempts - 1) {
         await new Promise((resolve) => setTimeout(resolve, 200 * (2 ** i)));
         continue;
       }
-      return { status, attempts: i + 1 };
+      break;
     } catch (err) {
       last = {
         state: CiState.UNKNOWN,
@@ -38,7 +45,7 @@ export async function getCiStatusWithRetry(
     }
   }
 
-  return { status: last, attempts };
+  return { status: bestKnown ?? last, attempts };
 }
 
 export function ciDiagnostics(status: CiStatus): string {

--- a/lib/services/ci-gate.ts
+++ b/lib/services/ci-gate.ts
@@ -1,4 +1,8 @@
-import { CiState, type CiStatus, type IssueProvider } from "../providers/provider.js";
+import {
+  CiState,
+  type CiStatus,
+  type IssueProvider,
+} from "../providers/provider.js";
 
 export type CiGateResult = {
   status: CiStatus;
@@ -10,17 +14,17 @@ export async function getCiStatusWithRetry(
   issueId: number,
   attempts = 3,
 ): Promise<CiGateResult> {
-  let last: CiStatus = { state: CiState.UNKNOWN, failedChecks: [], pendingChecks: [], summary: "CI status unavailable" };
-  let bestKnown: CiStatus | null = null;
+  let last: CiStatus = {
+    state: CiState.UNKNOWN,
+    failedChecks: [],
+    pendingChecks: [],
+    summary: "CI status unavailable",
+  };
 
   for (let i = 0; i < attempts; i++) {
     try {
       const status = await provider.getPrCiStatus(issueId);
       last = status;
-
-      if (status.state === CiState.FAIL || status.state === CiState.PENDING || status.state === CiState.PASS) {
-        bestKnown = status;
-      }
 
       if (status.state !== CiState.UNKNOWN) {
         return { status, attempts: i + 1 };
@@ -28,7 +32,7 @@ export async function getCiStatusWithRetry(
 
       // UNKNOWN is retried per policy (fail-closed only after all retries).
       if (i < attempts - 1) {
-        await new Promise((resolve) => setTimeout(resolve, 200 * (2 ** i)));
+        await new Promise((resolve) => setTimeout(resolve, 200 * 2 ** i));
         continue;
       }
       break;
@@ -40,21 +44,27 @@ export async function getCiStatusWithRetry(
         summary: (err as Error).message ?? "CI status lookup failed",
       };
       if (i < attempts - 1) {
-        await new Promise((resolve) => setTimeout(resolve, 200 * (2 ** i)));
+        await new Promise((resolve) => setTimeout(resolve, 200 * 2 ** i));
       }
     }
   }
 
-  return { status: bestKnown ?? last, attempts };
+  return { status: last, attempts };
 }
 
 export function ciDiagnostics(status: CiStatus): string {
   if (status.state === CiState.FAIL) {
-    const checks = status.failedChecks.length > 0 ? status.failedChecks.join(", ") : "unknown check(s)";
+    const checks =
+      status.failedChecks.length > 0
+        ? status.failedChecks.join(", ")
+        : "unknown check(s)";
     return `CI failed: ${checks}`;
   }
   if (status.state === CiState.PENDING) {
-    const checks = status.pendingChecks.length > 0 ? status.pendingChecks.join(", ") : "checks running";
+    const checks =
+      status.pendingChecks.length > 0
+        ? status.pendingChecks.join(", ")
+        : "checks running";
     return `CI pending: ${checks}`;
   }
   if (status.state === CiState.UNKNOWN) {


### PR DESCRIPTION
## Summary\n- harden GitHub CI status lookup when PR head SHA is briefly unavailable by retrying metadata fetch with short backoff\n- emit distinct logs for transient SHA race recovery vs persistent missing SHA\n- preserve known failed/pending checks across retry attempts and prefer concrete failure diagnostics over UNKNOWN fallback\n- add regression coverage for transient-missing-headRefOid recovery and diagnostic precedence\n\nAddresses issue #90