### PR TITLE
fix: reset dispatch-loop quarantine after recovery

### DIFF
--- a/lib/services/dispatch-loop-guard.test.ts
+++ b/lib/services/dispatch-loop-guard.test.ts
@@ -11,39 +11,102 @@ import {
   guardDispatchLoop,
 } from "./dispatch-loop-guard.js";
 
+async function withMockedNow<T>(
+  isoTime: string,
+  run: () => Promise<T>,
+): Promise<T> {
+  const RealDate = Date;
+  const fixedTime = RealDate.parse(isoTime);
+
+  class MockDate extends RealDate {
+    constructor(value?: string | number | Date) {
+      super(value ?? fixedTime);
+    }
+
+    static override now(): number {
+      return fixedTime;
+    }
+  }
+
+  globalThis.Date = MockDate as DateConstructor;
+  try {
+    return await run();
+  } finally {
+    globalThis.Date = RealDate;
+  }
+}
+
 describe("guardDispatchLoop", () => {
   it("quarantines a hot loop once, then allows immediate manual recovery", async () => {
     const h = await createTestHarness();
 
     try {
+      const auditDir = join(h.workspaceDir, DATA_DIR, "log");
+      const auditPath = join(auditDir, "audit.log");
+      const now = Date.parse("2026-03-10T12:08:00.000Z");
+
       h.provider.seedIssue({
         iid: 96,
         title: "Recoverable dispatch loop",
         labels: ["To Do"],
       });
 
-      for (let i = 0; i < 3; i++) {
-        await auditLog(h.workspaceDir, "dispatch", {
-          project: h.project.name,
-          issue: 96,
+      await mkdir(auditDir, { recursive: true });
+      await writeFile(
+        auditPath,
+        [
+          {
+            ts: "2026-03-10T12:05:00.000Z",
+            event: "dispatch",
+            project: h.project.name,
+            issue: 96,
+            issueTitle: "Recoverable dispatch loop",
+            role: "developer",
+            level: "senior",
+            sessionKey: "session-0",
+            labelTransition: "To Do → Doing",
+          },
+          {
+            ts: "2026-03-10T12:06:00.000Z",
+            event: "dispatch",
+            project: h.project.name,
+            issue: 96,
+            issueTitle: "Recoverable dispatch loop",
+            role: "developer",
+            level: "senior",
+            sessionKey: "session-1",
+            labelTransition: "To Do → Doing",
+          },
+          {
+            ts: "2026-03-10T12:07:00.000Z",
+            event: "dispatch",
+            project: h.project.name,
+            issue: 96,
+            issueTitle: "Recoverable dispatch loop",
+            role: "developer",
+            level: "senior",
+            sessionKey: "session-2",
+            labelTransition: "To Do → Doing",
+          },
+        ]
+          .map((entry) => JSON.stringify(entry))
+          .join("\n") + "\n",
+        "utf-8",
+      );
+
+      const first = await withMockedNow("2026-03-10T12:04:00.000Z", async () =>
+        guardDispatchLoop({
+          workspaceDir: h.workspaceDir,
+          provider: h.provider,
+          projectName: h.project.name,
+          issueId: 96,
           issueTitle: "Recoverable dispatch loop",
           role: "developer",
-          level: "senior",
-          sessionKey: `session-${i}`,
-          labelTransition: "To Do → Doing",
-        });
-      }
-
-      const first = await guardDispatchLoop({
-        workspaceDir: h.workspaceDir,
-        provider: h.provider,
-        projectName: h.project.name,
-        issueId: 96,
-        issueTitle: "Recoverable dispatch loop",
-        role: "developer",
-        fromLabel: "To Do",
-        quarantineLabel: "Refining",
-      });
+          fromLabel: "To Do",
+          quarantineLabel: "Refining",
+          now,
+        }),
+      );
 
       assert.equal(first.quarantined, true);
 
@@ -64,6 +127,7 @@ describe("guardDispatchLoop", () => {
         role: "developer",
         fromLabel: "To Do",
         quarantineLabel: "Refining",
+        now,
       });
 
       assert.equal(second.quarantined, false);
@@ -132,7 +196,7 @@ describe("guardDispatchLoop", () => {
             role: "developer",
           },
           {
-            ts: "2026-03-10T11:58:00.000Z",
+            ts: "2026-03-10T11:54:00.000Z",
             event: "dispatch_loop_quarantined",
             issue: 96,
             role: "developer",

--- a/lib/services/dispatch-loop-guard.test.ts
+++ b/lib/services/dispatch-loop-guard.test.ts
@@ -73,6 +73,29 @@ describe("guardDispatchLoop", () => {
         1,
         "manual recovery should not trigger a second quarantine comment",
       );
+
+      await auditLog(h.workspaceDir, "dispatch", {
+        project: h.project.name,
+        issue: 96,
+        issueTitle: "Recoverable dispatch loop",
+        role: "developer",
+        level: "senior",
+        sessionKey: "session-recovered",
+        labelTransition: "To Do → Doing",
+      });
+
+      const postRecoveryDispatches =
+        await countRecentDispatchesSinceLastQuarantine({
+          workspaceDir: h.workspaceDir,
+          issueId: 96,
+          role: "developer",
+        });
+
+      assert.equal(
+        postRecoveryDispatches,
+        1,
+        "dispatch counting should restart from zero after quarantine so immediate requeue can recover",
+      );
     } finally {
       await h.cleanup();
     }

--- a/lib/services/dispatch-loop-guard.test.ts
+++ b/lib/services/dispatch-loop-guard.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { log as auditLog } from "../audit.js";
+import { createTestHarness } from "../testing/index.js";
+import { guardDispatchLoop } from "./dispatch-loop-guard.js";
+
+describe("guardDispatchLoop", () => {
+  it("quarantines a hot loop once, then allows immediate manual recovery", async () => {
+    const h = await createTestHarness();
+
+    try {
+      h.provider.seedIssue({
+        iid: 96,
+        title: "Recoverable dispatch loop",
+        labels: ["To Do"],
+      });
+
+      for (let i = 0; i < 3; i++) {
+        await auditLog(h.workspaceDir, "dispatch", {
+          project: h.project.name,
+          issue: 96,
+          issueTitle: "Recoverable dispatch loop",
+          role: "developer",
+          level: "senior",
+          sessionKey: `session-${i}`,
+          labelTransition: "To Do → Doing",
+        });
+      }
+
+      const first = await guardDispatchLoop({
+        workspaceDir: h.workspaceDir,
+        provider: h.provider,
+        projectName: h.project.name,
+        issueId: 96,
+        issueTitle: "Recoverable dispatch loop",
+        role: "developer",
+        fromLabel: "To Do",
+        quarantineLabel: "Refining",
+      });
+
+      assert.equal(first.quarantined, true);
+
+      const quarantinedIssue = await h.provider.getIssue(96);
+      assert.ok(quarantinedIssue.labels.includes("Refining"));
+      assert.ok(quarantinedIssue.labels.includes("workflow:desync"));
+      assert.equal(h.provider.callsTo("addComment").length, 1);
+
+      // Simulate operator reconciliation + immediate requeue.
+      await h.provider.transitionLabel(96, "Refining", "To Do");
+
+      const second = await guardDispatchLoop({
+        workspaceDir: h.workspaceDir,
+        provider: h.provider,
+        projectName: h.project.name,
+        issueId: 96,
+        issueTitle: "Recoverable dispatch loop",
+        role: "developer",
+        fromLabel: "To Do",
+        quarantineLabel: "Refining",
+      });
+
+      assert.equal(second.quarantined, false);
+      assert.equal(second.recentDispatches, 0);
+      assert.equal(
+        h.provider.callsTo("addComment").length,
+        1,
+        "manual recovery should not trigger a second quarantine comment",
+      );
+    } finally {
+      await h.cleanup();
+    }
+  });
+});

--- a/lib/services/dispatch-loop-guard.test.ts
+++ b/lib/services/dispatch-loop-guard.test.ts
@@ -151,6 +151,7 @@ describe("guardDispatchLoop", () => {
       const postRecoveryDispatches =
         await countRecentDispatchesSinceLastQuarantine({
           workspaceDir: h.workspaceDir,
+          projectName: h.project.name,
           issueId: 96,
           role: "developer",
         });
@@ -180,24 +181,28 @@ describe("guardDispatchLoop", () => {
           {
             ts: "2026-03-10T11:55:00.000Z",
             event: "dispatch",
+            project: h.project.name,
             issue: 96,
             role: "developer",
           },
           {
             ts: "2026-03-10T11:56:00.000Z",
             event: "dispatch",
+            project: h.project.name,
             issue: 96,
             role: "developer",
           },
           {
             ts: "2026-03-10T11:57:00.000Z",
             event: "dispatch",
+            project: h.project.name,
             issue: 96,
             role: "developer",
           },
           {
             ts: "2026-03-10T11:54:00.000Z",
             event: "dispatch_loop_quarantined",
+            project: h.project.name,
             issue: 96,
             role: "developer",
           },
@@ -209,6 +214,7 @@ describe("guardDispatchLoop", () => {
 
       const recentDispatches = await countRecentDispatchesSinceLastQuarantine({
         workspaceDir: h.workspaceDir,
+        projectName: h.project.name,
         issueId: 96,
         role: "developer",
         now,
@@ -216,6 +222,179 @@ describe("guardDispatchLoop", () => {
       });
 
       assert.equal(recentDispatches, 0);
+    } finally {
+      await h.cleanup();
+    }
+  });
+
+  it("ignores dispatches and quarantine events from other projects with the same issue and role", async () => {
+    const h = await createTestHarness();
+
+    try {
+      const auditDir = join(h.workspaceDir, DATA_DIR, "log");
+      const auditPath = join(auditDir, "audit.log");
+      const now = Date.parse("2026-03-10T12:08:00.000Z");
+
+      h.provider.seedIssue({
+        iid: 96,
+        title: "Project-scoped dispatch loop",
+        labels: ["To Do"],
+      });
+
+      await mkdir(auditDir, { recursive: true });
+      await writeFile(
+        auditPath,
+        [
+          {
+            ts: "2026-03-10T12:02:00.000Z",
+            event: "dispatch_loop_quarantined",
+            project: "other-project",
+            issue: 96,
+            role: "developer",
+          },
+          {
+            ts: "2026-03-10T12:05:00.000Z",
+            event: "dispatch",
+            project: "other-project",
+            issue: 96,
+            role: "developer",
+          },
+          {
+            ts: "2026-03-10T12:06:00.000Z",
+            event: "dispatch",
+            project: "other-project",
+            issue: 96,
+            role: "developer",
+          },
+          {
+            ts: "2026-03-10T12:07:00.000Z",
+            event: "dispatch",
+            project: "other-project",
+            issue: 96,
+            role: "developer",
+          },
+          {
+            ts: "2026-03-10T12:04:00.000Z",
+            event: "dispatch",
+            project: h.project.name,
+            issue: 96,
+            role: "developer",
+          },
+        ]
+          .map((entry) => JSON.stringify(entry))
+          .join("\n") + "\n",
+        "utf-8",
+      );
+
+      const recentDispatches = await countRecentDispatchesSinceLastQuarantine({
+        workspaceDir: h.workspaceDir,
+        projectName: h.project.name,
+        issueId: 96,
+        role: "developer",
+        now,
+        windowMs: 10 * 60 * 1000,
+      });
+
+      assert.equal(
+        recentDispatches,
+        1,
+        "only dispatches from the current project should count",
+      );
+
+      const result = await guardDispatchLoop({
+        workspaceDir: h.workspaceDir,
+        provider: h.provider,
+        projectName: h.project.name,
+        issueId: 96,
+        issueTitle: "Project-scoped dispatch loop",
+        role: "developer",
+        fromLabel: "To Do",
+        quarantineLabel: "Refining",
+        now,
+      });
+
+      assert.equal(result.quarantined, false);
+      assert.equal(result.recentDispatches, 1);
+      assert.equal(h.provider.callsTo("transitionLabel").length, 0);
+      assert.equal(h.provider.callsTo("addComment").length, 0);
+    } finally {
+      await h.cleanup();
+    }
+  });
+
+  it("ignores dispatches from other projects with the same issue id and role", async () => {
+    const h = await createTestHarness();
+
+    try {
+      const auditDir = join(h.workspaceDir, DATA_DIR, "log");
+      const auditPath = join(auditDir, "audit.log");
+      const now = Date.parse("2026-03-10T12:08:00.000Z");
+
+      h.provider.seedIssue({
+        iid: 96,
+        title: "Project-scoped dispatch loop",
+        labels: ["To Do"],
+      });
+
+      await mkdir(auditDir, { recursive: true });
+      await writeFile(
+        auditPath,
+        [
+          {
+            ts: "2026-03-10T12:05:00.000Z",
+            event: "dispatch",
+            project: "other-project",
+            issue: 96,
+            role: "developer",
+          },
+          {
+            ts: "2026-03-10T12:06:00.000Z",
+            event: "dispatch",
+            project: "other-project",
+            issue: 96,
+            role: "developer",
+          },
+          {
+            ts: "2026-03-10T12:07:00.000Z",
+            event: "dispatch",
+            project: "other-project",
+            issue: 96,
+            role: "developer",
+          },
+        ]
+          .map((entry) => JSON.stringify(entry))
+          .join("\n") + "\n",
+        "utf-8",
+      );
+
+      const recentDispatches = await countRecentDispatchesSinceLastQuarantine({
+        workspaceDir: h.workspaceDir,
+        projectName: h.project.name,
+        issueId: 96,
+        role: "developer",
+        now,
+      });
+
+      assert.equal(recentDispatches, 0);
+
+      const result = await guardDispatchLoop({
+        workspaceDir: h.workspaceDir,
+        provider: h.provider,
+        projectName: h.project.name,
+        issueId: 96,
+        issueTitle: "Project-scoped dispatch loop",
+        role: "developer",
+        fromLabel: "To Do",
+        quarantineLabel: "Refining",
+        now,
+      });
+
+      assert.equal(result.quarantined, false);
+      assert.equal(result.recentDispatches, 0);
+
+      const issue = await h.provider.getIssue(96);
+      assert.deepEqual(issue.labels, ["To Do"]);
+      assert.equal(h.provider.callsTo("addComment").length, 0);
     } finally {
       await h.cleanup();
     }

--- a/lib/services/dispatch-loop-guard.test.ts
+++ b/lib/services/dispatch-loop-guard.test.ts
@@ -56,7 +56,7 @@ describe("guardDispatchLoop", () => {
         auditPath,
         [
           {
-            ts: "2026-03-10T12:05:00.000Z",
+            ts: "2026-03-10T12:01:00.000Z",
             event: "dispatch",
             project: h.project.name,
             issue: 96,
@@ -67,7 +67,7 @@ describe("guardDispatchLoop", () => {
             labelTransition: "To Do → Doing",
           },
           {
-            ts: "2026-03-10T12:06:00.000Z",
+            ts: "2026-03-10T12:02:00.000Z",
             event: "dispatch",
             project: h.project.name,
             issue: 96,
@@ -78,7 +78,7 @@ describe("guardDispatchLoop", () => {
             labelTransition: "To Do → Doing",
           },
           {
-            ts: "2026-03-10T12:07:00.000Z",
+            ts: "2026-03-10T12:03:00.000Z",
             event: "dispatch",
             project: h.project.name,
             issue: 96,
@@ -104,7 +104,7 @@ describe("guardDispatchLoop", () => {
           role: "developer",
           fromLabel: "To Do",
           quarantineLabel: "Refining",
-          now,
+          now: Date.parse("2026-03-10T12:04:00.000Z"),
         }),
       );
 
@@ -166,7 +166,7 @@ describe("guardDispatchLoop", () => {
     }
   });
 
-  it("counts only dispatches after the most recent quarantine event", async () => {
+  it("counts only dispatches after the most recent quarantine timestamp", async () => {
     const h = await createTestHarness();
 
     try {
@@ -202,6 +202,67 @@ describe("guardDispatchLoop", () => {
           {
             ts: "2026-03-10T11:54:00.000Z",
             event: "dispatch_loop_quarantined",
+            project: h.project.name,
+            issue: 96,
+            role: "developer",
+          },
+        ]
+          .map((entry) => JSON.stringify(entry))
+          .join("\n") + "\n",
+        "utf-8",
+      );
+
+      const recentDispatches = await countRecentDispatchesSinceLastQuarantine({
+        workspaceDir: h.workspaceDir,
+        projectName: h.project.name,
+        issueId: 96,
+        role: "developer",
+        now,
+        windowMs: 10 * 60 * 1000,
+      });
+
+      assert.equal(recentDispatches, 3);
+    } finally {
+      await h.cleanup();
+    }
+  });
+
+  it("ignores dispatches that happened before a later quarantine even if the log lines are out of order", async () => {
+    const h = await createTestHarness();
+
+    try {
+      const auditDir = join(h.workspaceDir, DATA_DIR, "log");
+      const auditPath = join(auditDir, "audit.log");
+      const now = Date.parse("2026-03-10T12:00:00.000Z");
+
+      await mkdir(auditDir, { recursive: true });
+      await writeFile(
+        auditPath,
+        [
+          {
+            ts: "2026-03-10T11:57:00.000Z",
+            event: "dispatch",
+            project: h.project.name,
+            issue: 96,
+            role: "developer",
+          },
+          {
+            ts: "2026-03-10T11:58:00.000Z",
+            event: "dispatch",
+            project: h.project.name,
+            issue: 96,
+            role: "developer",
+          },
+          {
+            ts: "2026-03-10T11:59:00.000Z",
+            event: "dispatch_loop_quarantined",
+            project: h.project.name,
+            issue: 96,
+            role: "developer",
+          },
+          {
+            ts: "2026-03-10T11:56:00.000Z",
+            event: "dispatch",
             project: h.project.name,
             issue: 96,
             role: "developer",

--- a/lib/services/dispatch-loop-guard.test.ts
+++ b/lib/services/dispatch-loop-guard.test.ts
@@ -1,9 +1,15 @@
 import assert from "node:assert/strict";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
 import { describe, it } from "node:test";
 
 import { log as auditLog } from "../audit.js";
+import { DATA_DIR } from "../setup/migrate-layout.js";
 import { createTestHarness } from "../testing/index.js";
-import { guardDispatchLoop } from "./dispatch-loop-guard.js";
+import {
+  countRecentDispatchesSinceLastQuarantine,
+  guardDispatchLoop,
+} from "./dispatch-loop-guard.js";
 
 describe("guardDispatchLoop", () => {
   it("quarantines a hot loop once, then allows immediate manual recovery", async () => {
@@ -67,6 +73,62 @@ describe("guardDispatchLoop", () => {
         1,
         "manual recovery should not trigger a second quarantine comment",
       );
+    } finally {
+      await h.cleanup();
+    }
+  });
+
+  it("counts only dispatches after the most recent quarantine event", async () => {
+    const h = await createTestHarness();
+
+    try {
+      const auditDir = join(h.workspaceDir, DATA_DIR, "log");
+      const auditPath = join(auditDir, "audit.log");
+      const now = Date.parse("2026-03-10T12:00:00.000Z");
+
+      await mkdir(auditDir, { recursive: true });
+      await writeFile(
+        auditPath,
+        [
+          {
+            ts: "2026-03-10T11:55:00.000Z",
+            event: "dispatch",
+            issue: 96,
+            role: "developer",
+          },
+          {
+            ts: "2026-03-10T11:56:00.000Z",
+            event: "dispatch",
+            issue: 96,
+            role: "developer",
+          },
+          {
+            ts: "2026-03-10T11:57:00.000Z",
+            event: "dispatch",
+            issue: 96,
+            role: "developer",
+          },
+          {
+            ts: "2026-03-10T11:58:00.000Z",
+            event: "dispatch_loop_quarantined",
+            issue: 96,
+            role: "developer",
+          },
+        ]
+          .map((entry) => JSON.stringify(entry))
+          .join("\n") + "\n",
+        "utf-8",
+      );
+
+      const recentDispatches = await countRecentDispatchesSinceLastQuarantine({
+        workspaceDir: h.workspaceDir,
+        issueId: 96,
+        role: "developer",
+        now,
+        windowMs: 10 * 60 * 1000,
+      });
+
+      assert.equal(recentDispatches, 0);
     } finally {
       await h.cleanup();
     }

--- a/lib/services/dispatch-loop-guard.ts
+++ b/lib/services/dispatch-loop-guard.ts
@@ -77,7 +77,7 @@ export async function countRecentDispatchesSinceLastQuarantine(opts: {
   for (const entry of entries) {
     if (entry.event !== "dispatch_loop_quarantined") continue;
     const time = getEntryTime(entry);
-    if (time !== null && time >= cutoff && time > lastQuarantineTs) {
+    if (time !== null && time > lastQuarantineTs) {
       lastQuarantineTs = time;
     }
   }

--- a/lib/services/dispatch-loop-guard.ts
+++ b/lib/services/dispatch-loop-guard.ts
@@ -79,23 +79,22 @@ export async function countRecentDispatchesSinceLastQuarantine(opts: {
       entry.role === role,
   );
 
-  let lastQuarantineIndex = -1;
-  for (let index = 0; index < entries.length; index += 1) {
-    if (entries[index]?.event === "dispatch_loop_quarantined") {
-      lastQuarantineIndex = index;
+  let lastQuarantineTime: number | null = null;
+  for (const entry of entries) {
+    if (entry.event !== "dispatch_loop_quarantined") continue;
+    const time = getEntryTime(entry);
+    if (time === null) continue;
+    if (lastQuarantineTime === null || time > lastQuarantineTime) {
+      lastQuarantineTime = time;
     }
   }
 
   let dispatchCount = 0;
-  for (
-    let index = lastQuarantineIndex + 1;
-    index < entries.length;
-    index += 1
-  ) {
-    const entry = entries[index];
+  for (const entry of entries) {
     if (entry.event !== "dispatch") continue;
     const time = getEntryTime(entry);
     if (time === null || time < cutoff) continue;
+    if (lastQuarantineTime !== null && time <= lastQuarantineTime) continue;
     dispatchCount += 1;
   }
 

--- a/lib/services/dispatch-loop-guard.ts
+++ b/lib/services/dispatch-loop-guard.ts
@@ -73,20 +73,23 @@ export async function countRecentDispatchesSinceLastQuarantine(opts: {
     (entry) => entry.issue === issueId && entry.role === role,
   );
 
-  let lastQuarantineTs = -Infinity;
-  for (const entry of entries) {
-    if (entry.event !== "dispatch_loop_quarantined") continue;
-    const time = getEntryTime(entry);
-    if (time !== null && time > lastQuarantineTs) {
-      lastQuarantineTs = time;
+  let lastQuarantineIndex = -1;
+  for (let index = 0; index < entries.length; index += 1) {
+    if (entries[index]?.event === "dispatch_loop_quarantined") {
+      lastQuarantineIndex = index;
     }
   }
 
   let dispatchCount = 0;
-  for (const entry of entries) {
+  for (
+    let index = lastQuarantineIndex + 1;
+    index < entries.length;
+    index += 1
+  ) {
+    const entry = entries[index];
     if (entry.event !== "dispatch") continue;
     const time = getEntryTime(entry);
-    if (time === null || time < cutoff || time <= lastQuarantineTs) continue;
+    if (time === null || time < cutoff) continue;
     dispatchCount += 1;
   }
 

--- a/lib/services/dispatch-loop-guard.ts
+++ b/lib/services/dispatch-loop-guard.ts
@@ -1,0 +1,168 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { log as auditLog } from "../audit.js";
+import { DATA_DIR } from "../setup/migrate-layout.js";
+import type { IssueProvider } from "../providers/provider.js";
+
+const DEFAULT_MAX_DISPATCHES = 3;
+const DEFAULT_WINDOW_MS = 10 * 60 * 1000;
+const DESYNC_LABEL = "workflow:desync";
+
+export type DispatchLoopGuardResult =
+  | { quarantined: false; recentDispatches: number }
+  | {
+      quarantined: true;
+      recentDispatches: number;
+      quarantineLabel: string;
+      addedLabel: string;
+    };
+
+type AuditEntry = {
+  ts?: string;
+  event?: string;
+  issue?: number;
+  role?: string;
+};
+
+function parseAuditEntries(content: string): AuditEntry[] {
+  return content
+    .split("\n")
+    .filter(Boolean)
+    .flatMap((line) => {
+      try {
+        return [JSON.parse(line) as AuditEntry];
+      } catch {
+        return [];
+      }
+    });
+}
+
+function getEntryTime(entry: AuditEntry): number | null {
+  if (!entry.ts) return null;
+  const time = Date.parse(entry.ts);
+  return Number.isNaN(time) ? null : time;
+}
+
+export async function countRecentDispatchesSinceLastQuarantine(opts: {
+  workspaceDir: string;
+  issueId: number;
+  role: string;
+  now?: number;
+  windowMs?: number;
+}): Promise<number> {
+  const {
+    workspaceDir,
+    issueId,
+    role,
+    now = Date.now(),
+    windowMs = DEFAULT_WINDOW_MS,
+  } = opts;
+
+  const auditPath = join(workspaceDir, DATA_DIR, "log", "audit.log");
+
+  let content = "";
+  try {
+    content = await readFile(auditPath, "utf-8");
+  } catch {
+    return 0;
+  }
+
+  const cutoff = now - windowMs;
+  const entries = parseAuditEntries(content).filter(
+    (entry) => entry.issue === issueId && entry.role === role,
+  );
+
+  let lastQuarantineTs = -Infinity;
+  for (const entry of entries) {
+    if (entry.event !== "dispatch_loop_quarantined") continue;
+    const time = getEntryTime(entry);
+    if (time !== null && time >= cutoff && time > lastQuarantineTs) {
+      lastQuarantineTs = time;
+    }
+  }
+
+  let dispatchCount = 0;
+  for (const entry of entries) {
+    if (entry.event !== "dispatch") continue;
+    const time = getEntryTime(entry);
+    if (time === null || time < cutoff || time <= lastQuarantineTs) continue;
+    dispatchCount += 1;
+  }
+
+  return dispatchCount;
+}
+
+export async function guardDispatchLoop(opts: {
+  workspaceDir: string;
+  provider: IssueProvider;
+  projectName: string;
+  issueId: number;
+  issueTitle: string;
+  role: string;
+  fromLabel: string;
+  quarantineLabel: string;
+  maxDispatches?: number;
+  windowMs?: number;
+  now?: number;
+}): Promise<DispatchLoopGuardResult> {
+  const {
+    workspaceDir,
+    provider,
+    projectName,
+    issueId,
+    issueTitle,
+    role,
+    fromLabel,
+    quarantineLabel,
+    maxDispatches = DEFAULT_MAX_DISPATCHES,
+    windowMs = DEFAULT_WINDOW_MS,
+    now,
+  } = opts;
+
+  const recentDispatches = await countRecentDispatchesSinceLastQuarantine({
+    workspaceDir,
+    issueId,
+    role,
+    now,
+    windowMs,
+  });
+
+  if (recentDispatches < maxDispatches) {
+    return { quarantined: false, recentDispatches };
+  }
+
+  await provider.transitionLabel(issueId, fromLabel, quarantineLabel);
+  await provider.addLabel(issueId, DESYNC_LABEL);
+  await provider.addComment(
+    issueId,
+    [
+      `⚠️ Dispatch loop detected for **${role}** on issue #${issueId}.`,
+      "",
+      `This issue was dispatched ${recentDispatches} times within the last ${Math.round(windowMs / 60000)} minutes without a successful reconciliation, so DevClaw moved it to **${quarantineLabel}** and paused further dispatches.`,
+      "",
+      "Suggested recovery steps:",
+      "1. Reconcile the actual issue state/labels with worker slot state.",
+      "2. Clear any stale owner or role:level labels if they no longer match reality.",
+      `3. Requeue manually once consistent (for example, move back out of **${quarantineLabel}** and run \`task_start\`).`,
+    ].join("\n"),
+  );
+
+  await auditLog(workspaceDir, "dispatch_loop_quarantined", {
+    project: projectName,
+    issue: issueId,
+    issueTitle,
+    role,
+    recentDispatches,
+    fromLabel,
+    toLabel: quarantineLabel,
+    label: DESYNC_LABEL,
+  });
+
+  return {
+    quarantined: true,
+    recentDispatches,
+    quarantineLabel,
+    addedLabel: DESYNC_LABEL,
+  };
+}

--- a/lib/services/dispatch-loop-guard.ts
+++ b/lib/services/dispatch-loop-guard.ts
@@ -21,6 +21,7 @@ export type DispatchLoopGuardResult =
 type AuditEntry = {
   ts?: string;
   event?: string;
+  project?: string;
   issue?: number;
   role?: string;
 };
@@ -46,6 +47,7 @@ function getEntryTime(entry: AuditEntry): number | null {
 
 export async function countRecentDispatchesSinceLastQuarantine(opts: {
   workspaceDir: string;
+  projectName: string;
   issueId: number;
   role: string;
   now?: number;
@@ -53,6 +55,7 @@ export async function countRecentDispatchesSinceLastQuarantine(opts: {
 }): Promise<number> {
   const {
     workspaceDir,
+    projectName,
     issueId,
     role,
     now = Date.now(),
@@ -70,7 +73,10 @@ export async function countRecentDispatchesSinceLastQuarantine(opts: {
 
   const cutoff = now - windowMs;
   const entries = parseAuditEntries(content).filter(
-    (entry) => entry.issue === issueId && entry.role === role,
+    (entry) =>
+      entry.project === projectName &&
+      entry.issue === issueId &&
+      entry.role === role,
   );
 
   let lastQuarantineIndex = -1;
@@ -125,6 +131,7 @@ export async function guardDispatchLoop(opts: {
 
   const recentDispatches = await countRecentDispatchesSinceLastQuarantine({
     workspaceDir,
+    projectName,
     issueId,
     role,
     now,

--- a/lib/services/tick.ts
+++ b/lib/services/tick.ts
@@ -34,6 +34,7 @@ import {
   detectStepRouting,
   findNextIssueForRole,
 } from "./queue-scan.js";
+import { guardDispatchLoop } from "./dispatch-loop-guard.js";
 
 // ---------------------------------------------------------------------------
 // projectTick
@@ -254,6 +255,24 @@ export async function projectTick(opts: {
 
     const { issue, label: currentLabel } = next;
     const targetLabel = getActiveLabel(workflow, role);
+
+    const loopGuard = await guardDispatchLoop({
+      workspaceDir,
+      provider,
+      projectName: project.name,
+      issueId: issue.iid,
+      issueTitle: issue.title,
+      role,
+      fromLabel: currentLabel,
+      quarantineLabel: refiningLabel,
+    });
+    if (loopGuard.quarantined) {
+      skipped.push({
+        role,
+        reason: `Issue #${issue.iid} moved to ${loopGuard.quarantineLabel}: dispatch loop detected after ${loopGuard.recentDispatches} recent dispatches`,
+      });
+      continue;
+    }
 
     // Level selection: label → heuristic (must happen before free slot check)
     const selectedLevel = resolveLevelForIssue(issue, role);


### PR DESCRIPTION
## Summary
- add a dispatch-loop guard in the tick path that quarantines hot redispatch cycles into Refining
- reset the guard after the most recent quarantine event so operators can recover and requeue immediately
- add a regression test covering quarantine once + immediate manual recovery

## Validation
- npm run check
- npx tsx --test lib/services/dispatch-loop-guard.test.ts lib/services/tick.reviewer-starvation.test.ts lib/services/pipeline-completion-robustness.test.ts lib/tools/worker/work-finish.test.ts
- npm run build

Addresses issue #96