### PR TITLE
fix: bind github provider to configured repo remote

### DIFF
--- a/lib/dispatch/attachment-hook.ts
+++ b/lib/dispatch/attachment-hook.ts
@@ -93,7 +93,12 @@ export function registerAttachmentHook(api: OpenClawPluginApi, ctx: PluginContex
     // Process each referenced issue
     for (const issueId of issueIds) {
       try {
-        const { provider } = await createProvider({ repo: project.repo, provider: project.provider, runCommand: ctx.runCommand });
+        const { provider } = await createProvider({
+          repo: project.repo,
+          provider: project.provider,
+          repoRemote: project.repoRemote,
+          runCommand: ctx.runCommand,
+        });
 
         await processAttachmentMessage({
           workspaceDir,

--- a/lib/providers/github.repo-remote.test.ts
+++ b/lib/providers/github.repo-remote.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { GitHubProvider } from "./github.js";
+import type { RunCommand } from "../context.js";
+
+function ok(stdout: string) {
+  return {
+    code: 0,
+    stdout,
+    stderr: "",
+    signal: null,
+    killed: false,
+    termination: "exit" as const,
+  };
+}
+
+describe("GitHubProvider repoRemote binding", () => {
+  it("binds gh issue commands to the configured repo when extra remotes exist", async () => {
+    const calls: Array<{ cmd: string[]; cwd?: string }> = [];
+    const runCommand: RunCommand = async (cmd, opts) => {
+      calls.push({ cmd, cwd: typeof opts === "object" ? opts?.cwd : undefined });
+      return ok(JSON.stringify({
+        number: 67,
+        title: "Test issue",
+        body: "Body",
+        labels: [{ name: "To Do" }],
+        state: "OPEN",
+        url: "https://github.com/rayjolt/devclaw/issues/67",
+      }));
+    };
+
+    const provider = new GitHubProvider({
+      repoPath: "/fake/repo",
+      repoRemote: "https://github.com/rayjolt/devclaw.git",
+      runCommand,
+    });
+
+    const issue = await provider.getIssue(67);
+
+    assert.equal(issue.iid, 67);
+    assert.deepEqual(calls, [{
+      cmd: [
+        "gh", "issue", "view", "67", "--json", "number,title,body,labels,state,url", "--repo", "rayjolt/devclaw",
+      ],
+      cwd: "/fake/repo",
+    }]);
+  });
+
+  it("expands API repo placeholders from repoRemote instead of relying on cwd repo selection", async () => {
+    const calls: Array<string[]> = [];
+    const runCommand: RunCommand = async (cmd) => {
+      calls.push(cmd);
+      return ok('{"id":1,"author":"octocat","body":"hello","created_at":"2026-03-10T00:00:00Z"}');
+    };
+
+    const provider = new GitHubProvider({
+      repoPath: "/fake/repo",
+      repoRemote: "git@github.com:rayjolt/devclaw.git",
+      runCommand,
+    });
+
+    const comments = await provider.listComments(67);
+
+    assert.equal(comments.length, 1);
+    assert.deepEqual(calls[0], [
+      "gh",
+      "api",
+      "repos/rayjolt/devclaw/issues/67/comments",
+      "--paginate",
+      "--jq",
+      ".[] | {id: .id, author: .user.login, body: .body, created_at: .created_at}",
+    ]);
+  });
+
+  it("uses configured repoRemote for dependency GraphQL queries without gh repo view", async () => {
+    const calls: Array<string[]> = [];
+    const runCommand: RunCommand = async (cmd) => {
+      calls.push(cmd);
+      return ok(JSON.stringify({
+        data: {
+          repository: {
+            issue: {
+              blockedBy: { nodes: [] },
+              blocking: { nodes: [] },
+            },
+          },
+        },
+      }));
+    };
+
+    const provider = new GitHubProvider({
+      repoPath: "/fake/repo",
+      repoRemote: "https://github.com/rayjolt/devclaw",
+      runCommand,
+    });
+
+    const deps = await provider.getIssueDependencies(67);
+
+    assert.deepEqual(deps, { issueId: 67, blockers: [], dependents: [] });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0]?.[0], "gh");
+    assert.equal(calls[0]?.[1], "api");
+    assert.equal(calls[0]?.[2], "graphql");
+    assert.match(calls[0]?.[4] ?? "", /repository\(owner: "rayjolt", name: "devclaw"\)/);
+  });
+});

--- a/lib/providers/github.repo-remote.test.ts
+++ b/lib/providers/github.repo-remote.test.ts
@@ -15,6 +15,28 @@ function ok(stdout: string) {
 }
 
 describe("GitHubProvider repoRemote binding", () => {
+  it("does not append --repo to global gh auth status health checks", async () => {
+    const calls: Array<{ cmd: string[]; cwd?: string }> = [];
+    const runCommand: RunCommand = async (cmd, opts) => {
+      calls.push({ cmd, cwd: typeof opts === "object" ? opts?.cwd : undefined });
+      return ok("");
+    };
+
+    const provider = new GitHubProvider({
+      repoPath: "/fake/repo",
+      repoRemote: "https://github.com/rayjolt/devclaw.git",
+      runCommand,
+    });
+
+    const healthy = await provider.healthCheck();
+
+    assert.equal(healthy, true);
+    assert.deepEqual(calls, [{
+      cmd: ["gh", "auth", "status"],
+      cwd: "/fake/repo",
+    }]);
+  });
+
   it("binds gh issue commands to the configured repo when extra remotes exist", async () => {
     const calls: Array<{ cmd: string[]; cwd?: string }> = [];
     const runCommand: RunCommand = async (cmd, opts) => {

--- a/lib/providers/github.ts
+++ b/lib/providers/github.ts
@@ -31,6 +31,8 @@ type GhIssue = {
   url: string;
 };
 
+const GH_REPO_SCOPED_COMMANDS = new Set(["issue", "pr", "label", "repo"]);
+
 function toIssue(gh: GhIssue): Issue {
   return {
     iid: gh.number, title: gh.title, description: gh.body ?? "",
@@ -54,6 +56,13 @@ function parseGitHubRepo(remote?: string): { owner: string; name: string } | nul
   }
 
   return null;
+}
+
+function supportsRepoSelection(args: string[]): boolean {
+  const command = args[0];
+  if (!command) return false;
+
+  return GH_REPO_SCOPED_COMMANDS.has(command);
 }
 
 export class GitHubProvider implements IssueProvider {
@@ -93,6 +102,8 @@ export class GitHubProvider implements IssueProvider {
       }
       return built;
     }
+
+    if (!supportsRepoSelection(args)) return args;
 
     const hasRepoFlag = args.includes("-R") || args.includes("--repo");
     if (hasRepoFlag) return args;

--- a/lib/providers/github.ts
+++ b/lib/providers/github.ts
@@ -38,25 +38,65 @@ function toIssue(gh: GhIssue): Issue {
   };
 }
 
+function parseGitHubRepo(remote?: string): { owner: string; name: string } | null {
+  const value = remote?.trim();
+  if (!value) return null;
+
+  const patterns = [
+    /^https?:\/\/github\.com\/([^/]+)\/([^/]+?)(?:\.git)?\/?$/i,
+    /^git@github\.com:([^/]+)\/([^/]+?)(?:\.git)?$/i,
+    /^ssh:\/\/git@github\.com\/([^/]+)\/([^/]+?)(?:\.git)?\/?$/i,
+  ];
+
+  for (const pattern of patterns) {
+    const match = value.match(pattern);
+    if (match) return { owner: match[1]!, name: match[2]! };
+  }
+
+  return null;
+}
+
 export class GitHubProvider implements IssueProvider {
   private repoPath: string;
   private workflow: WorkflowConfig;
   private runCommand: RunCommand;
+  private repoRemote?: string;
 
-  constructor(opts: { repoPath: string; runCommand: RunCommand; workflow?: WorkflowConfig }) {
+  constructor(opts: { repoPath: string; repoRemote?: string; runCommand: RunCommand; workflow?: WorkflowConfig }) {
     this.repoPath = opts.repoPath;
+    this.repoRemote = opts.repoRemote;
     this.runCommand = opts.runCommand;
     this.workflow = opts.workflow ?? DEFAULT_WORKFLOW;
   }
 
   private async gh(args: string[]): Promise<string> {
     return withResilience(async () => {
-      const result = await this.runCommand(["gh", ...args], { timeoutMs: 30_000, cwd: this.repoPath });
+      const command = await this.buildGhArgs(args);
+      const result = await this.runCommand(["gh", ...command], { timeoutMs: 30_000, cwd: this.repoPath });
       if (result.code != null && result.code !== 0) {
         throw new Error(result.stderr?.trim() || `gh command failed with exit code ${result.code}`);
       }
       return result.stdout.trim();
     });
+  }
+
+  private async buildGhArgs(args: string[]): Promise<string[]> {
+    const repo = this.repoInfo ?? parseGitHubRepo(this.repoRemote);
+    if (!repo) return args;
+
+    if (args[0] === "api") {
+      const built = [...args];
+      if (typeof built[1] === "string") {
+        built[1] = built[1]
+          .replaceAll(":owner", repo.owner)
+          .replaceAll(":repo", repo.name);
+      }
+      return built;
+    }
+
+    const hasRepoFlag = args.includes("-R") || args.includes("--repo");
+    if (hasRepoFlag) return args;
+    return [...args, "--repo", `${repo.owner}/${repo.name}`];
   }
 
   /** Cached repo owner/name for GraphQL queries. */
@@ -68,6 +108,13 @@ export class GitHubProvider implements IssueProvider {
    */
   private async getRepoInfo(): Promise<{ owner: string; name: string } | null> {
     if (this.repoInfo !== undefined) return this.repoInfo;
+
+    const parsedRemote = parseGitHubRepo(this.repoRemote);
+    if (parsedRemote) {
+      this.repoInfo = parsedRemote;
+      return this.repoInfo;
+    }
+
     try {
       const raw = await this.gh(["repo", "view", "--json", "owner,name"]);
       const data = JSON.parse(raw);

--- a/lib/providers/index.ts
+++ b/lib/providers/index.ts
@@ -11,6 +11,7 @@ export type ProviderOptions = {
   provider?: "gitlab" | "github";
   repo?: string;
   repoPath?: string;
+  repoRemote?: string;
   runCommand: RunCommand;
 };
 
@@ -19,7 +20,14 @@ export type ProviderWithType = {
   type: "github" | "gitlab";
 };
 
-async function detectProvider(repoPath: string, runCommand: RunCommand): Promise<"gitlab" | "github"> {
+async function detectProvider(
+  repoPath: string,
+  runCommand: RunCommand,
+  repoRemote?: string,
+): Promise<"gitlab" | "github"> {
+  const remote = repoRemote?.trim();
+  if (remote) return remote.includes("github.com") ? "github" : "gitlab";
+
   try {
     const result = await runCommand(["git", "remote", "get-url", "origin"], { timeoutMs: 5_000, cwd: repoPath });
     return result.stdout.trim().includes("github.com") ? "github" : "gitlab";
@@ -32,9 +40,9 @@ export async function createProvider(opts: ProviderOptions): Promise<ProviderWit
   const repoPath = opts.repoPath ?? (opts.repo ? resolveRepoPath(opts.repo) : null);
   if (!repoPath) throw new Error("Either repoPath or repo must be provided");
   const rc = opts.runCommand;
-  const type = opts.provider ?? await detectProvider(repoPath, rc);
+  const type = opts.provider ?? await detectProvider(repoPath, rc, opts.repoRemote);
   const provider = type === "github"
-    ? new GitHubProvider({ repoPath, runCommand: rc })
+    ? new GitHubProvider({ repoPath, repoRemote: opts.repoRemote, runCommand: rc })
     : new GitLabProvider({ repoPath, runCommand: rc });
   return { provider, type };
 }

--- a/lib/services/heartbeat/tick-runner.ts
+++ b/lib/services/heartbeat/tick-runner.ts
@@ -115,6 +115,7 @@ export async function tick(opts: {
       const { provider } = await createProvider({
         repo: project.repo,
         provider: project.provider,
+        repoRemote: project.repoRemote,
         runCommand,
       });
       const resolvedConfig = await loadConfig(workspaceDir, project.name);

--- a/lib/services/tick.ts
+++ b/lib/services/tick.ts
@@ -113,6 +113,7 @@ export async function projectTick(opts: {
       await createProvider({
         repo: project.repo,
         provider: project.provider,
+        repoRemote: project.repoRemote,
         runCommand: runCommand!,
       })
     ).provider;

--- a/lib/tools/admin/sync-labels.ts
+++ b/lib/tools/admin/sync-labels.ts
@@ -81,6 +81,7 @@ export function createSyncLabelsTool(ctx: PluginContext) {
           const { provider } = await createProvider({
             repo: project.repo,
             provider: project.provider,
+            repoRemote: project.repoRemote,
             runCommand: ctx.runCommand,
           });
 

--- a/lib/tools/helpers.ts
+++ b/lib/tools/helpers.ts
@@ -58,7 +58,12 @@ export async function resolveProject(
  * Uses stored provider type from project config if available, otherwise auto-detects.
  */
 export async function resolveProvider(project: Project, runCommand: RunCommand): Promise<ProviderWithType> {
-  return createProvider({ repo: project.repo, provider: project.provider, runCommand });
+  return createProvider({
+    repo: project.repo,
+    provider: project.provider,
+    repoRemote: project.repoRemote,
+    runCommand,
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary\n- bind GitHub provider calls to the configured project repo derived from repoRemote\n- thread repoRemote through provider creation paths used by task tooling and heartbeat passes\n- add regression coverage for multi-remote GitHub repos\n\nAddresses issue #69