### PR TITLE
fix: quarantine repeated dispatch loops

### DIFF
--- a/lib/dispatch/index.ts
+++ b/lib/dispatch/index.ts
@@ -17,15 +17,46 @@ import {
 import { resolveModel } from "../roles/index.js";
 import { notify, getNotificationConfig } from "./notify.js";
 import { loadConfig, type ResolvedRoleConfig } from "../config/index.js";
-import { ReviewPolicy, TestPolicy, resolveReviewRouting, resolveTestRouting, resolveNotifyChannel, isFeedbackState, hasReviewCheck, producesReviewableWork, hasTestPhase, detectOwner, getOwnerLabel, OWNER_LABEL_COLOR, getRoleLabelColor, STEP_ROUTING_COLOR, getStateLabels } from "../workflow/index.js";
-import { fetchPrFeedback, fetchPrContext, type PrFeedback, type PrContext } from "./pr-context.js";
+import {
+  ReviewPolicy,
+  TestPolicy,
+  resolveReviewRouting,
+  resolveTestRouting,
+  resolveNotifyChannel,
+  isFeedbackState,
+  hasReviewCheck,
+  producesReviewableWork,
+  hasTestPhase,
+  detectOwner,
+  getOwnerLabel,
+  OWNER_LABEL_COLOR,
+  getRoleLabelColor,
+  STEP_ROUTING_COLOR,
+  getStateLabels,
+} from "../workflow/index.js";
+import {
+  fetchPrFeedback,
+  fetchPrContext,
+  type PrFeedback,
+  type PrContext,
+} from "./pr-context.js";
 import { formatAttachmentsForTask } from "./attachments.js";
 import { loadRoleInstructions } from "./bootstrap-hook.js";
 import { slotName } from "../names.js";
 
-import { buildTaskMessage, buildConflictFixMessage, buildAnnouncement, formatSessionLabel } from "./message-builder.js";
-import { ensureSessionFireAndForget, sendToAgent, shouldClearSession } from "./session.js";
+import {
+  buildTaskMessage,
+  buildConflictFixMessage,
+  buildAnnouncement,
+  formatSessionLabel,
+} from "./message-builder.js";
+import {
+  ensureSessionFireAndForget,
+  sendToAgent,
+  shouldClearSession,
+} from "./session.js";
 import { acknowledgeComments, EYES_EMOJI } from "./acknowledge.js";
+import { guardDispatchLoop } from "./loop-guard.js";
 
 export type DispatchOpts = {
   workspaceDir: string;
@@ -84,9 +115,20 @@ export async function dispatchTask(
   opts: DispatchOpts,
 ): Promise<DispatchResult> {
   const {
-    workspaceDir, agentId, project, issueId, issueTitle,
-    issueDescription, issueUrl, role, level, fromLabel, toLabel,
-    provider, pluginConfig, runtime,
+    workspaceDir,
+    agentId,
+    project,
+    issueId,
+    issueTitle,
+    issueDescription,
+    issueUrl,
+    role,
+    level,
+    fromLabel,
+    toLabel,
+    provider,
+    pluginConfig,
+    runtime,
   } = opts;
 
   const slotIndex = opts.slotIndex ?? 0;
@@ -104,7 +146,14 @@ export async function dispatchTask(
   // Deactivated slot (issueId null) means session belongs to a previous issue — don't reuse
   if (existingSessionKey && !slot.issueId) {
     rc(
-      ["openclaw", "gateway", "call", "sessions.delete", "--params", JSON.stringify({ key: existingSessionKey })],
+      [
+        "openclaw",
+        "gateway",
+        "call",
+        "sessions.delete",
+        "--params",
+        JSON.stringify({ key: existingSessionKey }),
+      ],
       { timeoutMs: 10_000 },
     ).catch(() => {});
     existingSessionKey = null;
@@ -112,11 +161,26 @@ export async function dispatchTask(
 
   // Context budget check: clear session if over budget (unless same issue — feedback cycle)
   if (existingSessionKey && timeouts.sessionContextBudget < 1) {
-    const shouldClear = await shouldClearSession(existingSessionKey, slot.issueId, issueId, timeouts, workspaceDir, project.name, rc);
+    const shouldClear = await shouldClearSession(
+      existingSessionKey,
+      slot.issueId,
+      issueId,
+      timeouts,
+      workspaceDir,
+      project.name,
+      rc,
+    );
     if (shouldClear) {
       // Delete the gateway session (fire-and-forget)
       rc(
-        ["openclaw", "gateway", "call", "sessions.delete", "--params", JSON.stringify({ key: existingSessionKey })],
+        [
+          "openclaw",
+          "gateway",
+          "call",
+          "sessions.delete",
+          "--params",
+          JSON.stringify({ key: existingSessionKey }),
+        ],
         { timeoutMs: 10_000 },
       ).catch(() => {});
       await updateSlot(workspaceDir, project.slug, role, level, slotIndex, {
@@ -136,7 +200,14 @@ export async function dispatchTask(
   if (existingSessionKey && existingSessionKey !== sessionKey) {
     // Delete the orphaned gateway session (fire-and-forget)
     rc(
-      ["openclaw", "gateway", "call", "sessions.delete", "--params", JSON.stringify({ key: existingSessionKey })],
+      [
+        "openclaw",
+        "gateway",
+        "call",
+        "sessions.delete",
+        "--params",
+        JSON.stringify({ key: existingSessionKey }),
+      ],
       { timeoutMs: 10_000 },
     ).catch(() => {});
     existingSessionKey = null;
@@ -151,34 +222,83 @@ export async function dispatchTask(
   // Fetch PR context based on workflow role semantics (no hardcoded role/label checks)
   const { workflow } = resolvedConfig;
   const prFeedback = isFeedbackState(workflow, fromLabel)
-    ? await fetchPrFeedback(provider, issueId) : undefined;
+    ? await fetchPrFeedback(provider, issueId)
+    : undefined;
   const prContext = hasReviewCheck(workflow, role)
-    ? await fetchPrContext(provider, issueId) : undefined;
+    ? await fetchPrContext(provider, issueId)
+    : undefined;
 
   // Fetch attachment context (best-effort — never blocks dispatch)
   let attachmentContext: string | undefined;
   try {
-    attachmentContext = await formatAttachmentsForTask(workspaceDir, project.slug, issueId) || undefined;
-  } catch { /* best-effort */ }
+    attachmentContext =
+      (await formatAttachmentsForTask(workspaceDir, project.slug, issueId)) ||
+      undefined;
+  } catch {
+    /* best-effort */
+  }
 
   const primaryChannelId = project.channels[0]?.channelId ?? project.slug;
   const isConflictFix = prFeedback?.reason === "merge_conflict";
-  const taskMessage = isConflictFix && prFeedback
-    ? buildConflictFixMessage({
-        projectName: project.name, channelId: primaryChannelId, role, issueId,
-        issueTitle, issueUrl,
-        repo: project.repo, baseBranch: project.baseBranch,
-        resolvedRole, prFeedback,
-      })
-    : buildTaskMessage({
-        projectName: project.name, channelId: primaryChannelId, role, issueId,
-        issueTitle, issueDescription, issueUrl,
-        repo: project.repo, baseBranch: project.baseBranch,
-        comments, resolvedRole, prContext, prFeedback, attachmentContext,
-      });
+  const taskMessage =
+    isConflictFix && prFeedback
+      ? buildConflictFixMessage({
+          projectName: project.name,
+          channelId: primaryChannelId,
+          role,
+          issueId,
+          issueTitle,
+          issueUrl,
+          repo: project.repo,
+          baseBranch: project.baseBranch,
+          resolvedRole,
+          prFeedback,
+        })
+      : buildTaskMessage({
+          projectName: project.name,
+          channelId: primaryChannelId,
+          role,
+          issueId,
+          issueTitle,
+          issueDescription,
+          issueUrl,
+          repo: project.repo,
+          baseBranch: project.baseBranch,
+          comments,
+          resolvedRole,
+          prContext,
+          prFeedback,
+          attachmentContext,
+        });
 
   // Load role-specific instructions to inject into the worker's system prompt
-  const roleInstructions = await loadRoleInstructions(workspaceDir, project.name, role);
+  const roleInstructions = await loadRoleInstructions(
+    workspaceDir,
+    project.name,
+    role,
+  );
+
+  const loopGuard = await guardDispatchLoop({
+    workspaceDir,
+    provider,
+    workflow,
+    issueId,
+    issueTitle,
+    issueUrl,
+    role,
+    fromLabel,
+    toLabel,
+    projectName: project.name,
+  });
+  if (loopGuard.quarantined) {
+    return {
+      sessionAction,
+      sessionKey,
+      level,
+      model,
+      announcement: `Paused issue #${issueId} in ${loopGuard.holdLabel} after detecting ${loopGuard.dispatches} recent ${role} dispatches.`,
+    };
+  }
 
   // ── Commitment point — transition label (issue leaves queue) ────────
   await provider.transitionLabel(issueId, fromLabel, toLabel);
@@ -186,7 +306,13 @@ export async function dispatchTask(
   // Mark issue + PR as managed and all consumed comments as seen (fire-and-forget)
   provider.reactToIssue(issueId, EYES_EMOJI).catch(() => {});
   provider.reactToPr(issueId, EYES_EMOJI).catch(() => {});
-  acknowledgeComments(provider, issueId, comments, prFeedback, workspaceDir).catch((err) => {
+  acknowledgeComments(
+    provider,
+    issueId,
+    comments,
+    prFeedback,
+    workspaceDir,
+  ).catch((err) => {
     auditLog(workspaceDir, "dispatch_warning", {
       step: "acknowledgeComments",
       issue: issueId,
@@ -215,11 +341,13 @@ export async function dispatchTask(
     // Apply review routing label when role produces reviewable work (best-effort)
     if (producesReviewableWork(workflow, role)) {
       const reviewLabel = resolveReviewRouting(
-        workflow.reviewPolicy ?? ReviewPolicy.HUMAN, level,
+        workflow.reviewPolicy ?? ReviewPolicy.HUMAN,
+        level,
       );
       const oldRouting = issue.labels.filter((l) => l.startsWith("review:"));
       const safeRouting = filterNonStateLabels(oldRouting, stateLabels);
-      if (safeRouting.length > 0) await provider.removeLabels(issueId, safeRouting);
+      if (safeRouting.length > 0)
+        await provider.removeLabels(issueId, safeRouting);
       await provider.ensureLabel(reviewLabel, STEP_ROUTING_COLOR);
       await provider.addLabel(issueId, reviewLabel);
     }
@@ -227,11 +355,13 @@ export async function dispatchTask(
     // Apply test routing label when workflow has a test phase (best-effort)
     if (hasTestPhase(workflow)) {
       const testLabel = resolveTestRouting(
-        workflow.testPolicy ?? TestPolicy.SKIP, level,
+        workflow.testPolicy ?? TestPolicy.SKIP,
+        level,
       );
       const oldTestRouting = issue.labels.filter((l) => l.startsWith("test:"));
       const safeTestRouting = filterNonStateLabels(oldTestRouting, stateLabels);
-      if (safeTestRouting.length > 0) await provider.removeLabels(issueId, safeTestRouting);
+      if (safeTestRouting.length > 0)
+        await provider.removeLabels(issueId, safeTestRouting);
       await provider.ensureLabel(testLabel, STEP_ROUTING_COLOR);
       await provider.addLabel(issueId, testLabel);
     }
@@ -249,7 +379,10 @@ export async function dispatchTask(
   // Step 2: Send notification early (before session dispatch which can timeout)
   // This ensures users see the notification even if gateway is slow
   const notifyConfig = getNotificationConfig(pluginConfig);
-  const notifyTarget = resolveNotifyChannel(issue?.labels ?? [], project.channels);
+  const notifyTarget = resolveNotifyChannel(
+    issue?.labels ?? [],
+    project.channels,
+  );
   notify(
     {
       type: "workerStart",
@@ -273,7 +406,9 @@ export async function dispatchTask(
     },
   ).catch((err) => {
     auditLog(workspaceDir, "dispatch_warning", {
-      step: "notify", issue: issueId, role,
+      step: "notify",
+      issue: issueId,
+      role,
       error: (err as Error).message ?? String(err),
     }).catch(() => {});
   });
@@ -281,15 +416,28 @@ export async function dispatchTask(
   // Step 3: Ensure session exists (fire-and-forget — don't wait for gateway)
   // Session key is deterministic, so we can proceed immediately
   const sessionLabel = formatSessionLabel(project.name, role, level, botName);
-  ensureSessionFireAndForget(sessionKey, model, workspaceDir, rc, timeouts.sessionPatchMs, sessionLabel);
+  ensureSessionFireAndForget(
+    sessionKey,
+    model,
+    workspaceDir,
+    rc,
+    timeouts.sessionPatchMs,
+    sessionLabel,
+  );
 
   // Step 4: Send task to agent (fire-and-forget)
   // Model is set on the session via sessions.patch (step 3), not on the agent RPC —
   // the gateway's agent endpoint rejects unknown properties like 'model'.
   sendToAgent(sessionKey, taskMessage, {
-    agentId, projectName: project.name, issueId, role, level, slotIndex,
+    agentId,
+    projectName: project.name,
+    issueId,
+    role,
+    level,
+    slotIndex,
     dispatchAttempt,
-    orchestratorSessionKey: opts.sessionKey, workspaceDir,
+    orchestratorSessionKey: opts.sessionKey,
+    workspaceDir,
     dispatchTimeoutMs: timeouts.dispatchMs,
     extraSystemPrompt: roleInstructions.trim() || undefined,
     runCommand: rc,
@@ -298,32 +446,68 @@ export async function dispatchTask(
   // Step 5: Update worker state
   try {
     await recordWorkerState(workspaceDir, project.slug, role, slotIndex, {
-      issueId, level, sessionKey, sessionAction, fromLabel, name: botName, dispatchAttempt,
+      issueId,
+      level,
+      sessionKey,
+      sessionAction,
+      fromLabel,
+      name: botName,
+      dispatchAttempt,
     });
   } catch (err) {
     // Session is already dispatched — log warning but don't fail
     await auditLog(workspaceDir, "dispatch", {
-      project: project.name, issue: issueId, role,
+      project: project.name,
+      issue: issueId,
+      role,
       warning: "State update failed after successful dispatch",
-      error: (err as Error).message, sessionKey,
+      error: (err as Error).message,
+      sessionKey,
     });
   }
 
   // Step 6: Audit
   await auditDispatch(workspaceDir, {
-    project: project.name, issueId, issueTitle,
-    role, level, model, sessionAction, sessionKey,
-    fromLabel, toLabel,
+    project: project.name,
+    issueId,
+    issueTitle,
+    role,
+    level,
+    model,
+    sessionAction,
+    sessionKey,
+    fromLabel,
+    toLabel,
   });
 
-  const announcement = buildAnnouncement(level, role, sessionAction, issueId, issueTitle, issueUrl, resolvedRole, botName);
+  const announcement = buildAnnouncement(
+    level,
+    role,
+    sessionAction,
+    issueId,
+    issueTitle,
+    issueUrl,
+    resolvedRole,
+    botName,
+  );
 
   return { sessionAction, sessionKey, level, model, announcement };
 }
 
 async function recordWorkerState(
-  workspaceDir: string, slug: string, role: string, slotIndex: number,
-  opts: { issueId: number; level: string; sessionKey: string; sessionAction: "spawn" | "send"; fromLabel?: string; name?: string; dispatchAttempt: number },
+  workspaceDir: string,
+  slug: string,
+  role: string,
+  slotIndex: number,
+  opts: {
+    issueId: number;
+    level: string;
+    sessionKey: string;
+    sessionAction: "spawn" | "send";
+    fromLabel?: string;
+    name?: string;
+    dispatchAttempt: number;
+  },
 ): Promise<void> {
   await activateWorker(workspaceDir, slug, role, {
     issueId: String(opts.issueId),
@@ -341,27 +525,42 @@ async function recordWorkerState(
  * Filter out state labels from a label array to prevent accidental state loss.
  * State labels should only be modified via transitionLabel(). See #473.
  */
-function filterNonStateLabels(labels: string[], stateLabels: string[]): string[] {
+function filterNonStateLabels(
+  labels: string[],
+  stateLabels: string[],
+): string[] {
   return labels.filter((l) => !stateLabels.includes(l));
 }
 
 async function auditDispatch(
   workspaceDir: string,
   opts: {
-    project: string; issueId: number; issueTitle: string;
-    role: string; level: string; model: string; sessionAction: string;
-    sessionKey: string; fromLabel: string; toLabel: string;
+    project: string;
+    issueId: number;
+    issueTitle: string;
+    role: string;
+    level: string;
+    model: string;
+    sessionAction: string;
+    sessionKey: string;
+    fromLabel: string;
+    toLabel: string;
   },
 ): Promise<void> {
   await auditLog(workspaceDir, "dispatch", {
     project: opts.project,
-    issue: opts.issueId, issueTitle: opts.issueTitle,
-    role: opts.role, level: opts.level,
-    sessionAction: opts.sessionAction, sessionKey: opts.sessionKey,
+    issue: opts.issueId,
+    issueTitle: opts.issueTitle,
+    role: opts.role,
+    level: opts.level,
+    sessionAction: opts.sessionAction,
+    sessionKey: opts.sessionKey,
     labelTransition: `${opts.fromLabel} → ${opts.toLabel}`,
   });
   await auditLog(workspaceDir, "model_selection", {
-    issue: opts.issueId, role: opts.role, level: opts.level, model: opts.model,
+    issue: opts.issueId,
+    role: opts.role,
+    level: opts.level,
+    model: opts.model,
   });
 }
-

--- a/lib/dispatch/loop-guard.test.ts
+++ b/lib/dispatch/loop-guard.test.ts
@@ -171,4 +171,61 @@ describe("dispatch loop guard", () => {
       /Spawning DEVELOPER .*#96: Stop dispatch loops/,
     );
   });
+
+  it("does not quarantine legitimate rapid feedback cycles after successful completions", async () => {
+    h = await createTestHarness();
+    h.provider.seedIssue({
+      iid: 96,
+      title: "Stop dispatch loops",
+      labels: ["To Improve"],
+    });
+
+    for (let i = 0; i < 3; i++) {
+      await auditLog(h.workspaceDir, "dispatch", {
+        project: h.project.name,
+        issue: 96,
+        issueTitle: "Stop dispatch loops",
+        role: "developer",
+        level: "senior",
+        sessionAction: "send",
+        sessionKey: `feedback-cycle-${i}`,
+        labelTransition: "To Improve → Doing",
+      });
+
+      await auditLog(h.workspaceDir, "work_finish", {
+        project: h.project.name,
+        issue: 96,
+        issueTitle: "Stop dispatch loops",
+        role: "developer",
+        result: "done",
+        labelTransition: "Doing → Reviewing",
+      });
+    }
+
+    const result = await dispatchTask({
+      workspaceDir: h.workspaceDir,
+      agentId: "test-agent",
+      project: h.project,
+      issueId: 96,
+      issueTitle: "Stop dispatch loops",
+      issueDescription: "",
+      issueUrl: "https://github.com/rayjolt/devclaw/issues/96",
+      role: "developer",
+      level: "senior",
+      fromLabel: "To Improve",
+      toLabel: "Doing",
+      provider: h.provider,
+      runCommand: h.runCommand,
+    });
+
+    const issue = await h.provider.getIssue(96);
+    assert.ok(issue.labels.includes("Doing"));
+    assert.ok(!issue.labels.includes("Refining"));
+    assert.ok(!issue.labels.includes("workflow:desync"));
+    assert.equal(h.commands.taskMessages().length, 1);
+    assert.match(
+      result.announcement,
+      /Spawning DEVELOPER .*#96: Stop dispatch loops/,
+    );
+  });
 });

--- a/lib/dispatch/loop-guard.test.ts
+++ b/lib/dispatch/loop-guard.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert";
+import { createTestHarness, type TestHarness } from "../testing/index.js";
+import { dispatchTask } from "./index.js";
+import { log as auditLog } from "../audit.js";
+
+describe("dispatch loop guard", () => {
+  let h: TestHarness;
+
+  afterEach(async () => {
+    if (h) await h.cleanup();
+  });
+
+  it("quarantines an issue instead of redispatching after repeated recent dispatches", async () => {
+    h = await createTestHarness();
+    h.provider.seedIssue({
+      iid: 96,
+      title: "Stop dispatch loops",
+      labels: ["To Improve"],
+    });
+
+    for (let i = 0; i < 3; i++) {
+      await auditLog(h.workspaceDir, "dispatch", {
+        project: h.project.name,
+        issue: 96,
+        issueTitle: "Stop dispatch loops",
+        role: "developer",
+        level: "senior",
+        sessionAction: "send",
+        sessionKey: `test-${i}`,
+        labelTransition: "To Improve → Doing",
+      });
+    }
+
+    const result = await dispatchTask({
+      workspaceDir: h.workspaceDir,
+      agentId: "test-agent",
+      project: h.project,
+      issueId: 96,
+      issueTitle: "Stop dispatch loops",
+      issueDescription: "",
+      issueUrl: "https://github.com/rayjolt/devclaw/issues/96",
+      role: "developer",
+      level: "senior",
+      fromLabel: "To Improve",
+      toLabel: "Doing",
+      provider: h.provider,
+      runCommand: h.runCommand,
+    });
+
+    const issue = await h.provider.getIssue(96);
+    assert.ok(issue.labels.includes("Refining"));
+    assert.ok(issue.labels.includes("workflow:desync"));
+    assert.ok(!issue.labels.includes("Doing"));
+    assert.match(result.announcement, /Paused issue #96/);
+    assert.equal(
+      h.commands.taskMessages().length,
+      0,
+      "should not dispatch task message after quarantine",
+    );
+
+    const comments = await h.provider.listComments(96);
+    assert.equal(comments.length, 1);
+    assert.match(comments[0]!.body, /dispatch loop/i);
+  });
+});

--- a/lib/dispatch/loop-guard.test.ts
+++ b/lib/dispatch/loop-guard.test.ts
@@ -63,4 +63,112 @@ describe("dispatch loop guard", () => {
     assert.equal(comments.length, 1);
     assert.match(comments[0]!.body, /dispatch loop/i);
   });
+
+  it("allows immediate manual requeue after a prior quarantine reset the active loop window", async () => {
+    h = await createTestHarness();
+    h.provider.seedIssue({
+      iid: 96,
+      title: "Stop dispatch loops",
+      labels: ["To Improve"],
+    });
+
+    for (let i = 0; i < 3; i++) {
+      await auditLog(h.workspaceDir, "dispatch", {
+        project: h.project.name,
+        issue: 96,
+        issueTitle: "Stop dispatch loops",
+        role: "developer",
+        level: "senior",
+        sessionAction: "send",
+        sessionKey: `pre-quarantine-${i}`,
+        labelTransition: "To Improve → Doing",
+      });
+    }
+
+    await auditLog(h.workspaceDir, "dispatch_loop_quarantined", {
+      project: h.project.name,
+      issue: 96,
+      issueTitle: "Stop dispatch loops",
+      role: "developer",
+      fromLabel: "To Improve",
+      attemptedTo: "Doing",
+      quarantineLabel: "Refining",
+      dispatches: 3,
+      windowMs: 10 * 60 * 1_000,
+      commentPosted: true,
+    });
+
+    const result = await dispatchTask({
+      workspaceDir: h.workspaceDir,
+      agentId: "test-agent",
+      project: h.project,
+      issueId: 96,
+      issueTitle: "Stop dispatch loops",
+      issueDescription: "",
+      issueUrl: "https://github.com/rayjolt/devclaw/issues/96",
+      role: "developer",
+      level: "senior",
+      fromLabel: "To Improve",
+      toLabel: "Doing",
+      provider: h.provider,
+      runCommand: h.runCommand,
+    });
+
+    const issue = await h.provider.getIssue(96);
+    assert.ok(issue.labels.includes("Doing"));
+    assert.ok(!issue.labels.includes("Refining"));
+    assert.equal(h.commands.taskMessages().length, 1);
+    assert.match(
+      result.announcement,
+      /Spawning DEVELOPER .*#96: Stop dispatch loops/,
+    );
+  });
+
+  it("ignores dispatch history from other projects when checking loop thresholds", async () => {
+    h = await createTestHarness();
+    h.provider.seedIssue({
+      iid: 96,
+      title: "Stop dispatch loops",
+      labels: ["To Improve"],
+    });
+
+    for (let i = 0; i < 3; i++) {
+      await auditLog(h.workspaceDir, "dispatch", {
+        project: "other-project",
+        issue: 96,
+        issueTitle: "Stop dispatch loops elsewhere",
+        role: "developer",
+        level: "senior",
+        sessionAction: "send",
+        sessionKey: `other-project-${i}`,
+        labelTransition: "To Improve → Doing",
+      });
+    }
+
+    const result = await dispatchTask({
+      workspaceDir: h.workspaceDir,
+      agentId: "test-agent",
+      project: h.project,
+      issueId: 96,
+      issueTitle: "Stop dispatch loops",
+      issueDescription: "",
+      issueUrl: "https://github.com/rayjolt/devclaw/issues/96",
+      role: "developer",
+      level: "senior",
+      fromLabel: "To Improve",
+      toLabel: "Doing",
+      provider: h.provider,
+      runCommand: h.runCommand,
+    });
+
+    const issue = await h.provider.getIssue(96);
+    assert.ok(issue.labels.includes("Doing"));
+    assert.ok(!issue.labels.includes("Refining"));
+    assert.ok(!issue.labels.includes("workflow:desync"));
+    assert.equal(h.commands.taskMessages().length, 1);
+    assert.match(
+      result.announcement,
+      /Spawning DEVELOPER .*#96: Stop dispatch loops/,
+    );
+  });
 });

--- a/lib/dispatch/loop-guard.ts
+++ b/lib/dispatch/loop-guard.ts
@@ -1,0 +1,213 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { IssueProvider } from "../providers/provider.js";
+import type { WorkflowConfig } from "../workflow/index.js";
+import { StateType } from "../workflow/index.js";
+import { DATA_DIR } from "../setup/migrate-layout.js";
+import { log as auditLog } from "../audit.js";
+
+const DEFAULT_WINDOW_MS = 10 * 60 * 1_000;
+const DEFAULT_MAX_DISPATCHES = 3;
+const DESYNC_LABEL = "workflow:desync";
+
+function quarantineMarker(issueId: number): string {
+  return `<!-- devclaw:dispatch-loop:${issueId} -->`;
+}
+
+function findHoldLabel(workflow: WorkflowConfig): string | null {
+  const refining = Object.values(workflow.states).find(
+    (state) => state.type === StateType.HOLD && state.label === "Refining",
+  );
+  if (refining) return refining.label;
+  return (
+    Object.values(workflow.states).find(
+      (state) => state.type === StateType.HOLD,
+    )?.label ?? null
+  );
+}
+
+type AuditEntry = {
+  event?: string;
+  ts?: string;
+  issue?: number;
+  role?: string;
+  labelTransition?: string;
+};
+
+async function countRecentDispatches(
+  workspaceDir: string,
+  issueId: number,
+  role: string,
+  windowMs: number,
+): Promise<number> {
+  const auditPath = join(workspaceDir, DATA_DIR, "log", "audit.log");
+  try {
+    const content = await readFile(auditPath, "utf-8");
+    const cutoff = Date.now() - windowMs;
+    return content
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => {
+        try {
+          return JSON.parse(line) as AuditEntry;
+        } catch {
+          return null;
+        }
+      })
+      .filter((entry): entry is AuditEntry => !!entry)
+      .filter((entry) => entry.event === "dispatch")
+      .filter((entry) => entry.issue === issueId && entry.role === role)
+      .filter((entry) => {
+        const ts = entry.ts ? Date.parse(entry.ts) : NaN;
+        return Number.isFinite(ts) && ts >= cutoff;
+      }).length;
+  } catch {
+    return 0;
+  }
+}
+
+async function ensureQuarantineComment(
+  provider: IssueProvider,
+  issueId: number,
+  body: string,
+): Promise<boolean> {
+  const marker = quarantineMarker(issueId);
+  const comments = await provider.listComments(issueId).catch(() => []);
+  if (comments.some((comment) => comment.body.includes(marker))) {
+    return false;
+  }
+  await provider.addComment(issueId, `${body}\n\n${marker}`);
+  return true;
+}
+
+export async function guardDispatchLoop(opts: {
+  workspaceDir: string;
+  provider: IssueProvider;
+  workflow: WorkflowConfig;
+  issueId: number;
+  issueTitle: string;
+  issueUrl: string;
+  role: string;
+  fromLabel: string;
+  toLabel: string;
+  projectName: string;
+  windowMs?: number;
+  maxDispatches?: number;
+}): Promise<
+  | { quarantined: false }
+  | { quarantined: true; holdLabel: string; dispatches: number }
+> {
+  const {
+    workspaceDir,
+    provider,
+    workflow,
+    issueId,
+    issueTitle,
+    issueUrl,
+    role,
+    fromLabel,
+    toLabel,
+    projectName,
+    windowMs = DEFAULT_WINDOW_MS,
+    maxDispatches = DEFAULT_MAX_DISPATCHES,
+  } = opts;
+
+  const recentDispatches = await countRecentDispatches(
+    workspaceDir,
+    issueId,
+    role,
+    windowMs,
+  );
+
+  if (recentDispatches < maxDispatches) {
+    return { quarantined: false };
+  }
+
+  const holdLabel = findHoldLabel(workflow);
+  if (!holdLabel) {
+    await auditLog(workspaceDir, "dispatch_loop_detected", {
+      project: projectName,
+      issue: issueId,
+      issueTitle,
+      role,
+      fromLabel,
+      toLabel,
+      dispatches: recentDispatches,
+      windowMs,
+      quarantined: false,
+      reason: "no_hold_state",
+    }).catch(() => {});
+    return { quarantined: false };
+  }
+
+  const issue = await provider.getIssue(issueId).catch(() => null);
+  const currentLabel = issue
+    ? issue.labels.find(
+        (label) =>
+          label === fromLabel || label === toLabel || label === holdLabel,
+      )
+    : null;
+  const transitionFrom = currentLabel ?? fromLabel;
+
+  if (transitionFrom !== holdLabel) {
+    await provider
+      .transitionLabel(issueId, transitionFrom, holdLabel)
+      .catch(async (err) => {
+        await auditLog(workspaceDir, "dispatch_loop_detected", {
+          project: projectName,
+          issue: issueId,
+          issueTitle,
+          role,
+          fromLabel: transitionFrom,
+          toLabel: holdLabel,
+          dispatches: recentDispatches,
+          windowMs,
+          quarantined: false,
+          reason: "transition_failed",
+          error: (err as Error).message ?? String(err),
+        }).catch(() => {});
+        throw err;
+      });
+  }
+
+  await provider.ensureLabel(DESYNC_LABEL, "B60205").catch(() => {});
+  await provider.addLabel(issueId, DESYNC_LABEL).catch(() => {});
+
+  const commentPosted = await ensureQuarantineComment(
+    provider,
+    issueId,
+    `⚠️ DevClaw paused this issue after detecting a dispatch loop.\n\n` +
+      `- Project: ${projectName}\n` +
+      `- Issue: #${issueId} — ${issueTitle}\n` +
+      `- Role: ${role}\n` +
+      `- Recent dispatches: ${recentDispatches} within ${Math.round(windowMs / 60_000)} minutes\n` +
+      `- Attempted transition: ${fromLabel} → ${toLabel}\n` +
+      `- Quarantined state: ${holdLabel}\n\n` +
+      `Suggested corrective actions:\n` +
+      `1. Inspect the most recent worker comment and audit trail for rejected work_finish calls.\n` +
+      `2. Reconcile labels / worker state (clear stale owner or role labels if needed).\n` +
+      `3. Requeue manually once state is consistent.\n\n` +
+      `Reference: ${issueUrl}`,
+  ).catch(() => false);
+
+  await auditLog(workspaceDir, "dispatch_loop_quarantined", {
+    project: projectName,
+    issue: issueId,
+    issueTitle,
+    role,
+    fromLabel: transitionFrom,
+    attemptedTo: toLabel,
+    quarantineLabel: holdLabel,
+    dispatches: recentDispatches,
+    windowMs,
+    commentPosted,
+  }).catch(() => {});
+
+  return { quarantined: true, holdLabel, dispatches: recentDispatches };
+}
+
+export const LOOP_GUARD_CONSTANTS = {
+  DEFAULT_WINDOW_MS,
+  DEFAULT_MAX_DISPATCHES,
+  DESYNC_LABEL,
+};

--- a/lib/dispatch/loop-guard.ts
+++ b/lib/dispatch/loop-guard.ts
@@ -35,6 +35,15 @@ type AuditEntry = {
   labelTransition?: string;
 };
 
+function latestTimestamp(entries: AuditEntry[], event: string): number {
+  return entries
+    .filter((entry) => entry.event === event)
+    .reduce<number>((latest, entry) => {
+      const ts = entry.ts ? Date.parse(entry.ts) : NaN;
+      return Number.isFinite(ts) ? Math.max(latest, ts) : latest;
+    }, Number.NEGATIVE_INFINITY);
+}
+
 async function countRecentDispatches(
   workspaceDir: string,
   projectName: string,
@@ -68,19 +77,22 @@ async function countRecentDispatches(
           entry.role === role,
       );
 
-    const lastQuarantineTs = entries
-      .filter((entry) => entry.event === "dispatch_loop_quarantined")
-      .reduce<number>((latest, entry) => {
-        const ts = entry.ts ? Date.parse(entry.ts) : NaN;
-        return Number.isFinite(ts) ? Math.max(latest, ts) : latest;
-      }, Number.NEGATIVE_INFINITY);
+    const lastQuarantineTs = latestTimestamp(
+      entries,
+      "dispatch_loop_quarantined",
+    );
+    const lastSuccessfulCompletionTs = latestTimestamp(entries, "work_finish");
+    const activeCycleStart = Math.max(
+      lastQuarantineTs,
+      lastSuccessfulCompletionTs,
+    );
 
     return entries
       .filter((entry) => entry.event === "dispatch")
       .filter((entry) => {
-        if (!Number.isFinite(lastQuarantineTs)) return true;
+        if (!Number.isFinite(activeCycleStart)) return true;
         const ts = entry.ts ? Date.parse(entry.ts) : NaN;
-        return Number.isFinite(ts) && ts > lastQuarantineTs;
+        return Number.isFinite(ts) && ts > activeCycleStart;
       }).length;
   } catch {
     return 0;

--- a/lib/dispatch/loop-guard.ts
+++ b/lib/dispatch/loop-guard.ts
@@ -31,11 +31,13 @@ type AuditEntry = {
   ts?: string;
   issue?: number;
   role?: string;
+  project?: string;
   labelTransition?: string;
 };
 
 async function countRecentDispatches(
   workspaceDir: string,
+  projectName: string,
   issueId: number,
   role: string,
   windowMs: number,
@@ -44,7 +46,7 @@ async function countRecentDispatches(
   try {
     const content = await readFile(auditPath, "utf-8");
     const cutoff = Date.now() - windowMs;
-    return content
+    const entries = content
       .split("\n")
       .filter(Boolean)
       .map((line) => {
@@ -55,11 +57,30 @@ async function countRecentDispatches(
         }
       })
       .filter((entry): entry is AuditEntry => !!entry)
-      .filter((entry) => entry.event === "dispatch")
-      .filter((entry) => entry.issue === issueId && entry.role === role)
       .filter((entry) => {
         const ts = entry.ts ? Date.parse(entry.ts) : NaN;
         return Number.isFinite(ts) && ts >= cutoff;
+      })
+      .filter(
+        (entry) =>
+          entry.project === projectName &&
+          entry.issue === issueId &&
+          entry.role === role,
+      );
+
+    const lastQuarantineTs = entries
+      .filter((entry) => entry.event === "dispatch_loop_quarantined")
+      .reduce<number>((latest, entry) => {
+        const ts = entry.ts ? Date.parse(entry.ts) : NaN;
+        return Number.isFinite(ts) ? Math.max(latest, ts) : latest;
+      }, Number.NEGATIVE_INFINITY);
+
+    return entries
+      .filter((entry) => entry.event === "dispatch")
+      .filter((entry) => {
+        if (!Number.isFinite(lastQuarantineTs)) return true;
+        const ts = entry.ts ? Date.parse(entry.ts) : NaN;
+        return Number.isFinite(ts) && ts > lastQuarantineTs;
       }).length;
   } catch {
     return 0;
@@ -114,6 +135,7 @@ export async function guardDispatchLoop(opts: {
 
   const recentDispatches = await countRecentDispatches(
     workspaceDir,
+    projectName,
     issueId,
     role,
     windowMs,

--- a/lib/tools/worker/work-finish.test.ts
+++ b/lib/tools/worker/work-finish.test.ts
@@ -131,7 +131,7 @@ describe("work_finish: PR validation and conflict resolution", () => {
       assert.equal(resolveRejectedWorkFinishIssueId(roleWorker), null);
     });
 
-    it("allows a warning when there is exactly one unambiguous active issue", () => {
+    it("does not infer an issue from active slots when session key is missing", () => {
       const roleWorker: RoleWorkerState = {
         levels: {
           medior: [
@@ -153,7 +153,7 @@ describe("work_finish: PR validation and conflict resolution", () => {
         },
       };
 
-      assert.equal(resolveRejectedWorkFinishIssueId(roleWorker), 77);
+      assert.equal(resolveRejectedWorkFinishIssueId(roleWorker), null);
     });
   });
 

--- a/lib/tools/worker/work-finish.test.ts
+++ b/lib/tools/worker/work-finish.test.ts
@@ -15,6 +15,8 @@ import { mkdtemp, mkdir, writeFile, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { rm } from "node:fs/promises";
+import type { RoleWorkerState } from "../../projects/types.js";
+import { resolveRejectedWorkFinishIssueId } from "./work-finish.js";
 
 // Helper to create a mock audit log with a merge_conflict transition
 async function createMockAuditLog(
@@ -27,43 +29,133 @@ async function createMockAuditLog(
 
   const auditPath = join(logDir, "audit.log");
   const entries = [];
-  
+
   // Add some dummy entries
-  entries.push(JSON.stringify({
-    timestamp: "2026-03-01T10:00:00Z",
-    event: "issue_created",
-    issueId,
-    project: "devclaw",
-  }));
-  
-  if (hasMergeConflict) {
-    entries.push(JSON.stringify({
-      timestamp: "2026-03-01T10:15:00Z",
-      event: "review_transition",
+  entries.push(
+    JSON.stringify({
+      timestamp: "2026-03-01T10:00:00Z",
+      event: "issue_created",
       issueId,
-      from: "In Review",
-      to: "To Improve",
-      reason: "merge_conflict",
-      reviewer: "system",
       project: "devclaw",
-    }));
+    }),
+  );
+
+  if (hasMergeConflict) {
+    entries.push(
+      JSON.stringify({
+        timestamp: "2026-03-01T10:15:00Z",
+        event: "review_transition",
+        issueId,
+        from: "In Review",
+        to: "To Improve",
+        reason: "merge_conflict",
+        reviewer: "system",
+        project: "devclaw",
+      }),
+    );
   }
-  
+
   // Add final entry (timestamp for ordering)
-  entries.push(JSON.stringify({
-    timestamp: "2026-03-01T10:30:00Z",
-    event: "work_started",
-    issueId,
-    role: "developer",
-    project: "devclaw",
-  }));
-  
+  entries.push(
+    JSON.stringify({
+      timestamp: "2026-03-01T10:30:00Z",
+      event: "work_started",
+      issueId,
+      role: "developer",
+      project: "devclaw",
+    }),
+  );
+
   const content = entries.join("\n") + "\n";
   await writeFile(auditPath, content);
 }
 
 describe("work_finish: PR validation and conflict resolution", () => {
   let tempDir: string;
+
+  describe("resolveRejectedWorkFinishIssueId", () => {
+    it("uses a matching session key to find the related issue", () => {
+      const roleWorker: RoleWorkerState = {
+        levels: {
+          junior: [
+            {
+              active: false,
+              issueId: null,
+              lastIssueId: "42",
+              sessionKey: "session-a",
+              startTime: null,
+            },
+          ],
+          senior: [
+            {
+              active: true,
+              issueId: "99",
+              lastIssueId: null,
+              sessionKey: "session-b",
+              startTime: null,
+            },
+          ],
+        },
+      };
+
+      assert.equal(
+        resolveRejectedWorkFinishIssueId(roleWorker, "session-a"),
+        42,
+      );
+    });
+
+    it("does not pick an unrelated stale issue when no session key is available", () => {
+      const roleWorker: RoleWorkerState = {
+        levels: {
+          junior: [
+            {
+              active: false,
+              issueId: null,
+              lastIssueId: "11",
+              sessionKey: "stale-a",
+              startTime: null,
+            },
+          ],
+          senior: [
+            {
+              active: false,
+              issueId: null,
+              lastIssueId: "22",
+              sessionKey: "stale-b",
+              startTime: null,
+            },
+          ],
+        },
+      };
+
+      assert.equal(resolveRejectedWorkFinishIssueId(roleWorker), null);
+    });
+
+    it("allows a warning when there is exactly one unambiguous active issue", () => {
+      const roleWorker: RoleWorkerState = {
+        levels: {
+          medior: [
+            {
+              active: true,
+              issueId: "77",
+              lastIssueId: null,
+              sessionKey: "active-a",
+              startTime: null,
+            },
+            {
+              active: false,
+              issueId: null,
+              lastIssueId: "55",
+              sessionKey: "stale-b",
+              startTime: null,
+            },
+          ],
+        },
+      };
+
+      assert.equal(resolveRejectedWorkFinishIssueId(roleWorker), 77);
+    });
+  });
 
   before(async () => {
     tempDir = await mkdtemp(join(tmpdir(), "work-finish-test-"));
@@ -82,13 +174,13 @@ describe("work_finish: PR validation and conflict resolution", () => {
     it("should detect merge_conflict transition in audit log", async () => {
       const issueId = 123;
       await createMockAuditLog(tempDir, issueId, true);
-      
+
       // Import the helper (we'll need to test via integration since it's not exported)
       // For now, we'll test the behavior indirectly through validatePrExistsForDeveloper
       const auditPath = join(tempDir, "devclaw", "log", "audit.log");
       const content = await readFile(auditPath, "utf-8");
       const lines = content.split("\n").filter(Boolean);
-      
+
       let found = false;
       for (const line of lines) {
         const entry = JSON.parse(line);
@@ -101,18 +193,18 @@ describe("work_finish: PR validation and conflict resolution", () => {
           break;
         }
       }
-      
+
       assert.ok(found, "Should find merge_conflict transition in audit log");
     });
 
     it("should return false when no merge_conflict transition exists", async () => {
       const issueId = 456;
       await createMockAuditLog(tempDir, issueId, false);
-      
+
       const auditPath = join(tempDir, "devclaw", "log", "audit.log");
       const content = await readFile(auditPath, "utf-8");
       const lines = content.split("\n").filter(Boolean);
-      
+
       let found = false;
       for (const line of lines) {
         const entry = JSON.parse(line);
@@ -125,7 +217,7 @@ describe("work_finish: PR validation and conflict resolution", () => {
           break;
         }
       }
-      
+
       assert.ok(!found, "Should not find merge_conflict transition");
     });
 
@@ -147,12 +239,12 @@ describe("work_finish: PR validation and conflict resolution", () => {
         JSON.stringify({ event: "valid_again", issueId: 999 }),
       ];
       await writeFile(auditPath, entries.join("\n"));
-      
+
       // Should not throw
       const content = await readFile(auditPath, "utf-8");
       const lines = content.split("\n").filter(Boolean);
       let validCount = 0;
-      
+
       for (const line of lines) {
         try {
           const entry = JSON.parse(line);
@@ -161,15 +253,19 @@ describe("work_finish: PR validation and conflict resolution", () => {
           // skip malformed
         }
       }
-      
-      assert.equal(validCount, 2, "Should parse 2 valid JSON entries and skip malformed");
+
+      assert.equal(
+        validCount,
+        2,
+        "Should parse 2 valid JSON entries and skip malformed",
+      );
     });
   });
 
   describe("validatePrExistsForDeveloper: conflict detection", () => {
     it("should validate error message format when PR still conflicting", async () => {
       // Test that our error message matches the expected pattern
-      const errorMessage = 
+      const errorMessage =
         `Cannot complete work_finish(done) while PR still shows merge conflicts.\n\n` +
         `✗ PR status: CONFLICTING\n` +
         `✗ PR URL: https://github.com/test/repo/pull/42\n` +
@@ -184,36 +280,38 @@ describe("work_finish: PR validation and conflict resolution", () => {
         `  gh pr view 42\n` +
         `  # Should show "Mergeable" status\n\n` +
         `Once the PR shows as mergeable on GitHub, call work_finish again.`;
-      
+
       assert.ok(
-        errorMessage.includes("Cannot complete work_finish(done) while PR still shows merge conflicts"),
-        "Error should mention PR still has conflicts"
+        errorMessage.includes(
+          "Cannot complete work_finish(done) while PR still shows merge conflicts",
+        ),
+        "Error should mention PR still has conflicts",
       );
       assert.ok(
         errorMessage.includes("git log origin/"),
-        "Error should include diagnostic git command"
+        "Error should include diagnostic git command",
       );
       assert.ok(
         errorMessage.includes("git push --force-with-lease"),
-        "Error should include push instruction"
+        "Error should include push instruction",
       );
       assert.ok(
         errorMessage.includes("gh pr view"),
-        "Error should include verification command"
+        "Error should include verification command",
       );
     });
 
     it("should include branch name in error message", async () => {
       const branchName = "feature/my-fix";
-      const errorMessage = 
+      const errorMessage =
         `Cannot complete work_finish(done) while PR still shows merge conflicts.\n\n` +
         `✗ PR status: CONFLICTING\n` +
         `✗ PR URL: https://github.com/test/repo/pull/42\n` +
         `✗ Branch: ${branchName}`;
-      
+
       assert.ok(
         errorMessage.includes(branchName),
-        `Error message should include branch name: ${branchName}`
+        `Error message should include branch name: ${branchName}`,
       );
     });
   });
@@ -221,20 +319,24 @@ describe("work_finish: PR validation and conflict resolution", () => {
   describe("catch block precedence", () => {
     it("should correctly check for validation error type", () => {
       // Test that our error checking logic is correct
-      const validationError = new Error("Cannot mark work_finish(done) without an open PR.");
+      const validationError = new Error(
+        "Cannot mark work_finish(done) without an open PR.",
+      );
       const networkError = new Error("Failed to retrieve PR status");
-      
+
       // Simulate our error check logic
-      const shouldThrowValidation = 
-        validationError instanceof Error && 
-        (validationError.message.startsWith("Cannot mark work_finish(done)") || 
-         validationError.message.startsWith("Cannot complete work_finish(done)"));
-      
-      const shouldThrowNetwork = 
-        networkError instanceof Error && 
-        (networkError.message.startsWith("Cannot mark work_finish(done)") || 
-         networkError.message.startsWith("Cannot complete work_finish(done)"));
-      
+      const shouldThrowValidation =
+        validationError instanceof Error &&
+        (validationError.message.startsWith("Cannot mark work_finish(done)") ||
+          validationError.message.startsWith(
+            "Cannot complete work_finish(done)",
+          ));
+
+      const shouldThrowNetwork =
+        networkError instanceof Error &&
+        (networkError.message.startsWith("Cannot mark work_finish(done)") ||
+          networkError.message.startsWith("Cannot complete work_finish(done)"));
+
       assert.ok(shouldThrowValidation, "Should re-throw validation errors");
       assert.ok(!shouldThrowNetwork, "Should swallow network errors");
     });
@@ -247,7 +349,7 @@ describe("work_finish: PR validation and conflict resolution", () => {
         notAnError instanceof Error &&
         (notAnError.message.startsWith("Cannot mark work_finish(done)") ||
           notAnError.message.startsWith("Cannot complete work_finish(done)"));
-      
+
       assert.ok(!shouldRethrow, "Should not re-throw non-Error objects");
     });
   });
@@ -262,7 +364,7 @@ describe("work_finish: PR validation and conflict resolution", () => {
         prUrl: "https://github.com/test/repo/pull/123",
         mergeable: false,
       };
-      
+
       assert.ok(rejectionLog.event === "work_finish_rejected");
       assert.ok(rejectionLog.reason === "pr_still_conflicting");
       assert.ok(rejectionLog.mergeable === false);
@@ -276,7 +378,7 @@ describe("work_finish: PR validation and conflict resolution", () => {
         prUrl: "https://github.com/test/repo/pull/123",
         mergeable: true,
       };
-      
+
       assert.ok(successLog.event === "conflict_resolution_verified");
       assert.ok(successLog.mergeable === true);
     });

--- a/lib/tools/worker/work-finish.ts
+++ b/lib/tools/worker/work-finish.ts
@@ -12,25 +12,82 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { ToolContext } from "../../types.js";
 import type { PluginContext, RunCommand } from "../../context.js";
-import { getRoleWorker, resolveRepoPath, findSlotByIssue } from "../../projects/index.js";
+import {
+  getRoleWorker,
+  resolveRepoPath,
+  findSlotByIssue,
+} from "../../projects/index.js";
 import { executeCompletion, getRule } from "../../services/pipeline.js";
 import { log as auditLog } from "../../audit.js";
 import { DATA_DIR } from "../../setup/migrate-layout.js";
-import { requireWorkspaceDir, resolveChannelId, resolveProject, resolveProvider } from "../helpers.js";
-import { getAllRoleIds, isValidResult, getCompletionResults } from "../../roles/index.js";
+import {
+  requireWorkspaceDir,
+  resolveChannelId,
+  resolveProject,
+  resolveProvider,
+} from "../helpers.js";
+import {
+  getAllRoleIds,
+  isValidResult,
+  getCompletionResults,
+} from "../../roles/index.js";
 import { loadWorkflow } from "../../workflow/index.js";
+
+function workFinishWarningMarker(issueId: number, role: string): string {
+  return `<!-- devclaw:work-finish-warning:${issueId}:${role} -->`;
+}
+
+async function maybeCommentOnRejectedWorkFinish(opts: {
+  provider: Awaited<ReturnType<typeof resolveProvider>>["provider"];
+  issueId: number;
+  role: string;
+  error: Error;
+}): Promise<boolean> {
+  const { provider, issueId, role, error } = opts;
+  const marker = workFinishWarningMarker(issueId, role);
+  const comments = await provider.listComments(issueId).catch(() => []);
+  if (comments.some((comment) => comment.body.includes(marker))) return false;
+
+  const issue = await provider.getIssue(issueId).catch(() => null);
+  const labels = issue?.labels?.length
+    ? issue.labels.join(", ")
+    : "(unavailable)";
+
+  if (
+    !/not active|precondition failed|Completion transition failed|expected current label/i.test(
+      error.message,
+    )
+  ) {
+    return false;
+  }
+
+  await provider.addComment(
+    issueId,
+    `⚠️ DevClaw rejected a \`work_finish\` call for the ${role} worker.\n\n` +
+      `- Reason: ${error.message}\n` +
+      `- Current labels: ${labels}\n\n` +
+      `Suggested corrective actions:\n` +
+      `1. Compare the issue's current workflow label with the worker state in DevClaw.\n` +
+      `2. Clear stale role / owner labels or inactive worker state if they no longer match reality.\n` +
+      `3. Requeue only after the issue label and worker slot state agree again.\n\n` +
+      `${marker}`,
+  );
+  return true;
+}
 
 /**
  * Get the current git branch name.
  */
-async function getCurrentBranch(repoPath: string, runCommand: RunCommand): Promise<string> {
+async function getCurrentBranch(
+  repoPath: string,
+  runCommand: RunCommand,
+): Promise<string> {
   const result = await runCommand(["git", "branch", "--show-current"], {
     timeoutMs: 5_000,
     cwd: repoPath,
   });
   return result.stdout.trim();
 }
-
 
 /**
  * Check if this work_finish is completing a conflict resolution cycle.
@@ -101,10 +158,10 @@ async function validatePrExistsForDeveloper(
 
       throw new Error(
         `Cannot mark work_finish(done) without an open PR.\n\n` +
-        `✗ No PR found for branch: ${branchName}\n\n` +
-        `Please create a PR first:\n` +
-        `  gh pr create --base main --head ${branchName} --title "..." --body "..."\n\n` +
-        `Then call work_finish again.`,
+          `✗ No PR found for branch: ${branchName}\n\n` +
+          `Please create a PR first:\n` +
+          `  gh pr create --base main --head ${branchName} --title "..." --body "..."\n\n` +
+          `Then call work_finish again.`,
       );
     }
 
@@ -128,7 +185,10 @@ async function validatePrExistsForDeveloper(
     // merge conflicts, we must verify the PR is actually mergeable before accepting
     // work_finish(done). Without this check, developers can claim success after local
     // rebase but before pushing, causing infinite dispatch loops (#482).
-    const isConflictCycle = await isConflictResolutionCycle(workspaceDir, issueId);
+    const isConflictCycle = await isConflictResolutionCycle(
+      workspaceDir,
+      issueId,
+    );
 
     if (isConflictCycle && prStatus.mergeable === false) {
       await auditLog(workspaceDir, "work_finish_rejected", {
@@ -141,19 +201,19 @@ async function validatePrExistsForDeveloper(
       const branchName = prStatus.sourceBranch || "your-branch";
       throw new Error(
         `Cannot complete work_finish(done) while PR still shows merge conflicts.\n\n` +
-        `✗ PR status: CONFLICTING\n` +
-        `✗ PR URL: ${prStatus.url}\n` +
-        `✗ Branch: ${branchName}\n\n` +
-        `Your local rebase may have succeeded, but changes must be pushed to the remote.\n\n` +
-        `Verify your changes were pushed:\n` +
-        `  git log origin/${branchName}..HEAD\n` +
-        `  # Should show no commits (meaning everything is pushed)\n\n` +
-        `If unpushed commits exist, push them:\n` +
-        `  git push --force-with-lease origin ${branchName}\n\n` +
-        `Wait a few seconds for GitHub to update, then verify the PR:\n` +
-        `  gh pr view ${issueId}\n` +
-        `  # Should show "Mergeable" status\n\n` +
-        `Once the PR shows as mergeable on GitHub, call work_finish again.`,
+          `✗ PR status: CONFLICTING\n` +
+          `✗ PR URL: ${prStatus.url}\n` +
+          `✗ Branch: ${branchName}\n\n` +
+          `Your local rebase may have succeeded, but changes must be pushed to the remote.\n\n` +
+          `Verify your changes were pushed:\n` +
+          `  git log origin/${branchName}..HEAD\n` +
+          `  # Should show no commits (meaning everything is pushed)\n\n` +
+          `If unpushed commits exist, push them:\n` +
+          `  git push --force-with-lease origin ${branchName}\n\n` +
+          `Wait a few seconds for GitHub to update, then verify the PR:\n` +
+          `  gh pr view ${issueId}\n` +
+          `  # Should show "Mergeable" status\n\n` +
+          `Once the PR shows as mergeable on GitHub, call work_finish again.`,
       );
     }
 
@@ -168,7 +228,11 @@ async function validatePrExistsForDeveloper(
   } catch (err) {
     // Re-throw our own validation errors; swallow provider/network errors.
     // Swallowing keeps work_finish unblocked when the API is unreachable.
-    if (err instanceof Error && (err.message.startsWith("Cannot mark work_finish(done)") || err.message.startsWith("Cannot complete work_finish(done)"))) {
+    if (
+      err instanceof Error &&
+      (err.message.startsWith("Cannot mark work_finish(done)") ||
+        err.message.startsWith("Cannot complete work_finish(done)"))
+    ) {
       throw err;
     }
     console.warn(`PR validation warning for issue #${issueId}:`, err);
@@ -184,11 +248,34 @@ export function createWorkFinishTool(ctx: PluginContext) {
       type: "object",
       required: ["channelId", "role", "result"],
       properties: {
-        channelId: { type: "string", description: "YOUR chat/group ID — the numeric ID of the chat you are in right now (e.g. '-1003844794417'). Do NOT guess; use the ID of the conversation this message came from." },
-        role: { type: "string", enum: getAllRoleIds(), description: "Worker role" },
-        result: { type: "string", enum: ["done", "pass", "fail", "refine", "blocked", "approve", "reject"], description: "Completion result" },
+        channelId: {
+          type: "string",
+          description:
+            "YOUR chat/group ID — the numeric ID of the chat you are in right now (e.g. '-1003844794417'). Do NOT guess; use the ID of the conversation this message came from.",
+        },
+        role: {
+          type: "string",
+          enum: getAllRoleIds(),
+          description: "Worker role",
+        },
+        result: {
+          type: "string",
+          enum: [
+            "done",
+            "pass",
+            "fail",
+            "refine",
+            "blocked",
+            "approve",
+            "reject",
+          ],
+          description: "Completion result",
+        },
         summary: { type: "string", description: "Brief summary" },
-        prUrl: { type: "string", description: "PR/MR URL (auto-detected if omitted)" },
+        prUrl: {
+          type: "string",
+          description: "PR/MR URL (auto-detected if omitted)",
+        },
         createdTasks: {
           type: "array",
           items: {
@@ -200,7 +287,8 @@ export function createWorkFinishTool(ctx: PluginContext) {
               url: { type: "string", description: "Issue URL" },
             },
           },
-          description: "Tasks created during this work session (architect creates implementation tasks).",
+          description:
+            "Tasks created during this work session (architect creates implementation tasks).",
         },
       },
     },
@@ -208,21 +296,32 @@ export function createWorkFinishTool(ctx: PluginContext) {
     async execute(_id: string, params: Record<string, unknown>) {
       const role = params.role as string;
       const result = params.result as string;
-      const channelId = resolveChannelId(toolCtx, params.channelId as string | undefined);
+      const channelId = resolveChannelId(
+        toolCtx,
+        params.channelId as string | undefined,
+      );
       const summary = params.summary as string | undefined;
       const prUrl = params.prUrl as string | undefined;
-      const createdTasks = params.createdTasks as Array<{ id: number; title: string; url: string }> | undefined;
+      const createdTasks = params.createdTasks as
+        | Array<{ id: number; title: string; url: string }>
+        | undefined;
       const workspaceDir = requireWorkspaceDir(toolCtx);
 
       // Validate role:result using registry
       if (!isValidResult(role, result)) {
         const valid = getCompletionResults(role);
-        throw new Error(`${role.toUpperCase()} cannot complete with "${result}". Valid results: ${valid.join(", ")}`);
+        throw new Error(
+          `${role.toUpperCase()} cannot complete with "${result}". Valid results: ${valid.join(", ")}`,
+        );
       }
 
       // Resolve project + worker
       const { project } = await resolveProject(workspaceDir, channelId);
       const roleWorker = getRoleWorker(project, role);
+      const { provider } = await resolveProvider(project, ctx.runCommand);
+      const workflow = await loadWorkflow(workspaceDir, project.name);
+
+      let relatedIssueId: number | null = null;
 
       // Find the first active slot across all levels
       let slotIndex: number | null = null;
@@ -231,12 +330,19 @@ export function createWorkFinishTool(ctx: PluginContext) {
 
       for (const [level, slots] of Object.entries(roleWorker.levels)) {
         for (let i = 0; i < slots.length; i++) {
-          if (slots[i]!.active && slots[i]!.issueId &&
-              (!toolCtx.sessionKey || !slots[i]!.sessionKey ||
-               slots[i]!.sessionKey === toolCtx.sessionKey)) {
+          const slot = slots[i]!;
+          const sessionMatches =
+            !toolCtx.sessionKey ||
+            !slot.sessionKey ||
+            slot.sessionKey === toolCtx.sessionKey;
+          if (!sessionMatches) continue;
+          if (slot.issueId) relatedIssueId = Number(slot.issueId);
+          else if (slot.lastIssueId) relatedIssueId = Number(slot.lastIssueId);
+
+          if (slot.active && slot.issueId) {
             slotLevel = level;
             slotIndex = i;
-            issueId = Number(slots[i]!.issueId);
+            issueId = Number(slot.issueId);
             break;
           }
         }
@@ -244,11 +350,27 @@ export function createWorkFinishTool(ctx: PluginContext) {
       }
 
       if (slotIndex === null || slotLevel === null || issueId === null) {
-        throw new Error(`${role.toUpperCase()} worker not active on ${project.name}`);
+        const error = new Error(
+          `${role.toUpperCase()} worker not active on ${project.name}`,
+        );
+        if (relatedIssueId !== null) {
+          const commented = await maybeCommentOnRejectedWorkFinish({
+            provider,
+            issueId: relatedIssueId,
+            role,
+            error,
+          }).catch(() => false);
+          await auditLog(workspaceDir, "work_finish_rejected", {
+            project: project.name,
+            issue: relatedIssueId,
+            role,
+            reason: "worker_not_active",
+            error: error.message,
+            commented,
+          }).catch(() => {});
+        }
+        throw error;
       }
-
-      const { provider } = await resolveProvider(project, ctx.runCommand);
-      const workflow = await loadWorkflow(workspaceDir, project.name);
 
       if (!getRule(role, result, workflow))
         throw new Error(`Invalid completion: ${role}:${result}`);
@@ -258,31 +380,75 @@ export function createWorkFinishTool(ctx: PluginContext) {
 
       // For developers marking work as done, validate that a PR exists
       if (role === "developer" && result === "done") {
-        await validatePrExistsForDeveloper(issueId, repoPath, provider, ctx.runCommand, workspaceDir, project.slug);
+        await validatePrExistsForDeveloper(
+          issueId,
+          repoPath,
+          provider,
+          ctx.runCommand,
+          workspaceDir,
+          project.slug,
+        );
       }
 
-      const completion = await executeCompletion({
-        workspaceDir, projectSlug: project.slug, role, result, issueId, summary, prUrl, provider, repoPath,
-        projectName: project.name,
-        channels: project.channels,
-        pluginConfig,
-        level: slotLevel,
-        slotIndex,
-        runtime: ctx.runtime,
-        workflow,
-        createdTasks,
-        runCommand: ctx.runCommand,
-      });
+      try {
+        const completion = await executeCompletion({
+          workspaceDir,
+          projectSlug: project.slug,
+          role,
+          result,
+          issueId,
+          summary,
+          prUrl,
+          provider,
+          repoPath,
+          projectName: project.name,
+          channels: project.channels,
+          pluginConfig,
+          level: slotLevel,
+          slotIndex,
+          runtime: ctx.runtime,
+          workflow,
+          createdTasks,
+          runCommand: ctx.runCommand,
+        });
 
-      await auditLog(workspaceDir, "work_finish", {
-        project: project.name, issue: issueId, role, result,
-        summary: summary ?? null, labelTransition: completion.labelTransition,
-      });
+        await auditLog(workspaceDir, "work_finish", {
+          project: project.name,
+          issue: issueId,
+          role,
+          result,
+          summary: summary ?? null,
+          labelTransition: completion.labelTransition,
+        });
 
-      return jsonResult({
-        success: true, project: project.name, projectSlug: project.slug, issueId, role, result,
-        ...completion,
-      });
+        return jsonResult({
+          success: true,
+          project: project.name,
+          projectSlug: project.slug,
+          issueId,
+          role,
+          result,
+          ...completion,
+        });
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        const commented = await maybeCommentOnRejectedWorkFinish({
+          provider,
+          issueId,
+          role,
+          error,
+        }).catch(() => false);
+        await auditLog(workspaceDir, "work_finish_rejected", {
+          project: project.name,
+          issue: issueId,
+          role,
+          result,
+          reason: "completion_rejected",
+          error: error.message,
+          commented,
+        }).catch(() => {});
+        throw error;
+      }
     },
   });
 }

--- a/lib/tools/worker/work-finish.ts
+++ b/lib/tools/worker/work-finish.ts
@@ -87,25 +87,17 @@ export function resolveRejectedWorkFinishIssueId(
   roleWorker: RoleWorkerState,
   sessionKey?: string,
 ): number | null {
-  if (sessionKey) {
-    for (const slots of Object.values(roleWorker.levels)) {
-      for (const slot of slots) {
-        if (slot.sessionKey !== sessionKey) continue;
-        const issueId = getSlotIssueId(slot);
-        if (issueId !== null) return issueId;
-      }
+  if (!sessionKey) return null;
+
+  for (const slots of Object.values(roleWorker.levels)) {
+    for (const slot of slots) {
+      if (slot.sessionKey !== sessionKey) continue;
+      const issueId = getSlotIssueId(slot);
+      if (issueId !== null) return issueId;
     }
-    return null;
   }
 
-  const activeIssueIds = Object.values(roleWorker.levels)
-    .flatMap((slots) => slots)
-    .filter((slot) => slot.active)
-    .map((slot) => getSlotIssueId(slot))
-    .filter((issueId): issueId is number => issueId !== null);
-
-  const uniqueActiveIssueIds = [...new Set(activeIssueIds)];
-  return uniqueActiveIssueIds.length === 1 ? uniqueActiveIssueIds[0]! : null;
+  return null;
 }
 
 /**

--- a/lib/tools/worker/work-finish.ts
+++ b/lib/tools/worker/work-finish.ts
@@ -17,6 +17,7 @@ import {
   resolveRepoPath,
   findSlotByIssue,
 } from "../../projects/index.js";
+import type { RoleWorkerState, SlotState } from "../../projects/types.js";
 import { executeCompletion, getRule } from "../../services/pipeline.js";
 import { log as auditLog } from "../../audit.js";
 import { DATA_DIR } from "../../setup/migrate-layout.js";
@@ -73,6 +74,38 @@ async function maybeCommentOnRejectedWorkFinish(opts: {
       `${marker}`,
   );
   return true;
+}
+
+function getSlotIssueId(slot: SlotState): number | null {
+  const candidate = slot.issueId ?? slot.lastIssueId;
+  if (!candidate) return null;
+  const parsed = Number(candidate);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function resolveRejectedWorkFinishIssueId(
+  roleWorker: RoleWorkerState,
+  sessionKey?: string,
+): number | null {
+  if (sessionKey) {
+    for (const slots of Object.values(roleWorker.levels)) {
+      for (const slot of slots) {
+        if (slot.sessionKey !== sessionKey) continue;
+        const issueId = getSlotIssueId(slot);
+        if (issueId !== null) return issueId;
+      }
+    }
+    return null;
+  }
+
+  const activeIssueIds = Object.values(roleWorker.levels)
+    .flatMap((slots) => slots)
+    .filter((slot) => slot.active)
+    .map((slot) => getSlotIssueId(slot))
+    .filter((issueId): issueId is number => issueId !== null);
+
+  const uniqueActiveIssueIds = [...new Set(activeIssueIds)];
+  return uniqueActiveIssueIds.length === 1 ? uniqueActiveIssueIds[0]! : null;
 }
 
 /**
@@ -321,7 +354,10 @@ export function createWorkFinishTool(ctx: PluginContext) {
       const { provider } = await resolveProvider(project, ctx.runCommand);
       const workflow = await loadWorkflow(workspaceDir, project.name);
 
-      let relatedIssueId: number | null = null;
+      const relatedIssueId = resolveRejectedWorkFinishIssueId(
+        roleWorker,
+        toolCtx.sessionKey,
+      );
 
       // Find the first active slot across all levels
       let slotIndex: number | null = null;
@@ -336,8 +372,6 @@ export function createWorkFinishTool(ctx: PluginContext) {
             !slot.sessionKey ||
             slot.sessionKey === toolCtx.sessionKey;
           if (!sessionMatches) continue;
-          if (slot.issueId) relatedIssueId = Number(slot.issueId);
-          else if (slot.lastIssueId) relatedIssueId = Number(slot.lastIssueId);
 
           if (slot.active && slot.issueId) {
             slotLevel = level;


### PR DESCRIPTION
## Summary
- add a dispatch loop guard that quarantines repeatedly redispatched issues into a hold state and marks them as workflow desyncs
- post a single actionable quarantine comment instead of repeatedly notifying and redispatching the same issue
- add rejected work_finish warning comments/audit logging for worker-state and label-mismatch desync cases

Addresses issue #96

## Validation
- npx tsc --noEmit
- npx tsx --test lib/dispatch/loop-guard.test.ts lib/dispatch/index.notify-fallback.test.ts lib/tools/worker/work-finish.test.ts